### PR TITLE
fix fontawesome css import

### DIFF
--- a/frontend/assets/css/main.scss
+++ b/frontend/assets/css/main.scss
@@ -1,7 +1,7 @@
 @import "~/assets/css/colors.scss";
 @import "~/assets/css/variables.scss";
 @import "~/assets/css/fonts.scss";
-@import "~/assets/css/fontawesome.min.css";
+@import "~/assets/css/fontawesome.min";
 
 html {
   margin: 0;


### PR DESCRIPTION
otherwise production builds will return a 500 error when preloading the generated css file