### PR TITLE
Fix translation identifier for slashings on modal

### DIFF
--- a/frontend/components/dashboard/ValidatorSubsetModal.vue
+++ b/frontend/components/dashboard/ValidatorSubsetModal.vue
@@ -38,7 +38,7 @@ const caption = computed(() => {
       text = $t('dashboard.validator.summary.row.sync')
       break
     case 'slashings':
-      text = $t('dashboard.validator.summary.row.slashings')
+      text = $t('dashboard.validator.summary.row.slashed')
       break
     case 'proposal':
       text = $t('dashboard.validator.summary.row.proposals')


### PR DESCRIPTION
This PR fixes a broken language identifier on the "Validator Subset Modal" for when the modal is opened for the "Slashings" row.