### PR TITLE
small adaptation for timestamp after api changes

### DIFF
--- a/frontend/components/bc/format/FormatTimePassed.vue
+++ b/frontend/components/bc/format/FormatTimePassed.vue
@@ -31,7 +31,7 @@ const label = computed(() => {
   const ts: number = props.noUpdate ? initTs.value : timestamp.value
   switch (props.type) {
     case 'go-timestamp':
-      return formatGoTimestamp(props.value as string, ts, mappedSetting.value, props.unitLength, $t('locales.date'))
+      return formatGoTimestamp(props.value, ts, mappedSetting.value, props.unitLength, $t('locales.date'))
     case 'slot':
       return formatSlotToDateTime(props.value as number, ts, mappedSetting.value, props.unitLength, $t('locales.date'))
     case 'epoch':

--- a/frontend/utils/format.ts
+++ b/frontend/utils/format.ts
@@ -127,7 +127,10 @@ function formatTsToRelative (targetTimestamp?: number, baseTimestamp?: number, s
   return DateTime.fromMillis(targetTimestamp).setLocale(locales).toRelative({ base: date, style })
 }
 
-export function formatGoTimestamp (timestamp: string, compareTimestamp?: number, format: AgeFormat = 'relative', style: StringUnitLength = 'narrow', locales: string = 'en-US', withTime = true) {
+export function formatGoTimestamp (timestamp: string | number, compareTimestamp?: number, format: AgeFormat = 'relative', style: StringUnitLength = 'narrow', locales: string = 'en-US', withTime = true) {
+  if (typeof timestamp === 'number') {
+    timestamp *= 1000
+  }
   const dateTime = new Date(timestamp).getTime()
   return formatTs(dateTime / 1000, compareTimestamp, format, style, locales, withTime)
 }


### PR DESCRIPTION
This PR checks if the backend ts is a string or a number and acts accordingly. 

Related to this [API PR](https://github.com/gobitfly/beaconchain/pull/263/files)
