### PR TITLE
Fix button styling

### DIFF
--- a/frontend/components/dashboard/SharedDashboardModal.vue
+++ b/frontend/components/dashboard/SharedDashboardModal.vue
@@ -31,7 +31,7 @@ const text = computed(() => {
     <div class="dialog-container">
       {{ text.caption }}
       <BcLink :to="`/dashboard`" :replace="route.path.startsWith('/dashboard')">
-        <Button class="get-started">
+        <Button class="button">
           {{ text.button }}
         </Button>
       </BcLink>
@@ -47,8 +47,9 @@ const text = computed(() => {
   align-items: center;
   gap: var(--padding-large);
 
-  .get-started {
-    min-width: 120px;
+  .button {
+    min-width: fit-content;
+    white-space: nowrap;
   }
 }
 </style>


### PR DESCRIPTION
This PR
* Fixes the button styling on the "Shared Dashboard View" modal (required for mobile when the "Go to Dashboard" text is shown on the button)