### PR TITLE
Fix summary label on mobile

### DIFF
--- a/frontend/components/dashboard/table/SummaryDetails.vue
+++ b/frontend/components/dashboard/table/SummaryDetails.vue
@@ -37,7 +37,7 @@ const data = computed<SummaryRow[][]>(() => {
     if (!row) {
       let title = $t(`dashboard.validator.summary.row.${prop}`)
       if (prop === 'efficiency_all_time') {
-        title = `${title} (${$t(`statistics.${detail.split('_')[1]}`)})`
+        title = `${title} (${$t(`statistics.${detail}`)})`
       }
       row = { title, prop, details: [] }
       list[tableIndex].push(row)


### PR DESCRIPTION
This PR fixes the summary label in the validator dashboard summary table for expanded rows on mobile.
![image](https://github.com/gobitfly/beaconchain/assets/114066135/2d621e44-5deb-467e-80c9-60873fd261c3)
