### PR TITLE
(NOBIDS) frontend/types/network.ts

### DIFF
--- a/frontend/composables/useValue.ts
+++ b/frontend/composables/useValue.ts
@@ -24,7 +24,7 @@ export function useValue () {
         }
       }
 
-      // If a different sourceUnit is defiend we multiply accodringly. We usually get gwei, but you never know.
+      // If a different sourceUnit is defined we multiply accordingly. We usually get gwei, but you never know.
       if (options?.sourceUnit === 'GWEI') {
         value = value.mul(OneGwei)
       } else if (options?.sourceUnit === 'MAIN') {

--- a/frontend/types/currencies.ts
+++ b/frontend/types/currencies.ts
@@ -1,11 +1,11 @@
 const FiatCurrencies = ['AUD', 'CAD', 'CNY', 'EUR', 'GBP', 'JPY', 'USD'] as const
 type FiatCurrency = typeof FiatCurrencies[number]
-const CryptoCurrenies = ['ETH', 'GNO', 'DAI', 'xDAI'] as const
-type CryptoCurrency = typeof CryptoCurrenies[number]
+const CryptoCurrencies = ['ETH', 'GNO', 'DAI', 'xDAI'] as const
+type CryptoCurrency = typeof CryptoCurrencies[number]
 const Native = 'NAT' as const
 type Native = typeof Native
 type Currency = FiatCurrency | CryptoCurrency | Native
 
 type CryptoUnits = 'MAIN' | 'GWEI' | 'WEI'
 
-export { type Currency, type CryptoUnits, type CryptoCurrency, type FiatCurrency, CryptoCurrenies, FiatCurrencies, Native }
+export { type Currency, type CryptoUnits, type CryptoCurrency, type FiatCurrency, CryptoCurrencies, FiatCurrencies, Native }

--- a/frontend/types/networks.ts
+++ b/frontend/types/networks.ts
@@ -29,7 +29,7 @@ export const enum ChainIDs {
 
   ArbitrumOneEthereum = 42161,
   ArbitrumNovaEthereum= 42170,
-  ArbitrumSepolia = 421614,
+  ArbitrumOneSepolia = 421614,
 
   OptimismEthereum = 10,
   OptimismSepolia = 11155420,
@@ -92,13 +92,13 @@ export const ChainInfo: Record<ChainIDs, ChainInfoFields> = {
     elCurrency: 'ETH',
     path: '/arbitrum-nova-ethereum'
   },
-  [ChainIDs.ArbitrumSepolia]: {
-    name: 'Arbitrum Sepolia Testnet',
+  [ChainIDs.ArbitrumOneSepolia]: {
+    name: 'Arbitrum One Sepolia Testnet',
     mainNet: ChainIDs.ArbitrumOneEthereum,
     L1: ChainIDs.Sepolia,
     clCurrency: 'ETH',
     elCurrency: 'ETH',
-    path: '/arbitrum-sepolia'
+    path: '/arbitrum-one-sepolia'
   },
 
   [ChainIDs.OptimismEthereum]: {
@@ -151,4 +151,12 @@ export const ChainInfo: Record<ChainIDs, ChainInfoFields> = {
     elCurrency: 'xDAI',
     path: '/chiado'
   }
+}
+
+export function isMainNet (network: ChainIDs) : boolean {
+  return (ChainInfo[network].mainNet === network)
+}
+
+export function isL1 (network: ChainIDs) : boolean {
+  return (ChainInfo[network].L1 === network)
 }

--- a/frontend/types/value.ts
+++ b/frontend/types/value.ts
@@ -3,7 +3,7 @@ import type { CryptoCurrency, CryptoUnits, Currency } from '~/types/currencies'
 export type ValueConvertOptions = {
   sourceCurrency?: CryptoCurrency // source crypto currency - default: ETH
   sourceUnit?: CryptoUnits // source unit - default main unit (like eth)
-  targetCurrency?: Currency // terget currency - overrides the selected currency
+  targetCurrency?: Currency // target currency - overrides the selected currency
   fixedDecimalCount?: number // can override the usual settings, but can't go over 2 for fiat
   minUnit?: CryptoUnits // if output should only be in higher units (for example GWEI -> then it will never go down to WEI)
   fixedUnit?: CryptoUnits // fixed output unit - overrides min unit

--- a/frontend/utils/currency.ts
+++ b/frontend/utils/currency.ts
@@ -1,7 +1,7 @@
-import { FiatCurrencies, type FiatCurrency, CryptoCurrenies, type CryptoCurrency, type Currency } from '~/types/currencies'
+import { FiatCurrencies, type FiatCurrency, CryptoCurrencies, type CryptoCurrency, type Currency } from '~/types/currencies'
 
 const isFiat = (value?:Currency) => !!value && FiatCurrencies.includes(value as FiatCurrency)
-const isCrypto = (value?:Currency) => !!value && CryptoCurrenies.includes(value as CryptoCurrency)
+const isCrypto = (value?:Currency) => !!value && CryptoCurrencies.includes(value as CryptoCurrency)
 const isNative = (value?:Currency) => value === 'NAT'
 
 export { isFiat, isCrypto, isNative }


### PR DESCRIPTION
This file for the front-end sets types and fundamental data about different networks.

   To use it, you need to write first:
     `import { ChainIDs, ChainInfo } from '~/types/networks'`

   First, the file defines identifiers equal to the chain IDs of the networks.
   In your code, you write `ChainIDs.Ethereum` whenever you want to represent the main Ethereum network,
   or `ChainIDs.Sepolia` for the Sepolia testnet and so on.
   Those constants are integers but for a safer code you should define your constants, fields, variables
   and parameters as the type ChainIDs.

   The most important feature of this file is to provide a mapping between those chain IDs and
   information about the networks.
   For example, when your variable `myNetwork` is equal to 10200 (namely `ChainIDs.Chiado`, a testnet of Gnosis) :
   * `ChainInfo[myNetwork].path`  is the beginning of the path used to address this network in API endpoints.
   * `ChainInfo[myNetwork].mainNet`  is equal to the chain ID of the mainnet of Gnosis (100).
     So, to check whether your network is a testnet, you can do `myNetwork != ChainInfo[myNetwork].mainNet`.
   * `ChainInfo[myNetwork].elCurrency` is equal to 'xDAI' whereas `ChainInfo[myNetwork].clCurrency` is 'GNO'

 To check whether a network is a L2, you can do `myNetwork != ChainInfo[myNetwork].L1`.