### PR TITLE
dont shrink our table headers

### DIFF
--- a/frontend/components/bc/table/BcTableControl.vue
+++ b/frontend/components/bc/table/BcTableControl.vue
@@ -60,6 +60,7 @@ const onInput = (value: string) => {
   display: flex;
   align-items: center;
   gap: var(--padding);
+  flex-shrink: 0;
 
   .side {
     flex-grow: 1;


### PR DESCRIPTION
This PR
- prevents the table header to shrink if the content gets to big like in the Reward Duties Modal

![image](https://github.com/gobitfly/beaconchain/assets/125363940/38c8f9f2-aa32-440b-bb61-6f70e2b02464)
