### PR TITLE
Add method to API MappingData

### DIFF
--- a/frontend/composables/useCustomFetch.ts
+++ b/frontend/composables/useCustomFetch.ts
@@ -25,6 +25,7 @@ type MappingData = {
   noAuth?: boolean,
   mock?: boolean,
   legacy?: boolean
+  method?: 'GET' | 'POST' | 'PUT' | 'DELETE' // 'GET' will be used as default
 }
 
 function addQueryParams (path: string, query?: PathValues) {
@@ -73,11 +74,13 @@ const mapping: Record<string, MappingData> = {
   },
   [API_PATH.LOGIN]: {
     path: '/login',
+    method: 'POST',
     noAuth: true,
     mock: true
   },
   [API_PATH.REFRESH_TOKEN]: {
     path: '/refreshToken',
+    method: 'POST',
     noAuth: true,
     mock: true
   }
@@ -102,14 +105,15 @@ export async function useCustomFetch<T> (pathName: PathName, options: NitroFetch
     baseURL = map.mock ? `${url.protocol}${url.host}/mock` : map.legacy ? pConfig?.legacyApiServer : pConfig?.apiServer
   }
 
+  const method = map.method || 'GET'
   if (pathName === API_PATH.LOGIN) {
-    const res = await $fetch<LoginResponse>(path, { ...options, baseURL })
+    const res = await $fetch<LoginResponse>(path, { method, ...options, baseURL })
     refreshToken.value = res.refresh_token
     accessToken.value = res.access_token
     return res as T
   } else if (!map.noAuth) {
     if (!accessToken.value && refreshToken.value) {
-      const res = await useCustomFetch<{ access_token: string }>(API_PATH.REFRESH_TOKEN, { method: 'POST', body: { refresh_token: refreshToken.value } })
+      const res = await useCustomFetch<{ access_token: string }>(API_PATH.REFRESH_TOKEN, { body: { refresh_token: refreshToken.value } })
       accessToken.value = res.access_token
     }
 
@@ -121,5 +125,6 @@ export async function useCustomFetch<T> (pathName: PathName, options: NitroFetch
       options.headers.append('X-User-Id', xUserId)
     }
   }
-  return await $fetch<T>(path, { ...options, baseURL })
+
+  return await $fetch<T>(path, { method, ...options, baseURL })
 }

--- a/frontend/stores/useUserStore.ts
+++ b/frontend/stores/useUserStore.ts
@@ -8,8 +8,7 @@ export const useUserStore = defineStore('user-store', () => {
       body: {
         email,
         password
-      },
-      method: 'POST'
+      }
     })
   }
 


### PR DESCRIPTION
This PR adds a method field to the API MappingData and uses it to set the method to 'POST' for both `API_PATH.LOGIN`and `API_PATH.REFRESH_TOKEN`. This causes no behavior change.