### PR TITLE
dont initially show unsupported currencies

### DIFF
--- a/frontend/composables/useCurrency.ts
+++ b/frontend/composables/useCurrency.ts
@@ -10,7 +10,6 @@ export function useCurrency () {
   const showInDevelopment = Boolean(useRuntimeConfig().public.showInDevelopment)
 
   const selectedCurrency = useCookie<Currency>(COOKIE_KEY.CURRENCY, { default: () => 'NAT' })
-  const currency = readonly(selectedCurrency)
   function setCurrency (newCurrency: Currency) {
     selectedCurrency.value = newCurrency
   }
@@ -32,6 +31,8 @@ export function useCurrency () {
     return list.concat((latestState.value?.exchange_rates || []).map(r => r.code as Currency))
   })
 
+  const currency = computed(() => selectedCurrency.value && available.value.includes(selectedCurrency.value) ? selectedCurrency.value : available.value[0])
+
   const withLabel = computed(() => {
     return available.value?.map(currency => ({
       currency,
@@ -39,9 +40,9 @@ export function useCurrency () {
     }))
   })
 
-  watch([latestState, currency], () => {
+  watch([latestState, selectedCurrency], () => {
     // once we loaded our latestState and see that we don't support the currency we switch back to the first item
-    if (latestState.value && !available.value.includes(currency.value)) {
+    if (latestState.value && !available.value.includes(selectedCurrency.value)) {
       selectedCurrency.value = available.value[0]
     }
   })


### PR DESCRIPTION
This PR
- makes sure that you don't initially see a currency in the currency selection that is no longer supported.


Hint for the Reviewer: You can change your currency cookie to a not supported currency and refresh your page. Without the fix you should see the not supported currency that switches to the first one after hydration. 