### PR TITLE
Made the rewards duties info optional

### DIFF
--- a/backend/pkg/api/types/validator_dashboard.go
+++ b/backend/pkg/api/types/validator_dashboard.go
@@ -77,10 +77,10 @@ type InternalGetValidatorDashboardValidatorIndicesResponse ApiDataResponse[[]uin
 // ------------------------------------------------------------
 // Rewards Tab
 type VDBRewardesTableDuty struct {
-	Attestation float64 `json:"attestation"`
-	Proposal    float64 `json:"proposal"`
-	Sync        float64 `json:"sync"`
-	Slashing    uint64  `json:"slashing"`
+	Attestation *float64 `json:"attestation"`
+	Proposal    *float64 `json:"proposal"`
+	Sync        *float64 `json:"sync"`
+	Slashing    *uint64  `json:"slashing"`
 }
 
 type VDBRewardsTableRow struct {

--- a/frontend/types/api/validator_dashboard.ts
+++ b/frontend/types/api/validator_dashboard.ts
@@ -71,10 +71,10 @@ export type InternalGetValidatorDashboardValidatorIndicesResponse = ApiDataRespo
  * Rewards Tab
  */
 export interface VDBRewardesTableDuty {
-  attestation: number /* float64 */;
-  proposal: number /* float64 */;
-  sync: number /* float64 */;
-  slashing: number /* uint64 */;
+  attestation?: number /* float64 */;
+  proposal?: number /* float64 */;
+  sync?: number /* float64 */;
+  slashing?: number /* uint64 */;
 }
 export interface VDBRewardsTableRow {
   epoch: number /* uint64 */;


### PR DESCRIPTION
The rewards duties are now optional so that we can distinguish "No proposals happened" and "All proposals missed".