### PR TITLE
execution rewards

### DIFF
--- a/backend/pkg/commons/db/migrations/20240502161746_execution_rewards.sql
+++ b/backend/pkg/commons/db/migrations/20240502161746_execution_rewards.sql
@@ -1,0 +1,44 @@
+-- +goose Up
+-- +goose StatementBegin
+SELECT('up SQL query - set all empty execution_block_hashes to NULL');
+UPDATE blocks SET exec_block_hash = NULL WHERE exec_block_hash = '\x';
+-- +goose StatementEnd
+-- +goose StatementBegin
+SELECT('up SQL query - add unique constraint on execution_block_hashes');
+ALTER TABLE blocks ADD CONSTRAINT blocks_exec_block_hash_unique UNIQUE (exec_block_hash);
+-- +goose StatementEnd
+-- +goose StatementBegin
+SELECT('up SQL query - create execution_payload table');
+CREATE TABLE execution_payloads (
+	block_hash bytea NOT NULL,
+	fee_recipient_reward numeric(78, 18) NULL,
+	CONSTRAINT execution_payloads_pk PRIMARY KEY (block_hash)
+);
+-- +goose StatementEnd
+-- +goose StatementBegin
+SELECT('up SQL query - prefilling execution_payloads table with empty values');
+INSERT INTO execution_payloads (block_hash) SELECT exec_block_hash FROM blocks where exec_block_hash IS NOT NULL;
+-- +goose StatementEnd
+-- +goose StatementBegin
+SELECT('up SQL query - add foreign key constraint to blocks table');
+ALTER TABLE blocks ADD CONSTRAINT blocks_execution_payloads_fk FOREIGN KEY (exec_block_hash) REFERENCES execution_payloads(block_hash);
+-- +goose StatementEnd
+
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT('down SQL query - drop foreign key constraint to execution_payloads table');
+ALTER TABLE blocks DROP CONSTRAINT blocks_execution_payloads_fk;
+-- +goose StatementEnd
+-- +goose StatementBegin
+SELECT('down SQL query - drop execution_payloads table');
+DROP TABLE execution_payloads;
+-- +goose StatementEnd
+-- +goose StatementBegin
+SELECT('down SQL query - drop unique constraint on execution_block_hashes');
+ALTER TABLE blocks DROP CONSTRAINT blocks_exec_block_hash_unique;
+-- +goose StatementEnd
+-- +goose StatementBegin
+SELECT('down SQL query - set all NULL execution_block_hashes to empty (better safe than sorry)');
+UPDATE blocks SET exec_block_hash = '\x' WHERE exec_block_hash IS NULL;
+-- +goose StatementEnd

