### PR TITLE
Change link on premium modal to /pricing

### DIFF
--- a/frontend/components/bc/premium/BcPremiumModal.vue
+++ b/frontend/components/bc/premium/BcPremiumModal.vue
@@ -25,7 +25,7 @@ onMounted(() => {
     <div class="dismiss" @click="hide()">
       {{ props?.dismissLabel || $t('navigation.dismiss') }}
     </div>
-    <BcLink to="/premium/subscription" target="_blank" @click="hide()">
+    <BcLink to="/pricing" target="_blank" @click="hide()">
       <Button :label="$t('premium.unlock')" />
     </BcLink>
   </div>


### PR DESCRIPTION
This PR
* Changes the link for the "Unlock" button on the premium modal to `/pricing`