### PR TITLE
Remove press kit link

### DIFF
--- a/frontend/components/bc/footer/LinkList.vue
+++ b/frontend/components/bc/footer/LinkList.vue
@@ -11,8 +11,7 @@ import {
   faUserAstronaut,
   faAd,
   faShoppingCart,
-  faCheckCircle,
-  faNewspaper
+  faCheckCircle
 } from '@fortawesome/pro-solid-svg-icons'
 
 import { Target } from '~/types/links'


### PR DESCRIPTION
As requested by @buttaa, this PR removes the Press Kit link in the footer for now.