### PR TITLE
(NOBIDS) custom fetch() can call functions and has a timeout

### DIFF
--- a/frontend/composables/useCustomFetch.ts
+++ b/frontend/composables/useCustomFetch.ts
@@ -25,7 +25,7 @@ type PathName = typeof pathNames[number]
 export type PathValues = Record<string, string | number>
 
 interface MockFunction {
-  (body?: RequestInit['body'] | Record<string, any>, param?: PathValues, query?: PathValues) : any
+  (body?: any, param?: PathValues, query?: PathValues) : any
 }
 
 type MappingData = {


### PR DESCRIPTION
In _useCustomFetch.ts_:
* Adds a timeout to `fetch()` if the caller did not set one (which is our practice by default)
* Adds the *possibility* to call a response-generating function if `mock` is `true`.

--

To see a concrete example of this new version of _useCustomFetch.ts_ using a response-generating function, you can look at [the _useCustomFetch.ts_ of the search-bar branch](https://github.com/gobitfly/beaconchain/blob/BIDS-2959/Landing-SearchFrontend/frontend/composables/useCustomFetch.ts). The only difference is that the _useCustomFetch.ts_ of the search-bar branch has this line at the beginning:
`import { simulateAPIresponseForTheSearchBar } from '~/components/bc/searchbar/simulateapiresponse'`
and has a new entry in `mapping`:
```
[API_PATH.SEARCH]: {
    path: '/search',
    method: 'POST',
    noAuth: true,
    mock: true,
    mockFunction: simulateAPIresponseForTheSearchBar
  }
```
Type something in the search bar and the response-generating function is called by `useCustomFetch()` to fill the drop-down with results.