### PR TITLE
api: improve GetPagingFromData util func

### DIFF
--- a/backend/pkg/api/types/data_access.go
+++ b/backend/pkg/api/types/data_access.go
@@ -40,7 +40,7 @@ type CursorLike interface {
 
 type GenericCursor struct {
 	Direction enums.SortOrder `json:"d"`
-	Valid     bool            `json:"v"`
+	Valid     bool            `json:"-"`
 }
 
 func (c GenericCursor) IsCursor() bool {

--- a/backend/pkg/api/types/data_access.go
+++ b/backend/pkg/api/types/data_access.go
@@ -54,4 +54,3 @@ func (c GenericCursor) IsValid() bool {
 func (c GenericCursor) GetDirection() enums.SortOrder {
 	return c.Direction
 }
-

--- a/backend/pkg/api/types/data_access.go
+++ b/backend/pkg/api/types/data_access.go
@@ -33,13 +33,25 @@ type DashboardInfo struct {
 }
 
 type CursorLike interface {
-	isCursor() bool
+	IsCursor() bool
+	IsValid() bool
+	GetDirection() enums.SortOrder
 }
 
 type GenericCursor struct {
 	Direction enums.SortOrder `json:"d"`
+	Valid     bool            `json:"v"`
 }
 
-func (b GenericCursor) isCursor() bool {
+func (c GenericCursor) IsCursor() bool {
 	return true
 }
+
+func (c GenericCursor) IsValid() bool {
+	return c.Valid
+}
+
+func (c GenericCursor) GetDirection() enums.SortOrder {
+	return c.Direction
+}
+


### PR DESCRIPTION
`utils.GetPagingFromData` now automatically toggles `prevCursor` or `nextCursor` as required

stuff that is still required to be done out of bounds
```golang
//  --- do query with limit + 1, i.e fetch one more items that required --- 
// example sql `WHERE dashboard_id = $1 AND (block_slot < $2 or (block_slot = $2 and block_index < $3)) ORDER BY block_slot DESC, block_index DESC LIMIT $4` where $4 = limit + 1

// flag if above limit
moreDataFlag := len(data) > int(limit)
if !moreDataFlag && !currentCursor.IsValid() {
    // no paging required
    return responseData, nil, nil
}

// remove the last entry from data as it is only required for the check
if moreDataFlag {
    responseData = responseData[:len(responseData)-1]
    data = data[:len(data)-1]
}

// did we receive a cursor with a direction that is different than the overall request one? if yes invert data so it matches the overall one again
if currentCursor.IsValid() && currentDirection != currentCursor.Direction {
    slices.Reverse(responseData)
    slices.Reverse(data)
}

p, err := utils.GetPagingFromData(utils.DataStructure(data), currentCursor, currentDirection, moreDataFlag)
if err != nil {
    return nil, nil, fmt.Errorf("failed to get paging: %w", err)
}
```