### PR TITLE
(BIDS-2959) fix in locally-mocked search-results

### DIFF
--- a/frontend/utils/mock.ts
+++ b/frontend/utils/mock.ts
@@ -298,7 +298,7 @@ export function simulateAPIresponseForTheSearchBar (body? : Record<string, any>)
     response.data = response.data.filter(singleRes => searchableTypes.includes(singleRes.type as ResultType))
   }
   if (searchableNetworks.length) {
-    response.data = response.data.filter(singleRes => searchableNetworks.includes(singleRes.chain_id))
+    response.data = response.data.filter(singleRes => searchableNetworks.includes(singleRes.chain_id) || TypeInfo[singleRes.type as ResultType].belongsToAllNetworks)
   }
   // adding fake numbers of identical results where it is possible
   if (countIdenticalValidators) {


### PR DESCRIPTION
Mini PR.

It does not change anything at all when `mock: false` for the search bar.
When it is set to `true`, some results that where forgotten by mistake are now mocked.