### PR TITLE
(NOBIDS) small improvements

### DIFF
--- a/frontend/components/bc/BcTooltip.vue
+++ b/frontend/components/bc/BcTooltip.vue
@@ -98,6 +98,7 @@ const doHide = (event?: Event) => {
   if (event?.target === bcTooltipOwner.value || isParent(bcTooltipOwner.value, event?.target as HTMLElement)) {
     return
   }
+  removeParentListeners()
   if (isSelected.value) {
     doSelect(null)
   }
@@ -137,25 +138,30 @@ watch(() => [props.title, props.text], () => {
   }
 })
 
-const onWIndowResize = () => {
+const onWindowResize = () => {
   doHide()
-  addScrollParent()
 }
 
-onMounted(() => {
-  document.addEventListener('click', doHide)
-  document.addEventListener('scroll', doHide)
-  window.addEventListener('resize', onWIndowResize)
-  checkScrollListener(true)
-  addScrollParent()
+watch(isOpen, (value) => {
+  if (value) {
+    document.addEventListener('click', doHide)
+    document.addEventListener('scroll', doHide)
+    window.addEventListener('resize', onWindowResize)
+    checkScrollListener(true)
+    addScrollParent()
+  }
 })
 
-onUnmounted(() => {
+function removeParentListeners () {
   document.removeEventListener('click', doHide)
   document.removeEventListener('scroll', doHide)
-  window.removeEventListener('resize', onWIndowResize)
+  window.removeEventListener('resize', onWindowResize)
   checkScrollListener(false)
   removeScrollParent()
+}
+
+onUnmounted(() => {
+  removeParentListeners()
   if (isSelected.value) {
     doSelect(null)
   }

--- a/frontend/components/dashboard/ValidatorSlotViz.vue
+++ b/frontend/components/dashboard/ValidatorSlotViz.vue
@@ -15,8 +15,8 @@ watch(() => [dashboardKey.value, tick.value], (newValue, oldValue) => {
   }
   refreshSlotViz(dashboardKey.value)
 }, { immediate: true })
-
 </script>
+
 <template>
   <SlotVizViewer v-if="slotViz" :data="slotViz" :timestamp="tick" />
 </template>

--- a/frontend/stores/useLatestStateStore.ts
+++ b/frontend/stores/useLatestStateStore.ts
@@ -13,9 +13,17 @@ export function useLatestStateStore () {
 
   const latestState = computed(() => data.value)
 
-  async function refreshLatestState () {
-    const res = await fetch<InternalGetLatestStateResponse>(API_PATH.LATEST_STATE)
-    data.value = res.data
+  async function refreshLatestState () : Promise<LatestStateData|undefined> {
+    try {
+      const res = await fetch<InternalGetLatestStateResponse>(API_PATH.LATEST_STATE)
+      if (!res.data) {
+        return undefined
+      }
+      data.value = res.data
+      return data.value
+    } catch {
+      return undefined
+    }
   }
 
   return { latestState, refreshLatestState }

--- a/frontend/stores/useUserStore.ts
+++ b/frontend/stores/useUserStore.ts
@@ -27,12 +27,17 @@ export function useUserStore () {
     data.value = user
   }
 
-  const getUser = async () => {
+  async function getUser () : Promise<UserInfo|undefined> {
     try {
       const res = await fetch<InternalGetUserInfoResponse>(API_PATH.USER, undefined, undefined, undefined, true)
+      if (!res.data) {
+        return undefined
+      }
       setUser(res.data)
-    } catch (e) {
+      return res.data
+    } catch {
       setUser(undefined)
+      return undefined
     }
   }
 


### PR DESCRIPTION
Now:

- _BcTooltip.vue_ activates the listeners only when the tooltip is shown and turns them off when the tooltip is hidden.
This makes the UI to run less listeners than before (dozens on some pages).

- `refreshLatestState()` and `getUser()` return the data that they load in case of success or `undefined` in case of problem.
This allows `useAsyncData()` to call the API less often.