### PR TITLE
(NOBIDS) small fix in the logic of getUser()

### DIFF
--- a/frontend/components/bc/header/MainHeader.vue
+++ b/frontend/components/bc/header/MainHeader.vue
@@ -150,7 +150,9 @@ $smallHeaderThreshold: 1024px;
   justify-content: center;
   border-bottom: 1px solid var(--container-border-color);
   &.hide-because-it-is-unfinished {
-    border-bottom: none;
+    @media (max-width: $smallHeaderThreshold) {
+      border-bottom: none;
+    }
   }
   background-color: var(--container-background);
   .top-background {

--- a/frontend/stores/useUserStore.ts
+++ b/frontend/stores/useUserStore.ts
@@ -30,9 +30,6 @@ export function useUserStore () {
   async function getUser () : Promise<UserInfo|undefined> {
     try {
       const res = await fetch<InternalGetUserInfoResponse>(API_PATH.USER, undefined, undefined, undefined, true)
-      if (!res.data) {
-        return undefined
-      }
       setUser(res.data)
       return res.data
     } catch {


### PR DESCRIPTION
If undefined data was received from the API, `getUser()` would return `undefined` to inform `useAsyncData` that it must recall the API from the client.
The user was not set to `undefined` in the meantime. This was a mistake.

Also:
The bottom border of the header should be visible when `NUXT_PUBLIC_SHOW_IN_DEVELOPMENT` is `"false"` and the screen is large.
It was not the case. Fixed.