### PR TITLE
hide tooltip in a scrolling scroll container

### DIFF
--- a/frontend/components/bc/BcTooltip.vue
+++ b/frontend/components/bc/BcTooltip.vue
@@ -16,7 +16,7 @@ interface Props {
 const props = defineProps<Props>()
 const bcTooltipOwner = ref<HTMLElement | null>(null)
 const bcTooltip = ref<HTMLElement | null>(null)
-let scrollParent: HTMLElement | null = null
+let scrollParents: HTMLElement[] = []
 const tooltipAddedTimeout = ref<NodeJS.Timeout | null>(null)
 const { selected, doSelect } = useTooltipStore()
 const { width, height } = useWindowSize()
@@ -122,16 +122,11 @@ const checkScrollListener = (add: boolean) => {
 
 const addScrollParent = () => {
   removeScrollParent()
-  scrollParent = findScrollParent(bcTooltipOwner.value)
-  if (scrollParent) {
-    scrollParent.addEventListener('scroll', doHide)
-  }
+  scrollParents = findAllScrollParents(bcTooltipOwner.value)
+  scrollParents.forEach(elem => elem.addEventListener('scroll', doHide))
 }
 const removeScrollParent = () => {
-  if (scrollParent) {
-    scrollParent.removeEventListener('scroll', doHide)
-    scrollParent = null
-  }
+  scrollParents.forEach(elem => elem.removeEventListener('scroll', doHide))
 }
 
 watch(() => [props.title, props.text], () => {

--- a/frontend/components/bc/BcTooltip.vue
+++ b/frontend/components/bc/BcTooltip.vue
@@ -16,6 +16,7 @@ interface Props {
 const props = defineProps<Props>()
 const bcTooltipOwner = ref<HTMLElement | null>(null)
 const bcTooltip = ref<HTMLElement | null>(null)
+let scrollParent: HTMLElement | null = null
 const tooltipAddedTimeout = ref<NodeJS.Timeout | null>(null)
 const { selected, doSelect } = useTooltipStore()
 const { width, height } = useWindowSize()
@@ -93,8 +94,8 @@ const onHover = () => {
   }
 }
 
-const doHide = (event: Event) => {
-  if (event.target === bcTooltipOwner.value || isParent(bcTooltipOwner.value, event.target as HTMLElement)) {
+const doHide = (event?: Event) => {
+  if (event?.target === bcTooltipOwner.value || isParent(bcTooltipOwner.value, event?.target as HTMLElement)) {
     return
   }
   if (isSelected.value) {
@@ -119,6 +120,20 @@ const checkScrollListener = (add: boolean) => {
   }
 }
 
+const addScrollParent = () => {
+  removeScrollParent()
+  scrollParent = findScrollParent(bcTooltipOwner.value)
+  if (scrollParent) {
+    scrollParent.addEventListener('scroll', doHide)
+  }
+}
+const removeScrollParent = () => {
+  if (scrollParent) {
+    scrollParent.removeEventListener('scroll', doHide)
+    scrollParent = null
+  }
+}
+
 watch(() => [props.title, props.text], () => {
   if (isOpen.value) {
     requestAnimationFrame(() => {
@@ -127,16 +142,25 @@ watch(() => [props.title, props.text], () => {
   }
 })
 
+const onWIndowResize = () => {
+  doHide()
+  addScrollParent()
+}
+
 onMounted(() => {
   document.addEventListener('click', doHide)
   document.addEventListener('scroll', doHide)
+  window.addEventListener('resize', onWIndowResize)
   checkScrollListener(true)
+  addScrollParent()
 })
 
 onUnmounted(() => {
   document.removeEventListener('click', doHide)
   document.removeEventListener('scroll', doHide)
+  window.removeEventListener('resize', onWIndowResize)
   checkScrollListener(false)
+  removeScrollParent()
   if (isSelected.value) {
     doSelect(null)
   }

--- a/frontend/utils/html.ts
+++ b/frontend/utils/html.ts
@@ -14,6 +14,13 @@ export function isParent (parent:HTMLElement | null, child:HTMLElement | null): 
   return false
 }
 
+function isScrollable (element: HTMLElement): boolean {
+  if (element.offsetWidth < element.scrollWidth || element.offsetHeight < element.scrollHeight) {
+    return true
+  }
+  return false
+}
+
 export function isOrIsInIteractiveContainer (child:HTMLElement | null, stopSearchAtElement?: HTMLElement): boolean {
   if (!child || child === stopSearchAtElement) {
     return false
@@ -22,8 +29,18 @@ export function isOrIsInIteractiveContainer (child:HTMLElement | null, stopSearc
   if (child.nodeName === 'INPUT') {
     return true
   }
-  if (child.offsetWidth < child.scrollWidth || child.offsetHeight < child.scrollHeight) {
+  if (isScrollable(child)) {
     return true
   }
   return isOrIsInIteractiveContainer(child.parentElement, stopSearchAtElement)
+}
+
+export function findScrollParent (child:HTMLElement | null): HTMLElement | null {
+  if (!child) {
+    return null
+  }
+  if (isScrollable(child)) {
+    return child
+  }
+  return findScrollParent(child.parentElement)
 }

--- a/frontend/utils/html.ts
+++ b/frontend/utils/html.ts
@@ -35,12 +35,15 @@ export function isOrIsInIteractiveContainer (child:HTMLElement | null, stopSearc
   return isOrIsInIteractiveContainer(child.parentElement, stopSearchAtElement)
 }
 
-export function findScrollParent (child:HTMLElement | null): HTMLElement | null {
+export function findAllScrollParents (child:HTMLElement | null, list?: HTMLElement[]): HTMLElement[] {
+  if (!list) {
+    list = []
+  }
   if (!child) {
-    return null
+    return list
   }
   if (isScrollable(child)) {
-    return child
+    list.push(child)
   }
-  return findScrollParent(child.parentElement)
+  return findAllScrollParents(child.parentElement, list)
 }


### PR DESCRIPTION
This PR:
- hides the Tooltip if any of it's scrollable parents is scrolled
- it also hides the tooltip on window resize 


Add. Infos:
- I left the `scrollContainer` (class provided by the outside) functionality in (even dough the new logic should tackle most cased needed) 