### PR TITLE
some menu fixes

### DIFF
--- a/frontend/assets/css/prime_menubar.scss
+++ b/frontend/assets/css/prime_menubar.scss
@@ -51,6 +51,7 @@
       padding: var(--padding);
       white-space: nowrap;
       text-overflow: ellipsis;
+      max-width: 200px;
 
       &:not(:has(.p-active)):not(:has(.router-link-active)) {
         color: var(--text-color);

--- a/frontend/components/dashboard/DashboardHeader.vue
+++ b/frontend/components/dashboard/DashboardHeader.vue
@@ -231,7 +231,9 @@ const editDashboard = () => {
       width: 145px;
 
       &:has(.text-disabled) {
-        opacity: 0.5;
+        > .p-menuitem-content{
+          opacity: 0.5;
+        }
       }
     }
   }


### PR DESCRIPTION
This PR
- ensures that the menu content is not transparent
![image](https://github.com/gobitfly/beaconchain/assets/125363940/6b9d196e-e0b0-4530-811a-3d1fd10a4c1b)
- sets a max width for the menu items so they are truncated if too long