### PR TITLE
Change label for slashed validators in summary table

### DIFF
--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -434,7 +434,7 @@
           "proposals": "Proposals",
           "validators_proposal": "Validators",
           "slashed": "Slashings",
-          "validators_slashings": "Validators",
+          "validators_slashings": "Slashed Validators",
           "apr": "APR",
           "luck": "Luck"
         },


### PR DESCRIPTION
This PR
* Changes the label for slashed validators in the summary's table expandable from "Validators" to "Slashed Validators"

This PR does not
* Change the title of the validator subset modal for slashings as the text would be too long (discussed with @Buttaa )