### PR TITLE
use max decimals if value is to small to display

### DIFF
--- a/frontend/components/playground/PlaygroundConversion.vue
+++ b/frontend/components/playground/PlaygroundConversion.vue
@@ -53,6 +53,9 @@ const currentEpoch = computed(() => (latestState.value?.current_slot || 0) * 32)
     <div>
       less than 1Eth in ETH :<BcFormatValue value="0000000010002000001" :options="{minUnit:'MAIN'}" />
     </div>
+    <div>
+      less than 1Wei in ETH, min 0 decimals, max: 6:<BcFormatValue value="0000000000000000001" :options="{minUnit:'MAIN', addPlus: true, maxDecimalCount: 6, minDecimalCount: 0}" />
+    </div>
 
     <div>
       1 GNO :<BcFormatValue value="1000000000000000000" :options="{sourceCurrency: 'GNO'}" />

--- a/frontend/utils/format.ts
+++ b/frontend/utils/format.ts
@@ -86,7 +86,7 @@ export function trim (value:string | number, maxDecimalCount: number, minDecimal
     if (maxDecimalCount === 0) {
       return '<1'
     }
-    return `<0.${nZeros(minDecimalCount - 1)}1`
+    return `<0.${nZeros(maxDecimalCount - 1)}1`
   }
   const left = commmifyLeft(split[0])
   if (!dec?.length) {


### PR DESCRIPTION
This PR fixes the value formatting of to small values:

example with the config min: 0 decimals and max 6 decimals
Value 0.00000000001 
leads to:
before:
`<0.1` 
after: 
`<0.000001`

which is more accurate. 