### PR TITLE
Improve premium box logic for unknown products

### DIFF
--- a/frontend/components/pricing/PremiumProductBox.vue
+++ b/frontend/components/pricing/PremiumProductBox.vue
@@ -81,18 +81,15 @@ const planButton = computed(() => {
 
   if (isLoggedIn.value) {
     if (premiumSubscription.value) {
-      if (premiumSubscription.value.product_id === props.product.product_id_monthly || premiumSubscription.value.product_id === props.product.product_id_yearly) {
+      const subscribedProduct = products.value?.premium_products.find(product => product.product_id_monthly === premiumSubscription.value!.product_id || product.product_id_yearly === premiumSubscription.value!.product_id)
+      if ((premiumSubscription.value.product_id === props.product.product_id_monthly || premiumSubscription.value.product_id === props.product.product_id_yearly) || subscribedProduct === undefined) {
+        // (this box is either for the subscribed product) || (the user has an unknown product, possible from V1 or maybe a custom plan)
         text = $t('pricing.premium_product.button.manage_plan')
+      } else if (subscribedProduct.price_per_month_eur < props.product.price_per_month_eur) {
+        text = $t('pricing.premium_product.button.upgrade')
       } else {
-        const subscribedProduct = products.value?.premium_products.find(product => product.product_id_monthly === premiumSubscription.value!.product_id || product.product_id_yearly === premiumSubscription.value!.product_id)
-        if (subscribedProduct !== undefined) {
-          if (subscribedProduct.price_per_month_eur < props.product.price_per_month_eur) {
-            text = $t('pricing.premium_product.button.upgrade')
-          } else {
-            isDowngrade = true
-            text = $t('pricing.premium_product.button.downgrade')
-          }
-        }
+        isDowngrade = true
+        text = $t('pricing.premium_product.button.downgrade')
       }
     }
   } else {


### PR DESCRIPTION
This PR
* Causes the premium box button to show "Manage Plan" if the user has an unknown premium product subscribed

This may happen when a user has an old V1 subscription or maybe has a custom plan.

:warning: This PR should not change anything else :warning: