### PR TITLE
Update SlotViz tile behavior

### DIFF
--- a/frontend/components/slot/viz/SlotVizTile.vue
+++ b/frontend/components/slot/viz/SlotVizTile.vue
@@ -9,7 +9,6 @@ const props = defineProps<Props>()
 const data = computed(() => {
   const slot = props.data
   let outer = ''
-  let inner = ''
   const icons: SlotVizIcons[] = []
   switch (slot.state) {
     case 'missed':
@@ -20,18 +19,27 @@ const data = computed(() => {
       outer = 'proposed'
       break
   }
-  const hasFailed = !!slot.duties?.find(s => s.failedCount)
-  const hasSuccess = !!slot.duties?.find(s => s.successCount)
-  const hasPending = !!slot.duties?.find(s => s.pendingCount)
-  if (hasFailed && hasSuccess) {
-    inner = 'mixed'
-  } else if (hasFailed) {
-    inner = 'missed'
-  } else if (hasSuccess) {
-    inner = 'proposed'
-  } else if (hasPending) {
+
+  let inner = ''
+  if (slot.state === 'scheduled') {
     inner = 'pending'
+  } else {
+    const hasFailed = !!slot.duties?.find(s => s.failedCount)
+    const hasSuccess = !!slot.duties?.find(s => s.successCount)
+    const hasPending = !!slot.duties?.find(s => s.pendingCount)
+    if (!hasFailed && !hasSuccess && !hasPending) {
+      inner = 'proposed'
+    } else if (hasFailed && hasSuccess) {
+      inner = 'mixed'
+    } else if (hasFailed) {
+      inner = 'missed'
+    } else if (hasSuccess) {
+      inner = 'proposed'
+    } else if (hasPending) {
+      inner = 'pending'
+    }
   }
+
   const types: SlotVizIcons[] = ['proposal', 'slashing', 'sync', 'attestation']
   types.forEach((type) => {
     if (slot.duties?.find(s => s.type === type)) {
@@ -50,7 +58,6 @@ const data = computed(() => {
     firstIconClass: `count_${icons.length}`
   }
 })
-
 </script>
 <template>
   <SlotVizTooltip :id="data.id" :data="props.data">

--- a/frontend/public/mock/dashboard/slotViz.json
+++ b/frontend/public/mock/dashboard/slotViz.json
@@ -500,7 +500,7 @@
         },
         {
           "id": 3,
-          "state": "proposed"
+          "state": "missed"
         },
         {
           "id": 4,
@@ -512,7 +512,25 @@
         },
         {
           "id": 6,
-          "state": "proposed"
+          "state": "missed",
+          "duties": [
+            {
+              "type": "proposal",
+              "failedCount": 1,
+              "failedEarnings": "11200000000000000",
+              "validator": 1234
+            },
+            {
+              "type": "attestation",
+              "successCount": 4,
+              "successEarning": "11200000000000000"
+            },
+            {
+              "type": "slashing",
+              "successCount": 1,
+              "successEarning": "11200000000000000"
+            }
+          ]
         },
         {
           "id": 7,


### PR DESCRIPTION
This PR updates the SlotViz's tile behavior: Missed slots without duties now show a green box with a red border.

The mocked data for the SlotViz has been improved to show that. It also now contains a missed slot with mixed duties (not sure if that can ever happen but the frontend is able to deal with that).