### PR TITLE
(BIDS-3129) in the header: new layout on mobile screens

### DIFF
--- a/frontend/components/bc/header/MainHeader.vue
+++ b/frontend/components/bc/header/MainHeader.vue
@@ -308,8 +308,11 @@ $smallHeaderThreshold: 1024px;
           position: relative;
           margin-top: auto;
           line-height: 22px;
+          @media (max-width: $mobileHeaderThreshold) {
+            display: none;
+          }
         }
-        @media (max-width: 1359px) {
+        @media (max-width: 1360px) {
           font-size: var(--logo_small_font_size);
           letter-spacing: var(--logo_small_letter_spacing);
           gap: 6px;
@@ -318,16 +321,26 @@ $smallHeaderThreshold: 1024px;
           }
           svg {
             height: 18px;
+            @media (max-width: $mobileHeaderThreshold) {
+              height: 30px;
+            }
           }
         }
       }
 
       .variant {
         position: relative;
-        margin-top: auto;
-        line-height: 10px;
         font-size: var(--tiny_text_font_size);
+        line-height: 10px;
+        margin-top: auto;
+        @media (max-width: $mobileHeaderThreshold) {
+          margin-bottom: auto;
+          font-size: var(--button_font_size);
+        }
         color: var(--megamenu-text-color);
+        @media (max-width: $smallHeaderThreshold) {
+          color: var(--grey);
+        }
       }
     }
 

--- a/frontend/components/bc/header/MainHeader.vue
+++ b/frontend/components/bc/header/MainHeader.vue
@@ -330,17 +330,18 @@ $smallHeaderThreshold: 1024px;
 
       .variant {
         position: relative;
-        font-size: var(--tiny_text_font_size);
-        line-height: 10px;
         margin-top: auto;
+        font-size: var(--tiny_text_font_size);
         @media (max-width: $mobileHeaderThreshold) {
           margin-bottom: auto;
           font-size: var(--button_font_size);
         }
         color: var(--megamenu-text-color);
-        @media (max-width: $smallHeaderThreshold) {
+        @media (max-width: $smallHeaderThreshold) { // when it is in the upper header...
+          // ... the background is always dark blue (no matter the theme (dark/light)), so we need a light grey:
           color: var(--grey);
         }
+        line-height: 10px;
       }
     }
 


### PR DESCRIPTION
This PR changes the left side of the header **on mobile** :

![Screenshot from 2024-06-13 11-52-47](https://github.com/gobitfly/beaconchain/assets/150015231/d4c9c7c1-4fec-4c05-b78b-1200d0f22ebe)

- the brand name disappears,
- the logo becomes as high as the Signup button (30px),
- `v2 beta | {{ currentNetwork }}` is vertically centered and its font size becomes 14px.