### PR TITLE
api: return error instead of silently capping if limit is too high

### DIFF
--- a/backend/pkg/api/handlers/common.go
+++ b/backend/pkg/api/handlers/common.go
@@ -282,7 +282,10 @@ func checkPagingParams(handlerErr *error, q url.Values) Paging {
 		if err != nil {
 			joinErr(handlerErr, err.Error())
 		}
-		paging.limit = min(limit, maxQueryLimit)
+		if limit > maxQueryLimit {
+			joinErr(handlerErr, fmt.Sprintf("given value '%d' for parameter 'limit' is too large, maximum limit is %d", limit, maxQueryLimit))
+		}
+		paging.limit = limit
 	}
 
 	if paging.cursor != "" {

--- a/backend/pkg/api/handlers/common.go
+++ b/backend/pkg/api/handlers/common.go
@@ -280,10 +280,12 @@ func checkPagingParams(handlerErr *error, q url.Values) Paging {
 	if limitStr := q.Get("limit"); limitStr != "" {
 		limit, err := strconv.ParseUint(limitStr, 10, 64)
 		if err != nil {
-			joinErr(handlerErr, err.Error())
+			joinErr(handlerErr, fmt.Sprintf("given value '%s' for parameter 'limit' is not a valid positive integer", limitStr))
+			return paging
 		}
 		if limit > maxQueryLimit {
 			joinErr(handlerErr, fmt.Sprintf("given value '%d' for parameter 'limit' is too large, maximum limit is %d", limit, maxQueryLimit))
+			return paging
 		}
 		paging.limit = limit
 	}


### PR DESCRIPTION
```json
{
"error": "given value '100000' for parameter 'limit' is too large, maximum limit is 100"
}
```