### PR TITLE
Remove "per dashboard" on guppy

### DIFF
--- a/frontend/components/pricing/PremiumProductBox.vue
+++ b/frontend/components/pricing/PremiumProductBox.vue
@@ -98,6 +98,7 @@ const planButton = computed(() => {
 })
 
 const mainFeatures = computed<Feature[]>(() => {
+  const validatorPerDashboardAmount = formatNumber(props.product?.premium_perks.validators_per_dashboard)
   return [
     {
       name: $t('pricing.premium_product.validator_dashboards', { amount: formatNumber(props.product?.premium_perks.validator_dashboards) }, (props.product?.premium_perks.validator_dashboards || 0) <= 1 ? 1 : 2),
@@ -105,7 +106,9 @@ const mainFeatures = computed<Feature[]>(() => {
       percentage: percentages.value.validatorDashboards
     },
     {
-      name: $t('pricing.premium_product.validators_per_dashboard', { amount: formatNumber(props.product?.premium_perks.validators_per_dashboard) }),
+      name: props.product.premium_perks.validator_dashboards === 1
+        ? $t('pricing.premium_product.validators', { amount: validatorPerDashboardAmount })
+        : $t('pricing.premium_product.validators_per_dashboard', { amount: validatorPerDashboardAmount }),
       subtext: $t('pricing.per_validator', { amount: prices.value.perValidator }),
       available: true,
       tooltip: $t('pricing.pectra_tooltip', { effectiveBalance: formatNumber(props.product?.premium_perks.validators_per_dashboard * 32) }),

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -633,6 +633,7 @@
     "premium_product": {
       "popular": "Popular!",
       "validator_dashboards": "{amount} Validator Dashboard | {amount} Validator Dashboards",
+      "validators": "{amount} Validators",
       "validators_per_dashboard": "{amount} Validators per Dashboard",
       "timeframe_dashboard_chart": "{timeframe} dashboard chart history",
       "timeframe_heatmap_chart": "{timeframe} heatmap chart history",


### PR DESCRIPTION
This PR
* Removes the "per dashboard" text for the validator amount on the `Guppy` card (as `Guppy` only has a single validator dashboard)