### PR TITLE
fix validator sorting in rewards table

### DIFF
--- a/frontend/components/dashboard/ValidatorSubsetModal.vue
+++ b/frontend/components/dashboard/ValidatorSubsetModal.vue
@@ -57,7 +57,7 @@ watch(props, async (p) => {
       }
 
       const res = await fetch<InternalGetValidatorDashboardValidatorIndicesResponse>(API_PATH.DASHBOARD_VALIDATOR_INDICES, { query: { period: p?.timeFrame, duty, group_id: p?.groupId } }, { dashboardKey: `${p?.dashboardKey}` })
-      validators.value = res.data.sort((a, b) => a - b)
+      validators.value = sortValidatorIds(res.data)
       shownValidators.value = validators.value
       isLoading.value = false
     }

--- a/frontend/components/dashboard/ValidatorSubsetModal.vue
+++ b/frontend/components/dashboard/ValidatorSubsetModal.vue
@@ -7,6 +7,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import type { DashboardValidatorContext } from '~/types/dashboard/summary'
 import type { TimeFrame } from '~/types/value'
 import type { DashboardKey } from '~/types/dashboard'
+import { sortValidatorIds } from '~/utils/dashboard/validator'
 import { API_PATH } from '~/types/customFetch'
 import { type InternalGetValidatorDashboardValidatorIndicesResponse } from '~/types/api/validator_dashboard'
 
@@ -32,7 +33,7 @@ const MAX_VALIDATORS = 1000
 
 watch(props, async (p) => {
   if (p) {
-    shownValidators.value = [...p.validators].sort((a, b) => a - b)
+    shownValidators.value = sortValidatorIds(p.validators)
     validators.value = p.validators
     setHeader(
       p?.groupName

--- a/frontend/components/dashboard/ValidatorSubsetModal.vue
+++ b/frontend/components/dashboard/ValidatorSubsetModal.vue
@@ -32,7 +32,7 @@ const MAX_VALIDATORS = 1000
 
 watch(props, async (p) => {
   if (p) {
-    shownValidators.value = p.validators?.sort((a, b) => a - b)
+    shownValidators.value = [...p.validators].sort((a, b) => a - b)
     validators.value = p.validators
     setHeader(
       p?.groupName

--- a/frontend/components/dashboard/table/DashboardTableValidators.vue
+++ b/frontend/components/dashboard/table/DashboardTableValidators.vue
@@ -40,7 +40,7 @@ const groupName = computed(() => {
   return getGroupLabel($t, props.groupId, groups.value)
 })
 
-const cappedValidators = computed(() => props.validators?.slice(0, 10) || [])
+const cappedValidators = computed(() => [...props.validators].sort((a, b) => a - b).slice(0, 10) || [])
 
 </script>
 <template>

--- a/frontend/components/dashboard/table/DashboardTableValidators.vue
+++ b/frontend/components/dashboard/table/DashboardTableValidators.vue
@@ -7,6 +7,7 @@ import type { DashboardValidatorContext } from '~/types/dashboard/summary'
 import { DashboardValidatorSubsetModal } from '#components'
 import type { TimeFrame } from '~/types/value'
 import { getGroupLabel } from '~/utils/dashboard/group'
+import { sortValidatorIds } from '~/utils/dashboard/validator'
 import type { DashboardKey } from '~/types/dashboard'
 
 interface Props {
@@ -40,7 +41,7 @@ const groupName = computed(() => {
   return getGroupLabel($t, props.groupId, groups.value)
 })
 
-const cappedValidators = computed(() => [...props.validators].sort((a, b) => a - b).slice(0, 10) || [])
+const cappedValidators = computed(() => sortValidatorIds(props.validators).slice(0, 10) || [])
 
 </script>
 <template>

--- a/frontend/components/dashboard/table/DashboardTableValidators.vue
+++ b/frontend/components/dashboard/table/DashboardTableValidators.vue
@@ -41,7 +41,7 @@ const groupName = computed(() => {
   return getGroupLabel($t, props.groupId, groups.value)
 })
 
-const cappedValidators = computed(() => sortValidatorIds(props.validators).slice(0, 10) || [])
+const cappedValidators = computed(() => sortValidatorIds(props.validators).slice(0, 10))
 
 </script>
 <template>

--- a/frontend/utils/dashboard/validator.ts
+++ b/frontend/utils/dashboard/validator.ts
@@ -10,3 +10,10 @@ export function totalDutyRewards (duties?: ValidatorHistoryDuties) {
     return convertSum(...values)
   }
 }
+
+export function sortValidatorIds (list?: number[]): number[] {
+  if (!list) {
+    return []
+  }
+  return [...list].sort((a, b) => a - b)
+}


### PR DESCRIPTION
This PR:
- prevents the ValidatorSubsetModal from modifying the Validator list in the Rewards Table
- sorts the table Validator ids in the Rewards Table