### PR TITLE
Use dashboard key properly

### DIFF
--- a/frontend/composables/useCustomFetch.ts
+++ b/frontend/composables/useCustomFetch.ts
@@ -52,8 +52,8 @@ const mapping: Record<string, MappingData> = {
     mock: true
   },
   [API_PATH.DASHBOARD_SUMMARY_CHART]: {
-    path: '/validator-dashboards/{dashboard_id}/summary-chart?',
-    getPath: values => `/validator-dashboards/${values?.dashboardId}/summary-chart`,
+    path: '/validator-dashboards/{dashboardKey}/summary-chart?',
+    getPath: values => `/validator-dashboards/${values?.dashboardKey}/summary-chart`,
     mock: true
   },
   [API_PATH.DASHBOARD_OVERVIEW]: {

--- a/frontend/pages/dashboard/[[id]]/index.vue
+++ b/frontend/pages/dashboard/[[id]]/index.vue
@@ -35,7 +35,7 @@ const key = computed(() => {
         <template #header>
           <BcTabHeader :header="$t('dashboard.validator.tabs.summary')" :icon="faChartLineUp" />
         </template>
-        <DashboardTableSummary :dashboard-key="1" />
+        <DashboardTableSummary :dashboard-key="key" />
       </TabPanel>
       <TabPanel>
         <template #header>


### PR DESCRIPTION
This PR uses the already existing dashboard key properly for the validator dashboard summary chart endpoint.
Data is still mocked though.