### PR TITLE
Hide timeframe related values on /pricing

### DIFF
--- a/frontend/components/pricing/PremiumCompare.vue
+++ b/frontend/components/pricing/PremiumCompare.vue
@@ -31,7 +31,7 @@ const showContent = ref(false)
 const rows = computed(() => {
   const sorted = products.value?.premium_products?.sort((a, b) => a.price_per_month_eur - b.price_per_month_eur) ?? []
   const rows: CompareRow[] = []
-  const mapValue = (property: string, perks: PremiumPerks) => {
+  const mapValue = (property: string, perks: PremiumPerks):CompareValue => {
     if (['support_us', 'bulk_adding'].includes(property)) {
       return { value: perks.ad_free }
     }
@@ -49,8 +49,7 @@ const rows = computed(() => {
 
     return {
       value,
-      tooltip,
-      class: undefined as string | undefined
+      tooltip
     }
   }
   const addRow = (type: RowType, property?: string, className?: string, comingSoon = false, hidePositiveValues = false) => {

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -42,6 +42,7 @@
     "true": "True",
     "false": "False",
     "coming_soon": "Coming soon",
+    "soon": "Soon",
     "and_more": "and {count} more"
   },
   "seo": {


### PR DESCRIPTION
This PR
* Hides all values, where we don't know what we can support yet, by writing "Soon" in italic instead