### PR TITLE
(NOBIDS) hand-cursor over dashboard menus + larger filter-input in tables

### DIFF
--- a/frontend/assets/css/prime_menubar.scss
+++ b/frontend/assets/css/prime_menubar.scss
@@ -45,6 +45,7 @@
     background: var(--background-color);
     border: 1px solid var(--container-border-color);
     border-radius: var(--border-radius);
+    cursor: default;
 
     .p-menuitem {
       border-radius: var(--border-radius);
@@ -52,6 +53,7 @@
       white-space: nowrap;
       text-overflow: ellipsis;
       max-width: 200px;
+      cursor: pointer;
 
       &:not(:has(.p-active)):not(:has(.router-link-active)) {
         color: var(--text-color);

--- a/frontend/assets/css/prime_menubar.scss
+++ b/frontend/assets/css/prime_menubar.scss
@@ -6,8 +6,7 @@
   color: var(--text-color);
   user-select: none;
 
-  .p-menubar-root-list
-  {
+  .p-menubar-root-list {
     flex-wrap: nowrap;
     gap: var(--padding);
 
@@ -16,6 +15,7 @@
       border: 1px solid var(--container-border-color);
       border-radius: var(--border-radius);
       height: 30px;
+      cursor: pointer;
       &:has(.router-link-active),
       &:has(.p-active) {
         color: var(--primary-color);

--- a/frontend/components/bc/ContentFilter.vue
+++ b/frontend/components/bc/ContentFilter.vue
@@ -51,7 +51,7 @@ const filter = ref<string>('')
         padding 0.2s ease-in-out;
 
       &.visible {
-        width: 188px;
+        width: 230px;
         opacity: 100%;
         padding: 4px;
 

--- a/frontend/components/bc/table/BcTableControl.vue
+++ b/frontend/components/bc/table/BcTableControl.vue
@@ -21,8 +21,8 @@ const tableIsShown = ref(true)
 const onInput = (value: string) => {
   emit('setSearch', value)
 }
-
 </script>
+
 <template>
   <slot name="bc-table-header">
     <div class="bc-table-header">

--- a/frontend/components/dashboard/DashboardHeader.vue
+++ b/frontend/components/dashboard/DashboardHeader.vue
@@ -138,7 +138,6 @@ const editDashboard = () => {
     }
   })
 }
-
 </script>
 
 <template>


### PR DESCRIPTION
This PR:

Shows a hand cursor anywhere over the buttons + in the drop-down of the MenuBar:
![image](https://github.com/gobitfly/beaconchain/assets/150015231/6f122a26-43bf-4dc1-a06b-38369c32da59)

Enlarges by +22% the input field of the filter at the top of tables, so that its placeholders are never truncated like that:
![filter](https://github.com/gobitfly/beaconchain/assets/150015231/ee3bbe6a-e78b-49e7-9023-d510b8682ff7)
