### PR TITLE
several small fixes

### DIFF
--- a/frontend/components/bc/footer/LinkList.vue
+++ b/frontend/components/bc/footer/LinkList.vue
@@ -21,7 +21,7 @@ const columns: Row[] = [
   {
     title: $t('footer.legal_notices'),
     links: [
-      [$t('footer.imprint'), faBuilding, '/imprint', Target.Internal],
+      [$t('footer.imprint'), faBuilding, 'https://beaconcha.in/imprint', Target.Internal],
       [$t('footer.terms'), faFileContract, 'https://storage.googleapis.com/legal.beaconcha.in/tos.pdf', Target.External],
       [$t('footer.privacy'), faUserSecret, 'https://storage.googleapis.com/legal.beaconcha.in/privacy.pdf', Target.External]
     ]

--- a/frontend/components/bc/footer/LinkList.vue
+++ b/frontend/components/bc/footer/LinkList.vue
@@ -21,7 +21,7 @@ const columns: Row[] = [
   {
     title: $t('footer.legal_notices'),
     links: [
-      [$t('footer.imprint'), faBuilding, 'https://beaconcha.in/imprint', Target.Internal],
+      [$t('footer.imprint'), faBuilding, 'https://beaconcha.in/imprint', Target.External],
       [$t('footer.terms'), faFileContract, 'https://storage.googleapis.com/legal.beaconcha.in/tos.pdf', Target.External],
       [$t('footer.privacy'), faUserSecret, 'https://storage.googleapis.com/legal.beaconcha.in/privacy.pdf', Target.External]
     ]

--- a/frontend/components/bc/footer/LinkList.vue
+++ b/frontend/components/bc/footer/LinkList.vue
@@ -6,7 +6,6 @@ import {
   faBuilding,
   faFileContract,
   faUserSecret,
-  faLaptopCode,
   faFileInvoiceDollar,
   faUserAstronaut,
   faAd,
@@ -30,8 +29,7 @@ const columns: Row[] = [
   {
     title: $t('footer.resources'),
     links: [
-      [$t('footer.api_docs'), faLaptopCode, '/api/v2/docs/index.html', Target.Internal],
-      [$t('footer.api_pricing'), faFileInvoiceDollar, '/pricing', Target.Internal], // TODO: Requires pricing page to set the toggle at the top to "API Pricing"
+      [$t('footer.api_pricing'), faFileInvoiceDollar, '/pricing', Target.Internal],
       [$t('footer.premium'), faUserAstronaut, '/pricing', Target.Internal],
       [$t('footer.advertise'), faAd, '/advertisewithus', Target.Internal],
       [$t('footer.shop'), faShoppingCart, 'https://shop.beaconcha.in', Target.External],

--- a/frontend/components/dashboard/DashboardHeader.vue
+++ b/frontend/components/dashboard/DashboardHeader.vue
@@ -227,8 +227,11 @@ const editDashboard = () => {
 
     :deep(.p-menubar-root-list > .p-menuitem) {
       width: 145px;
+    }
+    :deep(.p-menubar-root-list .p-menuitem) {
 
-      &:has(.text-disabled) {
+      &:has(>.p-menuitem-content .text-disabled) {
+          cursor: default;
         > .p-menuitem-content{
           opacity: 0.5;
         }

--- a/frontend/components/dashboard/table/DashboardTableBlocks.vue
+++ b/frontend/components/dashboard/table/DashboardTableBlocks.vue
@@ -163,7 +163,7 @@ const isRowExpandable = (row: VDBBlocksTableRow) => {
               field="status"
               :sortable="!colsVisible.mobileStatus"
               :header="$t('dashboard.validator.col.status')"
-              :body-class="colsVisible.mobileStatus ? 'status-mobile' : ''"
+              :body-class="colsVisible.mobileStatus ? 'status-mobile status' : 'status'"
             >
               <template #body="slotProps">
                 <BlockTableStatus class="block-status" :block-slot="slotProps.data.slot" :status="slotProps.data.status" :mobile="colsVisible.mobileStatus" />
@@ -309,6 +309,12 @@ const isRowExpandable = (row: VDBBlocksTableRow) => {
     .p-column-title {
       @include utils.truncate-text;
     }
+  }
+  .reward {
+    padding: 4px 7px !important;
+  }
+  .status {
+    padding: 13px 7px !important;
   }
 
   .future-row {


### PR DESCRIPTION
This PR:
- routes the footer imprint to https://beaconcha.in/imprint
- removes the footer link to the API Docs
- fixes some paddings in the blocks table so that the rows have the same height as in the other tables
- fixes the transparent menu button (when a disabled button is a child of the main button on mobile) 
![image](https://github.com/gobitfly/beaconchain/assets/125363940/823b88f7-180e-4029-bf6a-7e55372b0668)
 