### PR TITLE
Nobids/minor changes for public dashboards

### DIFF
--- a/frontend/components/dashboard/DashboardControls.vue
+++ b/frontend/components/dashboard/DashboardControls.vue
@@ -58,8 +58,7 @@ const manageButtons = computed<MenuBarEntry[] | undefined>(() => {
 const shareButtonOptions = computed(() => {
   const label = isPublic.value ? $t('dashboard.shared') : $t('dashboard.share')
   const icon = isPublic.value ? faUsers : faShare
-  const tooltip = isPublic.value ? $t('dashboard.shared_tooltip') : undefined
-  return { label, icon, tooltip }
+  return { label, icon }
 })
 
 const share = () => {
@@ -141,11 +140,9 @@ const deleteAction = async (key: DashboardKey, deleteDashboard: boolean, forward
   <DashboardValidatorManagementModal v-if="dashboardType=='validator'" v-model="manageValidatorsModalVisisble" />
   <div class="header-row">
     <div class="action-button-container">
-      <BcTooltip v-if="shareButtonOptions.tooltip" :text="shareButtonOptions.tooltip" position="top" :fit-content="true">
-        <Button class="share-button" :disabled="isPublic" @click="share()">
-          {{ shareButtonOptions.label }}<FontAwesomeIcon :icon="shareButtonOptions.icon" />
-        </Button>
-      </BcTooltip>
+      <Button class="share-button" :disabled="isPublic" @click="share()">
+        {{ shareButtonOptions.label }}<FontAwesomeIcon :icon="shareButtonOptions.icon" />
+      </Button>
       <Button class="p-button-icon-only" :disabled="deleteButtonOptions.disabled" @click="onDelete()">
         <FontAwesomeIcon :icon="faTrash" />
       </Button>

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -228,7 +228,6 @@
     "notifications": "Notifications",
     "share": "Share",
     "shared": "Shared",
-    "shared_tooltip": "This is a public dashboard. Login to create a private one.",
     "share_dashboard": "Share Dashboard",
     "delete_dashboard": "Delete Dashboard",
     "group": {


### PR DESCRIPTION
This PR
* Changes the name shown on public dashboards to "Dashboard" (requested by @Buttaa)
* Harmonizes the font styling for the "VAT" text with the one used for feature subtexts (requested by our designer)

This PR does not
* Add a tooltip around the "Shared" button on public dashboards (requested by @Buttaa )