### PR TITLE
ensure disabled chart toggle uses the correct style

### DIFF
--- a/frontend/components/bc/BcIconToggle.vue
+++ b/frontend/components/bc/BcIconToggle.vue
@@ -28,12 +28,12 @@ const toggle = () => {
   <div class="bc-toggle" :class="{ selected }" :disabled="disabled || null" @click="toggle">
     <div class="icon true-icon">
       <slot name="trueIcon">
-        <FontAwesomeIcon v-if="props.trueIcon" :icon="props.trueIcon" />
+        <FontAwesomeIcon v-if="trueIcon" :icon="trueIcon" />
       </slot>
     </div>
     <div class="icon false-icon">
       <slot name="falseIcon">
-        <FontAwesomeIcon v-if="props.falseIcon" :icon="props.falseIcon" />
+        <FontAwesomeIcon v-if="falseIcon" :icon="falseIcon" />
       </slot>
     </div>
     <span class="slider" />
@@ -48,7 +48,7 @@ const toggle = () => {
   height: 23px;
   cursor: pointer;
 
-  &[disabled='true']{
+  &[disabled]{
     cursor: unset;
     pointer-events: none;
     opacity: 0.5;


### PR DESCRIPTION
This PR:
- fixes the disabled toggle style on initial page load 


info for tester:
The chart toggle did not correctly apply the disabled style on intial page load ... it only worked after switiching between tabs
![image](https://github.com/gobitfly/beaconchain/assets/125363940/98a43984-d065-4e87-b4ad-5ae91a9ed1f5)
