### PR TITLE
Implement PremiumViaAppBanner

### DIFF
--- a/frontend/components/pricing/PremiumProductBox.vue
+++ b/frontend/components/pricing/PremiumProductBox.vue
@@ -56,7 +56,7 @@ const percentages = computed(() => {
 })
 
 async function buttonCallback () {
-  if (isStripeDisabled.value) {
+  if (planButton.value.disabled) {
     return
   }
 

--- a/frontend/components/pricing/PremiumProductBox.vue
+++ b/frontend/components/pricing/PremiumProductBox.vue
@@ -8,7 +8,7 @@ import type { Feature } from '~/types/pricing'
 /// ///////////////
 // import { formatTimeDuration } from '~/utils/format' TODO: See commented code below
 
-const { products, bestPremiumProduct, currentPremiumSubscription } = useProductsStore()
+const { products, bestPremiumProduct, currentPremiumSubscription, isPremiumSubscribedViaApp } = useProductsStore()
 const { isLoggedIn } = useUserStore()
 const { t: $t } = useI18n()
 const { stripeCustomerPortal, stripePurchase, isStripeDisabled } = useStripe()
@@ -92,7 +92,9 @@ const planButton = computed(() => {
     text = $t('pricing.get_started')
   }
 
-  return { text, isDowngrade, disabled: isStripeDisabled.value || undefined }
+  const disabled = isStripeDisabled.value || isPremiumSubscribedViaApp.value || undefined
+
+  return { text, isDowngrade, disabled }
 })
 
 const mainFeatures = computed<Feature[]>(() => {

--- a/frontend/components/pricing/PremiumViaAppBanner.vue
+++ b/frontend/components/pricing/PremiumViaAppBanner.vue
@@ -1,17 +1,10 @@
 <script lang="ts" setup>
-import { ProductStoreAndroidPlaystore, ProductStoreIosAppstore } from '~/types/api/user'
-
 const { t: $t } = useI18n()
-const { currentPremiumSubscription } = useProductsStore()
-
-const visible = computed(() => {
-  const store = currentPremiumSubscription.value?.product_store
-  return (store === ProductStoreAndroidPlaystore || store === ProductStoreIosAppstore)
-})
+const { isPremiumSubscribedViaApp } = useProductsStore()
 </script>
 
 <template>
-  <div v-if="visible" class="banner">
+  <div v-if="isPremiumSubscribedViaApp" class="banner">
     {{ $t('pricing.premium_via_app_banner') }}
   </div>
 </template>

--- a/frontend/components/pricing/PremiumViaAppBanner.vue
+++ b/frontend/components/pricing/PremiumViaAppBanner.vue
@@ -1,0 +1,32 @@
+<script lang="ts" setup>
+import { ProductStoreAndroidPlaystore, ProductStoreIosAppstore } from '~/types/api/user'
+
+const { t: $t } = useI18n()
+const { currentPremiumSubscription } = useProductsStore()
+
+const visible = computed(() => {
+  const store = currentPremiumSubscription.value?.product_store
+  return (store === ProductStoreAndroidPlaystore || store === ProductStoreIosAppstore)
+})
+</script>
+
+<template>
+  <div v-if="visible" class="banner">
+    {{ $t('pricing.premium_via_app_banner') }}
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.banner {
+  width: 100%;
+  max-width: var(--pricing-content-width);
+  box-sizing: border-box;
+  border: 2px solid var(--primary-color);
+  border-radius: 7px;
+  color: var(--text-color);
+  background-color: var(--container-background);
+  padding: 10px 30px;
+
+  margin-bottom: 55px;
+}
+</style>

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -627,6 +627,7 @@
     "per_validator": "{amount} per validator",
     "pectra_tooltip": "After Pectra hardfork: {effectiveBalance} ETH maximum effective balance",
     "get_started": "Get started now",
+    "premium_via_app_banner": "You have an active premium subscription from the App Store / Play Store. You can manage your active subscriptions from there.",
     "premium_product": {
       "popular": "Popular!",
       "validator_dashboards": "{amount} Validator Dashboard | {amount} Validator Dashboards",

--- a/frontend/pages/pricing.vue
+++ b/frontend/pages/pricing.vue
@@ -31,6 +31,7 @@ const scrollToAddons = () => {
         <PricingTypeToggle />
         <PricingHeaderLine />
         <PricingPeriodToggle v-model="isYearly" />
+        <PricingPremiumViaAppBanner />
         <PricingPremiumProducts :is-yearly="isYearly" />
         <Button class="view-addons-button" @click="scrollToAddons()">
           {{ $t('pricing.view_addons') }}<FontAwesomeIcon :icon="faArrowDown" />

--- a/frontend/stores/useProductsStore.ts
+++ b/frontend/stores/useProductsStore.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import type { InternalGetProductSummaryResponse, ProductSummary } from '~/types/api/user'
 import { API_PATH } from '~/types/customFetch'
+import { ProductCategoryPremium } from '~/types/api/user'
 
 const productsStore = defineStore('products_store', () => {
   const data = ref <ProductSummary>()
@@ -11,11 +12,16 @@ const productsStore = defineStore('products_store', () => {
 export function useProductsStore () {
   const { fetch } = useCustomFetch()
   const { data } = storeToRefs(productsStore())
+  const { user } = useUserStore()
 
   const products = computed(() => data.value)
 
   const bestPremiumProduct = computed(() => {
     return data.value?.premium_products.reduce((max, product) => (product.price_per_year_eur > max.price_per_year_eur ? product : max), data.value.premium_products[0])
+  })
+
+  const currentPremiumSubscription = computed(() => {
+    return user.value?.subscriptions?.find(sub => sub.product_category === ProductCategoryPremium)
   })
 
   async function getProducts () {
@@ -29,5 +35,5 @@ export function useProductsStore () {
     return res
   }
 
-  return { products, getProducts, bestPremiumProduct }
+  return { products, getProducts, bestPremiumProduct, currentPremiumSubscription }
 }

--- a/frontend/stores/useProductsStore.ts
+++ b/frontend/stores/useProductsStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import type { InternalGetProductSummaryResponse, ProductSummary } from '~/types/api/user'
 import { API_PATH } from '~/types/customFetch'
-import { ProductCategoryPremium } from '~/types/api/user'
+import { ProductCategoryPremium, ProductStoreAndroidPlaystore, ProductStoreIosAppstore } from '~/types/api/user'
 
 const productsStore = defineStore('products_store', () => {
   const data = ref <ProductSummary>()
@@ -24,6 +24,11 @@ export function useProductsStore () {
     return user.value?.subscriptions?.find(sub => sub.product_category === ProductCategoryPremium)
   })
 
+  const isPremiumSubscribedViaApp = computed(() => {
+    const store = currentPremiumSubscription.value?.product_store
+    return (store === ProductStoreAndroidPlaystore || store === ProductStoreIosAppstore)
+  })
+
   async function getProducts () {
     if (data.value) {
       return data.value
@@ -35,5 +40,5 @@ export function useProductsStore () {
     return res
   }
 
-  return { products, getProducts, bestPremiumProduct, currentPremiumSubscription }
+  return { products, getProducts, bestPremiumProduct, currentPremiumSubscription, isPremiumSubscribedViaApp }
 }


### PR DESCRIPTION
This PR
* Implements the banner shown above the premium products on `/pricing` if the user subsribed to a premium product via app (iOS or Android)

For the reviewer:
The easiest way to show the banner is to change
https://github.com/gobitfly/beaconchain/blob/f9a1bcd4dd485bd33def1072496405062495fa8d/frontend/components/pricing/PremiumViaAppBanner.vue#L9
to
```ts
return (store === ProductStoreAndroidPlaystore || store === ProductStoreIosAppstore || true)
```