### PR TITLE
Improve text logic on shared dashboard view modal

### DIFF
--- a/frontend/components/dashboard/SharedDashboardModal.vue
+++ b/frontend/components/dashboard/SharedDashboardModal.vue
@@ -3,10 +3,21 @@ import { COOKIE_KEY, type CookiesPreference } from '~/types/cookie'
 
 const cookiePreference = useCookie<CookiesPreference>(COOKIE_KEY.COOKIES_PREFERENCE, { default: () => undefined })
 const { isShared } = useDashboardKey()
+const { dashboards } = useUserDashboardStore()
 const { t: $t } = useI18n()
 const route = useRoute()
 
 const visible = computed(() => isShared.value && cookiePreference.value !== undefined)
+
+const text = computed(() => {
+  const userHasOwnDashboard = ((dashboards.value?.validator_dashboards?.length || 0) + (dashboards.value?.account_dashboards?.length || 0)) > 0
+  const textRoot = userHasOwnDashboard ? 'dashboard.shared_modal_with_own' : 'dashboard.shared_modal_without_own'
+
+  const caption = $t(textRoot + '.text')
+  const button = $t(textRoot + '.button')
+
+  return { caption, button }
+})
 </script>
 
 <template>
@@ -18,10 +29,10 @@ const visible = computed(() => isShared.value && cookiePreference.value !== unde
     position="bottom"
   >
     <div class="dialog-container">
-      {{ $t('dashboard.shared_modal.text') }}
+      {{ text.caption }}
       <BcLink :to="`/dashboard`" :replace="route.path.startsWith('/dashboard')">
         <Button class="get-started">
-          {{ $t('dashboard.shared_modal.get_started') }}
+          {{ text.button }}
         </Button>
       </BcLink>
     </div>

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -282,9 +282,13 @@
         }
       }
     },
-    "shared_modal": {
+    "shared_modal_with_own": {
+      "text": "Access your personalized dashboard",
+      "button": "Go to Dashboard"
+    },
+    "shared_modal_without_own": {
       "text": "Create your own dashboard to get the most out of beaconcha.in",
-      "get_started": "Get started"
+      "button": "Get started"
     },
     "group": {
       "selection": {


### PR DESCRIPTION
This PR
* Causes the "Shared Dashboard View"-modal to have a different text whenever the user already has at least 1 local/private dashboard