### PR TITLE
don't default to shared dashboard

### DIFF
--- a/frontend/composables/useDashboardKeyProvider.ts
+++ b/frontend/composables/useDashboardKeyProvider.ts
@@ -33,7 +33,7 @@ export function useDashboardKeyProvider (type: DashboardType = 'validator', mock
         return
       }
       // only use the dashboard cookie key as default if you are not logged in and it's not private
-      if (!isLoggedIn.value && isPublicKey(dashboardKeyCookie.value)) {
+      if (!isLoggedIn.value && isPublicKey(dashboardKeyCookie.value) && !isSharedKey(dashboardKeyCookie.value)) {
         setDashboardKey(`${dashboardKeyCookie.value}`)
       }
       return


### PR DESCRIPTION
This PR:
- prevents from defaulting to the shared dashboard if you navigate to /dashboard