### PR TITLE
mark scheduled blocks of the past as probably missed

### DIFF
--- a/frontend/assets/css/colors.scss
+++ b/frontend/assets/css/colors.scss
@@ -166,7 +166,6 @@
     --positive-color: var(--green);
     --positive-contrast-color: var(--text-color-inverted);
     --partial-color: var(--orange);
-    --partial-contrast-color: var(--text-color);
     --light-tag-color: var(--light-grey);
 
     --megamenu-panel-color: var(--graphite);

--- a/frontend/components/bc/table/BcTableTag.vue
+++ b/frontend/components/bc/table/BcTableTag.vue
@@ -14,7 +14,7 @@ defineProps<Props>()
 
 </script>
 <template>
-  <BcTooltip v-if="label || icon" class="tag" :class="[color, size]" :text="tooltip">
+  <BcTooltip v-if="label || icon" class="tag" :class="[color, size]" :text="tooltip" :fit-content="true">
     {{ label }}
     <FontAwesomeIcon v-if="icon" :icon="icon" />
   </BcTooltip>

--- a/frontend/components/block/table/BlockTableStatus.vue
+++ b/frontend/components/block/table/BlockTableStatus.vue
@@ -13,13 +13,16 @@ const { t: $t } = useI18n()
 
 const { latestState } = useLatestStateStore()
 
+// we don't want to be reactive to the current_slot
+const currentSlot = latestState.value?.current_slot || 0
+
 const mapped = computed(() => {
   if (!props.status) {
     return
   }
   const size: TagSize = props.mobile ? 'circle' : 'default'
   let color: TagColor
-  const status = props.status === 'scheduled' && (props.blockSlot && (props.blockSlot < (latestState.value?.current_slot ?? 0))) ? 'probably_missed' : props.status
+  const status = props.status === 'scheduled' && (props.blockSlot && (props.blockSlot < currentSlot)) ? 'probably_missed' : props.status
   const tStatus = $t(`block.status.${status}`)
   const label = props.mobile ? tStatus.substring(0, 1) : tStatus
   const tooltip = status === 'probably_missed' ? $t('block.status_might_change_on_reorg') : props.mobile ? tStatus : undefined

--- a/frontend/components/block/table/BlockTableStatus.vue
+++ b/frontend/components/block/table/BlockTableStatus.vue
@@ -4,11 +4,14 @@ import type { TagSize, TagColor } from '~/types/tag'
 
 interface Props {
   status?: BlockStatus,
+  blockSlot?: number,
   mobile?: boolean
 }
 const props = defineProps<Props>()
 
 const { t: $t } = useI18n()
+
+const { latestState } = useLatestStateStore()
 
 const mapped = computed(() => {
   if (!props.status) {
@@ -16,10 +19,14 @@ const mapped = computed(() => {
   }
   const size: TagSize = props.mobile ? 'circle' : 'default'
   let color: TagColor
-  const tStatus = $t(`block.status.${props.status}`)
+  const status = props.status === 'scheduled' && (props.blockSlot && (props.blockSlot < (latestState.value?.current_slot ?? 0))) ? 'probably_missed' : props.status
+  const tStatus = $t(`block.status.${status}`)
   const label = props.mobile ? tStatus.substring(0, 1) : tStatus
-  const tooltip = props.mobile ? tStatus : undefined
-  switch (props.status) {
+  const tooltip = status === 'probably_missed' ? $t('block.status_might_change_on_reorg') : props.mobile ? tStatus : undefined
+  switch (status) {
+    case 'probably_missed':
+      color = 'partial'
+      break
     case 'missed':
       color = 'failed'
       break
@@ -35,6 +42,7 @@ const mapped = computed(() => {
   }
 
   return {
+    status,
     size,
     color,
     label,

--- a/frontend/components/dashboard/table/DashboardTableBlocks.vue
+++ b/frontend/components/dashboard/table/DashboardTableBlocks.vue
@@ -166,7 +166,7 @@ const isRowExpandable = (row: VDBBlocksTableRow) => {
               :body-class="colsVisible.mobileStatus ? 'status-mobile' : ''"
             >
               <template #body="slotProps">
-                <BlockTableStatus :status="slotProps.data.status" :mobile="colsVisible.mobileStatus" />
+                <BlockTableStatus class="block-status" :block-slot="slotProps.data.slot" :status="slotProps.data.status" :mobile="colsVisible.mobileStatus" />
               </template>
             </Column>
             <Column
@@ -228,7 +228,7 @@ const isRowExpandable = (row: VDBBlocksTableRow) => {
                     {{ $t('dashboard.validator.col.status') }}:
                   </div>
                   <div class="value">
-                    <BlockTableStatus :status="slotProps.data.status" :mobile="false" />
+                    <BlockTableStatus :block-slot="slotProps.data.slot" :status="slotProps.data.status" :mobile="false" />
                   </div>
                 </div>
                 <div v-if="!colsVisible.slot" class="row">
@@ -314,7 +314,7 @@ const isRowExpandable = (row: VDBBlocksTableRow) => {
   .future-row {
     td {
 
-      >div,
+      >div:not(.block-status),
       >span {
         opacity: 0.5;
       }

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -195,8 +195,10 @@
       "missed": "Missed",
       "orphaned": "Orphaned",
       "scheduled": "Scheduled",
-      "success": "Proposed"
+      "success": "Proposed",
+      "probably_missed": "Missed *"
     },
+    "status_might_change_on_reorg": "This block's status may change if a chain reorganistion occurs",
     "col": {
       "proposer": "Proposer",
       "graffiti": "Graffiti",

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -198,7 +198,7 @@
       "success": "Proposed",
       "probably_missed": "Missed *"
     },
-    "status_might_change_on_reorg": "This block's status may change if a chain reorganistion occurs",
+    "status_might_change_on_reorg": "This block's status may change if a chain reorganization occurs.",
     "col": {
       "proposer": "Proposer",
       "graffiti": "Graffiti",


### PR DESCRIPTION
This PR:
- marks scheduled blocks that are before the current slot from the latest state as (probably) missed* 

![image](https://github.com/gobitfly/beaconchain/assets/125363940/8699e4c8-953f-40da-bc51-c9c7357acc68)