--- a/backend/pkg/commons/db/migrations/20240502161746_execution_rewards.sql
+++ b/backend/pkg/commons/db/migrations/20240502161746_execution_rewards.sql
@@ -17,7 +17,7 @@ CREATE TABLE execution_payloads (
 -- +goose StatementEnd
 -- +goose StatementBegin
 SELECT('up SQL query - create index on execution_payloads table');
-CREATE UNIQUE INDEX execution_payloads_block_hash_idx ON public.execution_payloads USING btree (block_hash, fee_recipient_reward);
+CREATE UNIQUE INDEX execution_payloads_block_hash_idx ON execution_payloads USING btree (block_hash, fee_recipient_reward);
 -- +goose StatementEnd
 -- +goose StatementBegin
 SELECT('up SQL query - prefilling execution_payloads table with empty values');

--- a/backend/pkg/commons/db/migrations/20240502161746_execution_rewards.sql
+++ b/backend/pkg/commons/db/migrations/20240502161746_execution_rewards.sql
@@ -16,6 +16,10 @@ CREATE TABLE execution_payloads (
 );
 -- +goose StatementEnd
 -- +goose StatementBegin
+SELECT('up SQL query - create index on execution_payloads table');
+CREATE UNIQUE INDEX execution_payloads_block_hash_idx ON public.execution_payloads USING btree (block_hash, fee_recipient_reward);
+-- +goose StatementEnd
+-- +goose StatementBegin
 SELECT('up SQL query - prefilling execution_payloads table with empty values');
 INSERT INTO execution_payloads (block_hash) SELECT exec_block_hash FROM blocks where exec_block_hash IS NOT NULL;
 -- +goose StatementEnd

--- a/backend/pkg/exporter/db/db.go
+++ b/backend/pkg/exporter/db/db.go
@@ -51,6 +51,15 @@ func saveBlocks(blocks map[uint64]map[string]*types.Block, tx *sqlx.Tx, forceSlo
 		return err
 	}
 
+	stmtExecutionPayload, err := tx.Prepare(`
+		INSERT INTO execution_payloads (block_hash)
+		VALUES ($1)
+		ON CONFLICT (block_hash) DO NOTHING`)
+	if err != nil {
+		return err
+	}
+	defer stmtExecutionPayload.Close()
+
 	stmtBlock, err := tx.Prepare(`
 		INSERT INTO blocks (epoch, slot, blockroot, parentroot, stateroot, signature, randaoreveal, graffiti, graffiti_text, eth1data_depositroot, eth1data_depositcount, eth1data_blockhash, syncaggregate_bits, syncaggregate_signature, proposerslashingscount, attesterslashingscount, attestationscount, depositscount, withdrawalcount, voluntaryexitscount, syncaggregate_participation, proposer, status, exec_parent_hash, exec_fee_recipient, exec_state_root, exec_receipts_root, exec_logs_bloom, exec_random, exec_block_number, exec_gas_limit, exec_gas_used, exec_timestamp, exec_extra_data, exec_base_fee_per_gas, exec_block_hash, exec_transactions_count, exec_blob_gas_used, exec_excess_blob_gas, exec_blob_transactions_count)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40)
@@ -185,43 +194,57 @@ func saveBlocks(blocks map[uint64]map[string]*types.Block, tx *sqlx.Tx, forceSlo
 				// blockLog = blockLog.WithField("syncParticipation", b.SyncAggregate.SyncAggregateParticipation)
 			}
 
-			parentHash := []byte{}
-			feeRecipient := []byte{}
-			stateRoot := []byte{}
-			receiptRoot := []byte{}
-			logsBloom := []byte{}
-			random := []byte{}
-			blockNumber := uint64(0)
-			gasLimit := uint64(0)
-			gasUsed := uint64(0)
-			timestamp := uint64(0)
-			extraData := []byte{}
-			baseFeePerGas := uint64(0)
-			blockHash := []byte{}
-			txCount := 0
-			withdrawalCount := 0
-			blobGasUsed := uint64(0)
-			excessBlobGas := uint64(0)
-			blobTxCount := 0
+			type exectionPayloadData struct {
+				ParentHash      []byte
+				FeeRecipient    []byte
+				StateRoot       []byte
+				ReceiptRoot     []byte
+				LogsBloom       []byte
+				Random          []byte
+				BlockNumber     *uint64
+				GasLimit        *uint64
+				GasUsed         *uint64
+				Timestamp       *uint64
+				ExtraData       []byte
+				BaseFeePerGas   *uint64
+				BlockHash       []byte
+				TxCount         *int64
+				WithdrawalCount *int64
+				BlobGasUsed     *uint64
+				ExcessBlobGas   *uint64
+				BlobTxCount     *int64
+			}
+
+			execData := new(exectionPayloadData)
+
 			if b.ExecutionPayload != nil {
-				parentHash = b.ExecutionPayload.ParentHash
-				feeRecipient = b.ExecutionPayload.FeeRecipient
-				stateRoot = b.ExecutionPayload.StateRoot
-				receiptRoot = b.ExecutionPayload.ReceiptsRoot
-				logsBloom = b.ExecutionPayload.LogsBloom
-				random = b.ExecutionPayload.Random
-				blockNumber = b.ExecutionPayload.BlockNumber
-				gasLimit = b.ExecutionPayload.GasLimit
-				gasUsed = b.ExecutionPayload.GasUsed
-				timestamp = b.ExecutionPayload.Timestamp
-				extraData = b.ExecutionPayload.ExtraData
-				baseFeePerGas = b.ExecutionPayload.BaseFeePerGas
-				blockHash = b.ExecutionPayload.BlockHash
-				txCount = len(b.ExecutionPayload.Transactions)
-				withdrawalCount = len(b.ExecutionPayload.Withdrawals)
-				blobGasUsed = b.ExecutionPayload.BlobGasUsed
-				excessBlobGas = b.ExecutionPayload.ExcessBlobGas
-				blobTxCount = len(b.BlobKZGCommitments)
+				txCount := int64(len(b.ExecutionPayload.Transactions))
+				withdrawalCount := int64(len(b.ExecutionPayload.Withdrawals))
+				blobTxCount := int64(len(b.BlobKZGCommitments))
+				execData = &exectionPayloadData{
+					ParentHash:      b.ExecutionPayload.ParentHash,
+					FeeRecipient:    b.ExecutionPayload.FeeRecipient,
+					StateRoot:       b.ExecutionPayload.StateRoot,
+					ReceiptRoot:     b.ExecutionPayload.ReceiptsRoot,
+					LogsBloom:       b.ExecutionPayload.LogsBloom,
+					Random:          b.ExecutionPayload.Random,
+					BlockNumber:     &b.ExecutionPayload.BlockNumber,
+					GasLimit:        &b.ExecutionPayload.GasLimit,
+					GasUsed:         &b.ExecutionPayload.GasUsed,
+					Timestamp:       &b.ExecutionPayload.Timestamp,
+					ExtraData:       b.ExecutionPayload.ExtraData,
+					BaseFeePerGas:   &b.ExecutionPayload.BaseFeePerGas,
+					BlockHash:       b.ExecutionPayload.BlockHash,
+					TxCount:         &txCount,
+					WithdrawalCount: &withdrawalCount,
+					BlobGasUsed:     &b.ExecutionPayload.BlobGasUsed,
+					ExcessBlobGas:   &b.ExecutionPayload.ExcessBlobGas,
+					BlobTxCount:     &blobTxCount,
+				}
+				_, err = stmtExecutionPayload.Exec(execData.BlockHash)
+				if err != nil {
+					return fmt.Errorf("error executing stmtExecutionPayload for block %v: %w", b.Slot, err)
+				}
 			}
 			_, err = stmtBlock.Exec(
 				b.Slot/utils.Config.Chain.ClConfig.SlotsPerEpoch,
@@ -242,28 +265,28 @@ func saveBlocks(blocks map[uint64]map[string]*types.Block, tx *sqlx.Tx, forceSlo
 				len(b.AttesterSlashings),
 				len(b.Attestations),
 				len(b.Deposits),
-				withdrawalCount,
+				execData.WithdrawalCount,
 				len(b.VoluntaryExits),
 				syncAggParticipation,
 				b.Proposer,
 				strconv.FormatUint(b.Status, 10),
-				parentHash,
-				feeRecipient,
-				stateRoot,
-				receiptRoot,
-				logsBloom,
-				random,
-				blockNumber,
-				gasLimit,
-				gasUsed,
-				timestamp,
-				extraData,
-				baseFeePerGas,
-				blockHash,
-				txCount,
-				blobGasUsed,
-				excessBlobGas,
-				blobTxCount,
+				execData.ParentHash,
+				execData.FeeRecipient,
+				execData.StateRoot,
+				execData.ReceiptRoot,
+				execData.LogsBloom,
+				execData.Random,
+				execData.BlockNumber,
+				execData.GasLimit,
+				execData.GasUsed,
+				execData.Timestamp,
+				execData.ExtraData,
+				execData.BaseFeePerGas,
+				execData.BlockHash,
+				execData.TxCount,
+				execData.BlobGasUsed,
+				execData.ExcessBlobGas,
+				execData.BlobTxCount,
 			)
 			if err != nil {
 				return fmt.Errorf("error executing stmtBlocks for block %v: %w", b.Slot, err)

--- a/backend/pkg/exporter/modules/base.go
+++ b/backend/pkg/exporter/modules/base.go
@@ -73,7 +73,9 @@ func StartAll(context ModuleContext) {
 	} else {
 		modules = append(modules,
 			NewSlotExporter(context),
-			NewExecutionDepositsExporter(context))
+			NewExecutionDepositsExporter(context),
+			NewExecutionPayloadsExporter(context),
+		)
 	}
 
 	startSubscriptionModules(&context, modules)

--- a/backend/pkg/exporter/modules/execution_deposits_exporter.go
+++ b/backend/pkg/exporter/modules/execution_deposits_exporter.go
@@ -236,7 +236,7 @@ func (d *executionDepositsExporter) exportTillBlock(block uint64) (err error) {
 		return err
 	}
 
-	log.Debugf("updating cached view took %v", time.Since(start))
+	log.Debugf("updating cached deposits view took %v", time.Since(start))
 
 	if len(depositsToSave) > 0 {
 		err = d.aggregateDeposits()

--- a/backend/pkg/exporter/modules/execution_deposits_exporter.go
+++ b/backend/pkg/exporter/modules/execution_deposits_exporter.go
@@ -33,6 +33,8 @@ import (
 
 // if we ever end up in a situation where we possibly have gaps in the data remember: the merkletree_index is unique.
 // if one is missing, simple take the blocks from the merkletree_index before and after and fetch the deposits again.
+// tho it is sadly stored as a little endian encoded int so you will have to convert it to a number first.
+// fixing this would've required messing with v1, better to do when its gone
 
 type executionDepositsExporter struct {
 	ModuleContext

--- a/backend/pkg/exporter/modules/execution_payloads.go
+++ b/backend/pkg/exporter/modules/execution_payloads.go
@@ -1,0 +1,216 @@
+package modules
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math/big"
+	"sync"
+
+	"github.com/gobitfly/beaconchain/pkg/commons/db"
+	"github.com/gobitfly/beaconchain/pkg/commons/log"
+	"github.com/gobitfly/beaconchain/pkg/commons/types"
+	constypes "github.com/gobitfly/beaconchain/pkg/consapi/types"
+	"github.com/pkg/errors"
+	"github.com/shopspring/decimal"
+	"golang.org/x/sync/errgroup"
+)
+
+type executionPayloadsExporter struct {
+	ModuleContext ModuleContext
+	ExportMutex   *sync.Mutex
+}
+
+func NewExecutionPayloadsExporter(moduleContext ModuleContext) ModuleInterface {
+	return &executionPayloadsExporter{
+		ModuleContext: moduleContext,
+		ExportMutex:   &sync.Mutex{},
+	}
+}
+
+func (d *executionPayloadsExporter) OnHead(event *constypes.StandardEventHeadResponse) (err error) {
+	return nil // nop
+}
+
+func (d *executionPayloadsExporter) Init() error {
+	return nil // nop
+}
+
+func (d *executionPayloadsExporter) GetName() string {
+	return "ExecutionPayloads-Exporter"
+}
+
+func (d *executionPayloadsExporter) OnChainReorg(event *constypes.StandardEventChainReorg) (err error) {
+	return nil // nop
+}
+
+// can take however long it wants to run, is run in a separate goroutine, so no need to worry about blocking
+func (d *executionPayloadsExporter) OnFinalizedCheckpoint(event *constypes.StandardFinalizedCheckpointResponse) (err error) {
+	// if mutex is locked, return early
+	if !d.ExportMutex.TryLock() {
+		log.Infof("execution payloads exporter is already running")
+		return nil
+	}
+	defer d.ExportMutex.Unlock()
+
+	err = d.maintainTable()
+	if err != nil {
+		return fmt.Errorf("error maintaining table: %w", err)
+	}
+
+	return nil
+}
+
+// this is basically synchronous, each time it gets called it will kill the previous export and replace it with itself
+func (d *executionPayloadsExporter) maintainTable() (err error) {
+	blocks := struct {
+		MinBlock sql.NullInt64 `db:"min"`
+		MaxBlock sql.NullInt64 `db:"max"`
+	}{}
+	err = db.ReaderDb.Get(&blocks, `
+		SELECT
+			MIN(b.exec_block_number),
+			MAX(b.exec_block_number)
+		FROM
+			blocks b
+			inner JOIN execution_payloads ep ON b.exec_block_hash = ep.block_hash
+		WHERE
+			ep.fee_recipient_reward IS NULL and b.status='1'
+	`)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			log.Infof("no missing blocks found")
+			return nil
+		}
+		return fmt.Errorf("error getting min and max block: %w", err)
+	}
+	if !blocks.MinBlock.Valid || !blocks.MaxBlock.Valid {
+		log.Infof("no missing blocks found")
+		return nil
+	}
+	minBlock := uint64(blocks.MinBlock.Int64)
+	maxBlock := uint64(blocks.MaxBlock.Int64)
+
+	if minBlock == 0 {
+		log.Infof("no missing blocks found")
+		return nil
+	}
+
+	log.Infof("min block: %v, max block: %v", blocks.MinBlock, blocks.MaxBlock)
+
+	// channel that will receive blocks from bigtable
+	blockChan := make(chan *types.Eth1BlockIndexed, 1000)
+	type Result struct {
+		BlockHash          []byte
+		FeeRecipientReward decimal.Decimal
+	}
+	resData := make([]Result, 0, maxBlock-minBlock+1)
+
+	ctx, finish := context.WithCancel(context.Background())
+	defer finish()
+	group, _ := errgroup.WithContext(ctx)
+
+	// coroutine to process the blocks
+	group.Go(func() error {
+		var block *types.Eth1BlockIndexed
+		for i := minBlock; i <= maxBlock; i++ {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case b, ok := <-blockChan:
+				block = b
+				if !ok {
+					return nil
+				}
+			}
+			// read txn reward
+			raw := block.GetTxReward()
+			if raw == nil {
+				// use 0
+				raw = []byte{0}
+			}
+			hash := block.GetHash()
+			if hash == nil {
+				return fmt.Errorf("error getting block hash for block %v", block.Number)
+			}
+			// convert raw (bytes) to bigint
+			num := new(big.Int).SetBytes(raw)
+			// convert bigint to decimal
+			dec := decimal.NewFromBigInt(num, -18)
+			if err != nil {
+				return fmt.Errorf("error converting tx reward to decimal for block %v: %w", block.Number, err)
+			}
+			resData = append(resData, Result{BlockHash: hash, FeeRecipientReward: dec})
+		}
+		return nil
+	})
+
+	err = db.BigtableClient.StreamBlocksIndexedDescending(blockChan, maxBlock, minBlock)
+
+	if err != nil {
+		finish()
+		return fmt.Errorf("error streaming blocks: %w", err)
+	}
+
+	err = group.Wait()
+
+	if err != nil {
+		return fmt.Errorf("error processing blocks: %w", err)
+	}
+
+	// update the execution_payloads table
+
+	log.Infof("preparing copy update to temp table")
+
+	// load data into temp table
+	_, err = db.WriterDb.Exec(`
+		CREATE TEMP TABLE temp_fee_recipient_reward (
+			block_hash bytea PRIMARY KEY,
+			fee_recipient_reward numeric
+		);
+	`)
+	defer func() {
+		_, err = db.WriterDb.Exec(`DROP TABLE IF EXISTS temp_fee_recipient_reward;`)
+		if err != nil {
+			log.Error(err, "error dropping temp table", 0)
+		}
+	}()
+
+	if err != nil {
+		return fmt.Errorf("error creating temp table: %w", err)
+	}
+
+	// prepare data for bulk insert
+	dat := make([][]interface{}, len(resData))
+	for i, r := range resData {
+		dat[i] = []interface{}{r.BlockHash, r.FeeRecipientReward}
+	}
+
+	log.Infof("copying data to temp table")
+
+	err = db.CopyToTable("temp_fee_recipient_reward", []string{"block_hash", "fee_recipient_reward"}, dat)
+	if err != nil {
+		return fmt.Errorf("error copying data to temp table: %w", err)
+	}
+
+	log.Infof("updating execution_payloads")
+
+	// update execution_payloads using temp table
+	_, err = db.WriterDb.Exec(`
+		UPDATE execution_payloads ep
+		SET fee_recipient_reward = t.fee_recipient_reward
+		FROM temp_fee_recipient_reward t
+		WHERE ep.block_hash = t.block_hash;
+	`)
+	if err != nil {
+		return fmt.Errorf("error updating execution_payloads: %w", err)
+	}
+
+	log.Infof("finished updating execution_payloads")
+
+	if err != nil {
+		return fmt.Errorf("error caching data: %w", err)
+	}
+
+	return nil
+}

--- a/backend/pkg/exporter/modules/execution_payloads_exporter.go
+++ b/backend/pkg/exporter/modules/execution_payloads_exporter.go
@@ -95,7 +95,6 @@ func (d *executionPayloadsExporter) updateCachedView() (err error) {
 	return err
 }
 
-// this is basically synchronous, each time it gets called it will kill the previous export and replace it with itself
 func (d *executionPayloadsExporter) maintainTable() (err error) {
 	blocks := struct {
 		MinBlock sql.NullInt64 `db:"min"`
@@ -125,9 +124,9 @@ func (d *executionPayloadsExporter) maintainTable() (err error) {
 	minBlock := uint64(blocks.MinBlock.Int64)
 	maxBlock := uint64(blocks.MaxBlock.Int64)
 
-	if minBlock == 0 {
-		log.Infof("no missing blocks found")
-		return nil
+	// limit to 1mil blocks to prevent reading too much from bigtable
+	if maxBlock-minBlock > 1e6 {
+		maxBlock = minBlock + 1e6
 	}
 
 	log.Infof("min block: %v, max block: %v", blocks.MinBlock, blocks.MaxBlock)

--- a/backend/pkg/exporter/modules/execution_payloads_exporter.go
+++ b/backend/pkg/exporter/modules/execution_payloads_exporter.go
@@ -96,7 +96,6 @@ func (d *executionPayloadsExporter) updateCachedView() (err error) {
 			slot DESC;
 	`, "cached_proposal_rewards", []string{"dashboard_id", "slot"}, []string{"dashboard_id", "reward"})
 	return err
-
 }
 
 // this is basically synchronous, each time it gets called it will kill the previous export and replace it with itself

