### PR TITLE
sort and filter the summary table in the frontend

### DIFF
--- a/frontend/components/dashboard/table/DashboardTableSummary.vue
+++ b/frontend/components/dashboard/table/DashboardTableSummary.vue
@@ -5,7 +5,6 @@ import type { VDBSummaryTableRow } from '~/types/api/validator_dashboard'
 import type { Cursor, TableQueryParams } from '~/types/datatable'
 import { useValidatorDashboardOverviewStore } from '~/stores/dashboard/useValidatorDashboardOverviewStore'
 import { DAHSHBOARDS_ALL_GROUPS_ID } from '~/types/dashboard'
-import { getGroupLabel } from '~/utils/dashboard/group'
 
 const { dashboardKey, isPublic } = useDashboardKey()
 
@@ -14,11 +13,10 @@ const pageSize = ref<number>(10)
 const { t: $t } = useI18n()
 const showInDevelopment = Boolean(useRuntimeConfig().public.showInDevelopment)
 
-const { summary, query: lastQuery, isLoading, getSummary } = useValidatorDashboardSummaryStore()
+const { summary, query: lastQuery, isLoading, getSummary, groupNameLabel } = useValidatorDashboardSummaryStore()
 const { value: query, temp: tempQuery, bounce: setQuery } = useDebounceValue<TableQueryParams | undefined>(undefined, 500)
 
 const { overview } = useValidatorDashboardOverviewStore()
-const { groups } = useValidatorDashboardGroups()
 
 const { width } = useWindowSize()
 const colsVisible = computed(() => {
@@ -44,10 +42,6 @@ watch(query, (q) => {
     getSummary(dashboardKey.value, q)
   }
 }, { immediate: true })
-
-const groupNameLabel = (groupId?: number) => {
-  return getGroupLabel($t, groupId, groups.value)
-}
 
 const onSort = (sort: DataTableSortEvent) => {
   loadData(setQuerySort(sort, lastQuery?.value))
@@ -152,7 +146,6 @@ const getRowClass = (row: VDBSummaryTableRow) => {
             <Column
               v-if="colsVisible.validator"
               class="validator_column"
-              :sortable="true"
               :header="$t('dashboard.validator.col.validators')"
             >
               <template #body="slotProps">

--- a/frontend/stores/dashboard/useValidatorDashboardSummaryStore.ts
+++ b/frontend/stores/dashboard/useValidatorDashboardSummaryStore.ts
@@ -1,41 +1,88 @@
 import { defineStore } from 'pinia'
-import type { InternalGetValidatorDashboardSummaryResponse } from '~/types/api/validator_dashboard'
+import { filter, get, orderBy } from 'lodash-es'
+import type { InternalGetValidatorDashboardSummaryResponse, VDBSummaryTableRow } from '~/types/api/validator_dashboard'
 import type { DashboardKey } from '~/types/dashboard'
 import type { TableQueryParams } from '~/types/datatable'
 import { API_PATH } from '~/types/customFetch'
+import { getGroupLabel } from '~/utils/dashboard/group'
 
 const validatorDashboardSummaryStore = defineStore('validator_dashboard_sumary_store', () => {
   const data = ref < InternalGetValidatorDashboardSummaryResponse>()
   const query = ref < TableQueryParams>()
+  const lastDashboardKey = ref<DashboardKey>()
 
-  return { data, query }
+  return { data, query, lastDashboardKey }
 })
 
 export function useValidatorDashboardSummaryStore () {
   const { fetch } = useCustomFetch()
+  const { groups } = useValidatorDashboardGroups()
+  const { t: $t } = useI18n()
 
-  const { data, query: storedQuery } = storeToRefs(validatorDashboardSummaryStore())
+  const { data, query: storedQuery, lastDashboardKey } = storeToRefs(validatorDashboardSummaryStore())
   const isLoading = ref(false)
 
-  const summary = computed(() => data.value)
   const query = computed(() => storedQuery.value)
+
+  const groupNameLabel = (groupId?: number) => {
+    return getGroupLabel($t, groupId, groups.value)
+  }
+
+  const summary = computed<InternalGetValidatorDashboardSummaryResponse | undefined>(() => {
+    if (!data.value) {
+      return
+    }
+
+    const search = query.value?.search?.toLowerCase()
+    let list: VDBSummaryTableRow[] = !search
+      ? data.value.data
+      : filter(data.value.data, (item) => {
+        const name = groupNameLabel(item.group_id).toLowerCase()
+        return name.includes(search)
+      })
+    const [sort, order] = query.value?.sort?.split(':') || [undefined, undefined]
+    if (sort && order) {
+      if (sort === 'group_id') {
+        list = orderBy(list, [item => groupNameLabel(item.group_id).toLowerCase()], order as 'asc' | 'desc')
+      } else if (sort.startsWith('efficiency')) {
+        list = orderBy(list, [(item) => {
+          const path = sort.replace('efficiency_', 'efficiency.')
+          return get(item, path)
+        }], order as 'asc' | 'desc')
+      }
+    }
+    const totalCount = list.length
+    let cursor = query.value?.cursor as (number | undefined)
+    const limit = query.value?.limit ?? 10
+    if (cursor && cursor as number >= totalCount) {
+      cursor = 0
+    }
+    list = list.slice(cursor, (cursor ?? 0) + limit)
+    return {
+      paging: {
+        total_count: totalCount
+      },
+      data: list
+    }
+  }
+  )
 
   async function getSummary (dashboardKey: DashboardKey, query?: TableQueryParams) {
     if (!dashboardKey) {
       data.value = undefined
       return undefined
     }
-    isLoading.value = true
     storedQuery.value = query
+    isLoading.value = true
+    if (lastDashboardKey.value !== dashboardKey || !data.value) {
+      lastDashboardKey.value = dashboardKey
+      const res = await fetch<InternalGetValidatorDashboardSummaryResponse>(API_PATH.DASHBOARD_SUMMARY, undefined, { dashboardKey })
 
-    const res = await fetch<InternalGetValidatorDashboardSummaryResponse>(API_PATH.DASHBOARD_SUMMARY, undefined, { dashboardKey }, query)
-    isLoading.value = false
-    if (JSON.stringify(storedQuery.value) !== JSON.stringify(query)) {
-      return // in case some query params change while loading
+      data.value = res
     }
-    data.value = res
-    return res
+    isLoading.value = false
+    return summary.value
   }
 
-  return { summary, query, isLoading, getSummary }
+  return { summary, query, isLoading, getSummary, groupNameLabel }
 }


### PR DESCRIPTION
Current State: This will probably be done by the backend, so this PR can be ignored.

I will leave the PR open just in case this changes.

This PR 
- implements sorting and filtering of the summary table in the frontend


This PR
- does not filter for validator id as we don't have all in the frontend