### PR TITLE
convert nano average to time duration

### DIFF
--- a/frontend/components/dashboard/table/SummaryValue.vue
+++ b/frontend/components/dashboard/table/SummaryValue.vue
@@ -192,7 +192,7 @@ const data = computed(() => {
           <b>
             {{ $t('common.average') }}:
           </b>
-          {{ $t('common.every_day', {}, data.luck.proposal.average) }}
+          {{ $t('common.every_x', { duration: formatNanoSecondDuration(data.luck.proposal.average, $t)}) }}
         </div>
         <br>
         <div class="row next_chapter">
@@ -216,7 +216,7 @@ const data = computed(() => {
           <b>
             {{ $t('common.average') }}:
           </b>
-          {{ $t('common.every_day', {}, data.luck.sync.average) }}
+          {{ $t('common.every_x', { duration: formatNanoSecondDuration(data.luck.sync.average, $t)}) }}
         </div>
       </template>
     </BcTooltip>

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -13,6 +13,7 @@
     "expected": "Expected",
     "in_day": "In one day | In {count} days",
     "every_day": "Every day | Every {count} days",
+    "every_x":"Every {duration}",
     "id": "ID",
     "average": "Average",
     "index": "Index",

--- a/frontend/utils/format.ts
+++ b/frontend/utils/format.ts
@@ -195,6 +195,14 @@ export function formatTimeDuration (seconds: number | undefined, t: ComposerTran
   return t(translationId, { amount }, amount === 1 ? 1 : 2)
 }
 
+export function formatNanoSecondDuration (nano:number | undefined, t: ComposerTranslation):string | undefined {
+  if (nano === undefined) {
+    return undefined
+  }
+  const seconds = Math.floor(nano / 1000000000)
+  return formatTimeDuration(seconds, t)
+}
+
 export function formatFiat (value:number, currency: string, locales: string, minimumFractionDigits?: number, maximumFractionDigits?: number) {
   const formatter = new Intl.NumberFormat(locales, {
     style: 'currency',


### PR DESCRIPTION
This PR
- correctly converts the luck average from nano seconds to a time duration