### PR TITLE
(BIDS-2959) MiddleEllipsis: improvement of the workaround against the Chrome bug

### DIFF
--- a/frontend/components/bc/searchbar/MiddleEllipsis.vue
+++ b/frontend/components/bc/searchbar/MiddleEllipsis.vue
@@ -233,8 +233,10 @@ watch(() => props.widthMediaqueryThreshold, (threshold, previousThreshold) => {
   if (SSR || !navigator.userAgent.includes('Chrom')) {
     return
   }
+  if (mediaqueryWidthListener) {
+    mediaqueryWidthListener.onchange = null
+  }
   if (amIinsideAparent.value || !threshold) {
-    if (mediaqueryWidthListener) { mediaqueryWidthListener.onchange = null }
     return
   }
   mediaqueryWidthListener = window.matchMedia('(max-width: ' + threshold + 'px)')


### PR DESCRIPTION
The visual bug in Chrome (bug when the layout is suddenly changed by media queries) was back since we increased the width of the scroll bars.

The reason was that the workaround was unable to consider the width of the scroll bars.

Fixed