### PR TITLE
Adapt to api changes removing the orphaned status for proposals

### DIFF
--- a/frontend/components/playground/PlaygroundDutyStatus.vue
+++ b/frontend/components/playground/PlaygroundDutyStatus.vue
@@ -83,7 +83,7 @@ const data: ValidatorHistoryDuties[] = [
       cl_sync_inclusion_income: '0',
       cl_slashing_inclusion_income: '0',
       el_income: '0',
-      status: 'orphaned'
+      status: 'failed'
     }
   },
   {}


### PR DESCRIPTION
Replacing the 'orphaned' state in the playground tests for the proposal state (after the related api change caused a script error)