### PR TITLE
Only show premium modal if not a single validator can be added

### DIFF
--- a/frontend/components/dashboard/ValidatorManagementModal.vue
+++ b/frontend/components/dashboard/ValidatorManagementModal.vue
@@ -108,7 +108,7 @@ const removeValidators = async (validators?: NumberOrString[]) => {
 }
 
 const addValidator = (result: ResultSuggestion) => {
-  if (total.value + result.count > maxValidatorsPerDashboard.value) {
+  if (total.value + 1 > maxValidatorsPerDashboard.value) {
     dialog.open(BcPremiumModal, {})
     return
   }


### PR DESCRIPTION
This PR
* causes the premium modal only to be shown when not a single validator can be added in `addValidator`