### PR TITLE
adapt to dashboard name change api

### DIFF
--- a/frontend/components/dashboard/DashboardControls.vue
+++ b/frontend/components/dashboard/DashboardControls.vue
@@ -128,9 +128,9 @@ const onDelete = () => {
 const deleteAction = async (key: DashboardKey, deleteDashboard: boolean, forward: boolean) => {
   if (deleteDashboard) {
     if (dashboardType.value === 'validator') {
-      await fetch(API_PATH.DASHBOARD_EDIT_VALIDATOR, { body: { key }, method: 'DELETE' }, { dashboardKey: key })
+      await fetch(API_PATH.DASHBOARD_DELETE_VALIDATOR, { body: { key } }, { dashboardKey: key })
     } else {
-      await fetch(API_PATH.DASHBOARD_EDIT_ACCOUNT, { body: { key }, method: 'DELETE' }, { dashboardKey: key })
+      await fetch(API_PATH.DASHBOARD_DELETE_ACCOUNT, { body: { key } }, { dashboardKey: key })
     }
 
     await refreshDashboards()

--- a/frontend/components/dashboard/DashboardRenameModal.vue
+++ b/frontend/components/dashboard/DashboardRenameModal.vue
@@ -27,9 +27,8 @@ const rename = async () => {
     return
   }
   isLoading.value = true
-  const path = props.value?.dashboardType === 'validator' ? API_PATH.DASHBOARD_EDIT_VALIDATOR : API_PATH.DASHBOARD_EDIT_ACCOUNT
-  // TODO: validate params once backend is done.
-  await fetch(path, { body: { id: props.value?.dashboard.id, name: name.value } }, { dashboardKey: `${props.value?.dashboard.id}` })
+  const path = props.value?.dashboardType === 'validator' ? API_PATH.DASHBOARD_RENAME_VALIDATOR : API_PATH.DASHBOARD_RENAME_ACCOUNT
+  await fetch(path, { body: { name: name.value } }, { dashboardKey: `${props.value?.dashboard.id}` })
 
   isLoading.value = false
   dialogRef?.value.close(true)

--- a/frontend/types/customFetch.ts
+++ b/frontend/types/customFetch.ts
@@ -6,8 +6,10 @@ export enum API_PATH {
   USER_DASHBOARDS = '/user/dashboards',
   DASHBOARD_CREATE_ACCOUNT = '/dashboard/createAccount',
   DASHBOARD_CREATE_VALIDATOR = '/dashboard/createValidator',
-  DASHBOARD_EDIT_ACCOUNT = '/dashboard/accountValidator',
-  DASHBOARD_EDIT_VALIDATOR = '/dashboard/deleteValidator',
+  DASHBOARD_DELETE_ACCOUNT = '/dashboard/deleteAccountDashbaoard',
+  DASHBOARD_DELETE_VALIDATOR = '/dashboard/deleteValidatorDashboard',
+  DASHBOARD_RENAME_ACCOUNT = '/dashboard/renameAccountDashbaoard',
+  DASHBOARD_RENAME_VALIDATOR = '/dashboard/renameValidatorDashboard',
   DASHBOARD_VALIDATOR_MANAGEMENT = '/validator-dashboards/validators',
   DASHBOARD_VALIDATOR_GROUPS = '/validator-dashboards/groups',
   DASHBOARD_VALIDATOR_CREATE_PUBLIC_ID = '/validator-dashboards/publicIds',
@@ -108,15 +110,27 @@ export const mapping: Record<string, MappingData> = {
     mock: false,
     method: 'POST'
   },
-  [API_PATH.DASHBOARD_EDIT_ACCOUNT]: {
+  [API_PATH.DASHBOARD_DELETE_ACCOUNT]: {
     path: '/account-dashboards/{dashboardKey}',
     getPath: values => `/account-dashboards/${values?.dashboardKey}`,
     mock: true,
-    method: 'PUT'
+    method: 'DELETE'
   },
-  [API_PATH.DASHBOARD_EDIT_VALIDATOR]: {
+  [API_PATH.DASHBOARD_DELETE_VALIDATOR]: {
     path: '/validator-dashboards/{dashboardKey}',
     getPath: values => `/validator-dashboards/${values?.dashboardKey}`,
+    mock: false,
+    method: 'DELETE'
+  },
+  [API_PATH.DASHBOARD_RENAME_ACCOUNT]: {
+    path: '/account-dashboards/{dashboardKey}/name',
+    getPath: values => `/account-dashboards/${values?.dashboardKey}/name`,
+    mock: true,
+    method: 'PUT'
+  },
+  [API_PATH.DASHBOARD_RENAME_VALIDATOR]: {
+    path: '/validator-dashboards/{dashboardKey}/name',
+    getPath: values => `/validator-dashboards/${values?.dashboardKey}/name`,
     mock: false,
     method: 'PUT'
   },


### PR DESCRIPTION
This PR adapts to the newly released api for name change:

- split up delete and edit name path's
- use the 'real name change api path