### PR TITLE
ignore invalid validators in dashboard

### DIFF
--- a/backend/pkg/api/data_access/vdb_deposits.go
+++ b/backend/pkg/api/data_access/vdb_deposits.go
@@ -286,7 +286,7 @@ func (d *DataAccessService) GetValidatorDashboardClDeposits(dashboardId t.VDBId,
 	for i, row := range data {
 		pubkeys[i] = hexutil.Encode(row.PublicKey)
 	}
-	indices, err := d.services.GetValidatorIndexOfPubkeySlice(pubkeys)
+	indices, err := d.services.GetValidatorIndicesOfPubkeySlice(pubkeys)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to recover indices after query: %w", err)
 	}

--- a/backend/pkg/api/data_access/vdb_management.go
+++ b/backend/pkg/api/data_access/vdb_management.go
@@ -86,19 +86,19 @@ func (d *DataAccessService) GetValidatorsFromSlices(indices []uint64, publicKeys
 		return nil, nil
 	}
 
-	_, err := d.services.GetPubkeysOfValidatorIndexSlice(indices)
+	existingIndices, err := d.services.GetExistingValidatorIndices(indices)
 	if err != nil {
 		return nil, err
 	}
 
-	extraIndices, err := d.services.GetValidatorIndexOfPubkeySlice(publicKeys)
+	extraIndices, err := d.services.GetExistingValidatorIndexesOfPubkeySlice(publicKeys)
 	if err != nil {
 		return nil, err
 	}
 
 	// convert to t.VDBValidator slice
-	validators := make([]t.VDBValidator, len(indices)+len(publicKeys))
-	for i, index := range append(indices, extraIndices...) {
+	validators := make([]t.VDBValidator, len(existingIndices)+len(publicKeys))
+	for i, index := range append(existingIndices, extraIndices...) {
 		validators[i] = t.VDBValidator{Index: index}
 	}
 

--- a/backend/pkg/api/handlers/internal.go
+++ b/backend/pkg/api/handlers/internal.go
@@ -114,8 +114,6 @@ func (h *HandlerService) InternalPutAccountDashboardTransactionsSettings(w http.
 // --------------------------------------
 // Validator Dashboards
 
-var errMsgParsingId = errors.New("error parsing parameter 'dashboard_id'")
-
 func (h *HandlerService) InternalPostValidatorDashboards(w http.ResponseWriter, r *http.Request) {
 	var err error
 	user, err := h.getUser(r)

--- a/backend/pkg/commons/utils/config.go
+++ b/backend/pkg/commons/utils/config.go
@@ -233,7 +233,7 @@ func ReadConfig(cfg *types.Config, path string) error {
 	cfg.Chain.Id = cfg.Chain.ClConfig.DepositChainID
 
 	if cfg.RedisSessionStoreEndpoint == "" && cfg.RedisCacheEndpoint != "" {
-		log.Infof("using RedisCacheEndpoint %s as RedisSessionStoreEndpoint as no dedicated RedisSessionStoreEndpoint was provided", cfg.RedisCacheEndpoint)
+		log.Warnf("using RedisCacheEndpoint %s as RedisSessionStoreEndpoint as no dedicated RedisSessionStoreEndpoint was provided", cfg.RedisCacheEndpoint)
 		cfg.RedisSessionStoreEndpoint = cfg.RedisCacheEndpoint
 	}
 


### PR DESCRIPTION
with this pr, invalid validators included in a non logged-in dashboard URL will get ignored, instead of the api returning an error. invalid validator in this context means a non-existent index or pubkey, the URL still needs to have the correct syntax