### PR TITLE
use correct icon for the slot viz slashing tooltip

### DIFF
--- a/frontend/components/slot/viz/SlotVizTooltip.vue
+++ b/frontend/components/slot/viz/SlotVizTooltip.vue
@@ -58,7 +58,7 @@ const data = computed(() => {
       const dutySubText = $t('slotViz.tooltip.slashing.failed.sub')
       rows.push([{
         class: 'failed',
-        icon: 'sync',
+        icon: 'slashing',
         dutyText,
         count: slot.slashing.failed.total_count,
         duties: slot.slashing.failed.slashings?.map(slash => ({
@@ -74,7 +74,7 @@ const data = computed(() => {
       const dutyText = $t('slotViz.tooltip.slashing.success.main')
       rows.push([{
         class: 'success',
-        icon: 'sync',
+        icon: 'slashing',
         dutyText,
         count: slot.slashing.success.total_count
       }])


### PR DESCRIPTION
This PR fixes the Slashing Icon for the Slot Viz Tooltip

Before:
![image](https://github.com/gobitfly/beaconchain/assets/125363940/5328c7d2-176c-44e7-87eb-e181030fea1f)


After:
![image](https://github.com/gobitfly/beaconchain/assets/125363940/96c25a2b-0003-4864-aef7-1fb858ebd1b4)