--- a/backend/pkg/exporter/modules/execution_payloads_exporter.go
+++ b/backend/pkg/exporter/modules/execution_payloads_exporter.go
@@ -76,12 +76,9 @@ func (d *executionPayloadsExporter) updateCachedView() (err error) {
 			uvdv.dashboard_id,
 			uvdv.group_id,
 			b.slot,
-			coalesce(rb.value / 1e18, ep.fee_recipient_reward) AS reward,
-			rb.value IS NOT NULL AS is_mev,
-			case
-				when rb.value IS NOT NULL then rb.proposer_fee_recipient
-				else b.exec_fee_recipient
-			end as fee_recipient
+			coalesce(rb.value / 1e18, ep.fee_recipient_reward) as reward,
+			coalesce(rb.proposer_fee_recipient, b.exec_fee_recipient) as fee_recipient, 
+			rb.value IS NOT NULL AS is_mev
 		FROM
 			blocks b
 			INNER JOIN execution_payloads ep ON ep.block_hash = b.exec_block_hash


### PR DESCRIPTION
adds exporter task to fetch missing rewards to postgres each time an epoch is justified. it automatically fills whatever is missing. no manual backfill should be needed. migration files is there. there is a cached materialized view that joins with the relay rewards for dashboard usage

depends on https://github.com/gobitfly/eth2-beaconchain-explorer/pull/2879