### PR TITLE
expose csrf token header

### DIFF
--- a/backend/pkg/api/router.go
+++ b/backend/pkg/api/router.go
@@ -43,12 +43,14 @@ func GetCorsMiddleware(allowedHosts []string) func(http.Handler) http.Handler {
 			gorillaHandlers.AllowedOrigins([]string{"*"}),
 			gorillaHandlers.AllowedMethods([]string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions, http.MethodHead}),
 			gorillaHandlers.AllowedHeaders([]string{"Content-Type", "Authorization", "X-CSRF-Token"}),
+			gorillaHandlers.ExposedHeaders([]string{"X-CSRF-Token"}),
 		)
 	}
 	return gorillaHandlers.CORS(
 		gorillaHandlers.AllowedOrigins(allowedHosts),
 		gorillaHandlers.AllowedMethods([]string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions, http.MethodHead}),
 		gorillaHandlers.AllowedHeaders([]string{"Content-Type", "Authorization", "X-CSRF-Token"}),
+		gorillaHandlers.ExposedHeaders([]string{"X-CSRF-Token"}),
 		gorillaHandlers.AllowCredentials(),
 	)
 }


### PR DESCRIPTION
The browser isn't allowed to read the custom CSRF header until it's exposed in the CORS policy, which causes the browser not to be able to send a valid CSRF token for unsafe requests upon navigating to the V2 frontend in a fresh state (e.g., incognito or after deleting the cache). This PR exposes the CSRF header in the API's CORS policy.