### PR TITLE
Fix network id when creating validator dashboards

### DIFF
--- a/frontend/stores/dashboard/useUserDashboardStore.ts
+++ b/frontend/stores/dashboard/useUserDashboardStore.ts
@@ -74,7 +74,7 @@ export function useUserDashboardStore () {
       return cd
     }
     // Create user specific Validator dashboard
-    const res = await fetch<{data: VDBPostReturnData}>(API_PATH.DASHBOARD_CREATE_VALIDATOR, { body: { name, network: '0' } })
+    const res = await fetch<{data: VDBPostReturnData}>(API_PATH.DASHBOARD_CREATE_VALIDATOR, { body: { name, network: 1 } })
     if (res.data) {
       data.value = {
         account_dashboards: dashboards.value?.account_dashboards || [],


### PR DESCRIPTION
This PR:
* Fixes the network parameter when creating a validator dashboard (it now uses "1" for "Ethereum" as this is currently the only option in the backend)