### PR TITLE
show hide icon

### DIFF
--- a/frontend/components/bc/BcTooltip.vue
+++ b/frontend/components/bc/BcTooltip.vue
@@ -11,6 +11,8 @@ interface Props {
   fitContent?: boolean,
   renderTextAsHtml?: boolean,
   scrollContainer?: string // query selector for scrollable parent container
+  dontOpenPermanently?: boolean
+  hoverDelay?: number
 }
 
 const props = defineProps<Props>()
@@ -82,15 +84,23 @@ const handleClick = () => {
   if (isSelected.value) {
     doSelect(null)
   } else if (canBeOpened.value) {
-    doSelect(bcTooltipOwner.value)
+    if (props.dontOpenPermanently) {
+      instantHover(true)
+    } else {
+      doSelect(bcTooltipOwner.value)
+    }
     setPosition()
   }
 }
 
 const onHover = () => {
   if (canBeOpened.value && !selected.value) {
-    instantHover(true)
-    setPosition()
+    if (props.hoverDelay) {
+      bounceHover(true, false, false, props.hoverDelay)
+    } else {
+      instantHover(true)
+      setPosition()
+    }
   }
 }
 
@@ -144,6 +154,7 @@ const onWindowResize = () => {
 
 watch(isOpen, (value) => {
   if (value) {
+    setPosition()
     document.addEventListener('click', doHide)
     document.addEventListener('scroll', doHide)
     window.addEventListener('resize', onWindowResize)

--- a/frontend/components/bc/toggle/MultiBar.vue
+++ b/frontend/components/bc/toggle/MultiBar.vue
@@ -1,13 +1,9 @@
 <script setup lang="ts">
-import type { IconDefinition } from '@fortawesome/fontawesome-svg-core'
-import type { Component } from 'vue'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { type MultiBarItem } from '~/types/multiBar'
 
 interface Props {
-  icons: {
-    icon?: IconDefinition
-    component?: Component,
-    value: string
-  }[]
+  icons: MultiBarItem[]
 }
 
 const props = defineProps<Props>()
@@ -34,10 +30,18 @@ watch(modelValues, () => {
 
 <template>
   <div class="bc-togglebar">
-    <BcToggleMultiBarButton v-for="icon in props.icons" :key="icon.value" v-model="modelValues[icon.value]" :icon="icon.icon">
+    <BcToggleMultiBarButton
+      v-for="icon in props.icons"
+      :key="icon.value"
+      v-model="modelValues[icon.value]"
+      :class="icon.className"
+      :icon="icon.icon"
+      :tooltip="icon.tooltip"
+    >
       <template #icon>
         <slot :name="icon.value">
-          <component :is="icon.component" />
+          <component :is="icon.component" v-if="icon.component" />
+          <FontAwesomeIcon v-else-if="icon.icon" :icon="icon.icon" />
         </slot>
       </template>
     </BcToggleMultiBarButton>

--- a/frontend/components/bc/toggle/MultiBarButton.vue
+++ b/frontend/components/bc/toggle/MultiBarButton.vue
@@ -19,7 +19,7 @@ const icon = computed(() => {
 </script>
 
 <template>
-  <BcTooltip :dont-open-permanently="true">
+  <BcTooltip :dont-open-permanently="true" :hover-delay="350">
     <template #tooltip>
       <div class="button-tooltip">
         <div>{{ selected ? $t('filter.enabled'): $t('filter.disabled') }}</div>

--- a/frontend/components/bc/toggle/MultiBarButton.vue
+++ b/frontend/components/bc/toggle/MultiBarButton.vue
@@ -19,7 +19,7 @@ const icon = computed(() => {
 </script>
 
 <template>
-  <BcTooltip>
+  <BcTooltip :dont-open-permanently="true">
     <template #tooltip>
       <div class="button-tooltip">
         <div>{{ selected ? $t('filter.enabled'): $t('filter.disabled') }}</div>

--- a/frontend/components/bc/toggle/MultiBarButton.vue
+++ b/frontend/components/bc/toggle/MultiBarButton.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import type { IconDefinition } from '@fortawesome/fontawesome-svg-core'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import BcTooltip from '../BcTooltip.vue'
 
 interface Props {
   icon?: IconDefinition,
   falseIcon?: IconDefinition,
+  tooltip?: string,
 }
 
 const props = defineProps<Props>()
@@ -17,16 +19,33 @@ const icon = computed(() => {
 </script>
 
 <template>
-  <ToggleButton v-model="selected" class="bc-toggle" on-label="''" off-icon="''">
-    <template #icon="slotProps">
-      <slot name="icon" v-bind="slotProps">
-        <FontAwesomeIcon v-if="icon" :icon="icon" />
-      </slot>
+  <BcTooltip>
+    <template #tooltip>
+      <div class="button-tooltip">
+        <div>{{ selected ? $t('filter.enabled'): $t('filter.disabled') }}</div>
+        <div v-if="tooltip" class="individual">
+          {{ tooltip }}
+        </div>
+      </div>
     </template>
-  </ToggleButton>
+    <ToggleButton v-model="selected" class="bc-toggle" on-label="''" off-icon="''">
+      <template #icon="slotProps">
+        <slot name="icon" v-bind="slotProps">
+          <FontAwesomeIcon v-if="icon" :icon="icon" />
+        </slot>
+      </template>
+    </ToggleButton>
+  </BcTooltip>
 </template>
 
 <style lang="scss" scoped>
+.button-tooltip{
+  width: max-content;
+  text-align: left;
+  .individual{
+    margin-top: var(--padding);
+  }
+}
 .bc-toggle {
   &.p-button {
     &.p-togglebutton {

--- a/frontend/components/bc/toggle/MultiBarButton.vue
+++ b/frontend/components/bc/toggle/MultiBarButton.vue
@@ -22,10 +22,10 @@ const icon = computed(() => {
   <BcTooltip :dont-open-permanently="true" :hover-delay="350">
     <template #tooltip>
       <div class="button-tooltip">
-        <div>{{ selected ? $t('filter.enabled'): $t('filter.disabled') }}</div>
         <div v-if="tooltip" class="individual">
           {{ tooltip }}
         </div>
+        <div>{{ selected ? $t('filter.enabled'): $t('filter.disabled') }}</div>
       </div>
     </template>
     <ToggleButton v-model="selected" class="bc-toggle" on-label="''" off-icon="''">
@@ -43,7 +43,7 @@ const icon = computed(() => {
   width: max-content;
   text-align: left;
   .individual{
-    margin-top: var(--padding);
+    margin-bottom: var(--padding);
   }
 }
 .bc-toggle {

--- a/frontend/components/dashboard/ValidatorSlotViz.vue
+++ b/frontend/components/dashboard/ValidatorSlotViz.vue
@@ -3,6 +3,7 @@
 import { useValidatorSlotVizStore } from '~/stores/dashboard/useValidatorSlotVizStore'
 
 const { dashboardKey } = useDashboardKey()
+const { validatorCount } = useValidatorDashboardOverviewStore()
 
 const { tick, resetTick } = useInterval(12)
 
@@ -15,10 +16,17 @@ watch(() => [dashboardKey.value, tick.value], (newValue, oldValue) => {
   }
   refreshSlotViz(dashboardKey.value)
 }, { immediate: true })
+
+const initiallyHideVisible = computed(() => {
+  if (validatorCount.value === undefined) {
+    return undefined
+  }
+  return validatorCount.value > 60
+})
 </script>
 
 <template>
-  <SlotVizViewer v-if="slotViz" :data="slotViz" :timestamp="tick" />
+  <SlotVizViewer v-if="slotViz" :data="slotViz" :timestamp="tick" :initially-hide-visible="initiallyHideVisible" />
 </template>
 
 <style lang="scss" scoped>

--- a/frontend/components/slot/viz/SlotVizTile.vue
+++ b/frontend/components/slot/viz/SlotVizTile.vue
@@ -16,6 +16,7 @@ const data = computed(() => {
     slashing: props.selectedCategories.includes('slashing') ? props.data.slashing : undefined,
     sync: props.selectedCategories.includes('sync') ? props.data.sync : undefined
   }
+  const showIcons = props.selectedCategories.includes('visible')
   let outer = ''
   const icons: SlotVizIcons[] = []
   switch (slot.status) {
@@ -58,17 +59,19 @@ const data = computed(() => {
     }
   }
 
-  if (slot.proposal) {
-    icons.push('proposal')
-  }
-  if (slot.slashing) {
-    icons.push('slashing')
-  }
-  if (slot.sync) {
-    icons.push('sync')
-  }
-  if (slot.attestations) {
-    icons.push('attestation')
+  if (showIcons) {
+    if (slot.proposal) {
+      icons.push('proposal')
+    }
+    if (slot.slashing) {
+      icons.push('slashing')
+    }
+    if (slot.sync) {
+      icons.push('sync')
+    }
+    if (slot.attestations) {
+      icons.push('attestation')
+    }
   }
 
   return {

--- a/frontend/components/slot/viz/SlotVizTooltip.vue
+++ b/frontend/components/slot/viz/SlotVizTooltip.vue
@@ -158,7 +158,7 @@ const data = computed(() => {
 })
 </script>
 <template>
-  <BcTooltip :target="props.id" layout="dark" scroll-container="#slot-viz">
+  <BcTooltip :target="props.id" layout="dark" scroll-container="#slot-viz" :hover-delay="350">
     <slot />
     <template #tooltip>
       <div class="with-duties">

--- a/frontend/components/slot/viz/SlotVizViewer.vue
+++ b/frontend/components/slot/viz/SlotVizViewer.vue
@@ -1,34 +1,47 @@
 <script setup lang="ts">
+import { faEye } from '@fortawesome/pro-solid-svg-icons'
 import type { SlotVizEpoch } from '~/types/api/slot_viz'
 import { type SlotVizCategories } from '~/types/dashboard/slotViz'
 import { formatNumber } from '~/utils/format'
 import { IconSlotAttestation, IconSlotBlockProposal, IconSlotSlashing, IconSlotSync } from '#components'
 import { COOKIE_KEY } from '~/types/cookie'
 import { useNetworkStore } from '~/stores/useNetworkStore'
+import type { MultiBarItem } from '~/types/multiBar'
 
 interface Props {
-  data: SlotVizEpoch[]
+  data: SlotVizEpoch[],
+  initiallyHideVisible?: boolean,
   timestamp?: number
 }
 const props = defineProps<Props>()
 
 const { tsToSlot } = useNetworkStore()
+const { t: $t } = useI18n()
 
-const selectedCategories = useCookie<SlotVizCategories[]>(COOKIE_KEY.SLOT_VIZ_SELECTED_CATEGORIES, { default: () => ['attestation', 'proposal', 'slashing', 'sync'] })
+const selectedCategories = useCookie<SlotVizCategories[]>(COOKIE_KEY.SLOT_VIZ_SELECTED_CATEGORIES, { default: () => ['attestation', 'proposal', 'slashing', 'sync', 'visible', 'initial'] })
 
-const icons:{ component: Component, value: SlotVizCategories }[] = [
+const icons: MultiBarItem[] = [
   {
     component: IconSlotBlockProposal,
-    value: 'proposal'
+    value: 'proposal',
+    tooltip: $t('slotViz.filter.proposal')
   }, {
     component: IconSlotAttestation,
-    value: 'attestation'
+    value: 'attestation',
+    tooltip: $t('slotViz.filter.attestation')
   }, {
     component: IconSlotSync,
-    value: 'sync'
+    value: 'sync',
+    tooltip: $t('slotViz.filter.sync')
   }, {
     component: IconSlotSlashing,
-    value: 'slashing'
+    value: 'slashing',
+    tooltip: $t('slotViz.filter.slashing')
+  }, {
+    icon: faEye,
+    value: 'visible',
+    className: 'visible-icon',
+    tooltip: $t('slotViz.filter.visible')
   }
 ]
 
@@ -58,6 +71,27 @@ const currentSlotId = computed(() => {
   return Math.max(mostRecentScheduledSlotId.value ?? 0, tsToSlot((props.timestamp ?? 0) / 1000) - 1)
 })
 
+watch(props, () => {
+  if (props.initiallyHideVisible !== undefined) {
+    const initialIndex = selectedCategories.value.indexOf('initial')
+    if (initialIndex < 0) {
+      return
+    }
+    const categories = selectedCategories.value
+    if (props.initiallyHideVisible) {
+      categories.splice(initialIndex, 1)
+      const visibleIndex = categories.indexOf('visible')
+      if (visibleIndex >= 0) {
+        categories.splice(visibleIndex, 1)
+      }
+    } else {
+      categories.splice(initialIndex, 1, 'visible')
+    }
+
+    selectedCategories.value = categories
+  }
+}, { immediate: true })
+
 </script>
 <template>
   <div id="slot-viz" class="content">
@@ -65,7 +99,7 @@ const currentSlotId = computed(() => {
       <div class="row" />
       <div v-for="row in props.data" :key="row.epoch" class="row">
         <div class="epoch">
-          <BcFormatNumber :text="row.state === 'head' ? $t('slotViz.head') : formatNumber(row.epoch) " />
+          <BcFormatNumber :text="row.state === 'head' ? $t('slotViz.head') : formatNumber(row.epoch)" />
         </div>
       </div>
     </div>
@@ -74,7 +108,13 @@ const currentSlotId = computed(() => {
         <BcToggleMultiBar v-model="selectedCategories" :icons="icons" />
       </div>
       <div v-for="row in props.data" :key="row.epoch" class="row">
-        <SlotVizTile v-for="slot in row.slots" :key="slot.slot" :data="slot" :selected-categories="selectedCategories" :current-slot-id="currentSlotId" />
+        <SlotVizTile
+          v-for="slot in row.slots"
+          :key="slot.slot"
+          :data="slot"
+          :selected-categories="selectedCategories"
+          :current-slot-id="currentSlotId"
+        />
       </div>
     </div>
   </div>
@@ -108,10 +148,26 @@ const currentSlotId = computed(() => {
       justify-content: flex-start;
       height: 30px;
       gap: var(--padding);
-      &:first-child{
+
+      &:first-child {
         height: 46px;
       }
     }
+  }
+
+  :deep(.visible-icon) {
+    margin-left: 4px;
+    overflow: visible;
+    position: relative;
+  }
+
+  :deep(.visible-icon):before {
+    content: ' ';
+    background-color: var(--container-border-color);
+    height: 100%;
+    width: 1px;
+    position: absolute;
+    left: -8px;
   }
 }
 </style>

--- a/frontend/composables/useDebounceValue.ts
+++ b/frontend/composables/useDebounceValue.ts
@@ -15,14 +15,14 @@ export function useDebounceValue<T> (initialValue: T, bounceMs: number = 100) {
     timeout.value = null
   }
 
-  const bounce = (value: T, instantIfNoTimer = false, endlesBounce = false) => {
+  const bounce = (value: T, instantIfNoTimer = false, endlesBounce = false, ms?: number) => {
     tempRef.value = value
     if (instantIfNoTimer && !timeout.value) {
       valueRef.value = value
     }
     if (endlesBounce || !timeout.value) {
       removeTimeout()
-      timeout.value = setTimeout(timeFinished, bounceMs)
+      timeout.value = setTimeout(timeFinished, ms || bounceMs)
     }
   }
 

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -147,11 +147,11 @@
   "slotViz": {
     "head": "Head",
     "filter": {
-      "attestation": "If enabled, attestations will be shown.",
-      "proposal": "If enabled, blocks will be shown.",
-      "slashing": "If enabled, slashings will be shown.",
-      "sync": "If enabled, sync committees will be shown.",
-      "visible": "If enabled, all duties will be shown."
+      "attestation": "Attestations will be shown, if enabled.",
+      "proposal": "Blocks will be shown, if enabled.",
+      "slashing": "Slashings will be shown, if enabled.",
+      "sync": "Sync committees will be shown, if enabled.",
+      "visible": "All duties will be shown, if enabled."
     },
     "tooltip": {
       "attestation": "Attestation",

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -92,6 +92,10 @@
     "amount": "Amount",
     "valid": "Valid"
   },
+  "filter": {
+    "enabled": "Filter enabled.",
+    "disabled": "Filter disabled."
+  },
   "premium": {
     "title": "beaconcha.in Premium",
     "description": "Monitoring without limits on web and mobile.",
@@ -142,6 +146,13 @@
   },
   "slotViz": {
     "head": "Head",
+    "filter": {
+      "attestation": "If enabled, attestations will be shown.",
+      "proposal": "If enabled, blocks will be shown.",
+      "slashing": "If enabled, slashings will be shown.",
+      "sync": "If enabled, sync-comm will be shown.",
+      "visible": "If enabled, all duties will be shown."
+    },
     "tooltip": {
       "attestation": "Attestation",
       "sync": "Sync Committee",

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -147,11 +147,11 @@
   "slotViz": {
     "head": "Head",
     "filter": {
-      "attestation": "Attestations will be shown, if enabled.",
-      "proposal": "Blocks will be shown, if enabled.",
-      "slashing": "Slashings will be shown, if enabled.",
-      "sync": "Sync committees will be shown, if enabled.",
-      "visible": "All duties will be shown, if enabled."
+      "attestation": "If enabled, attestations will be shown.",
+      "proposal": "If enabled, blocks will be shown.",
+      "slashing": "If enabled, slashings will be shown.",
+      "sync": "If enabled, sync committees will be shown.",
+      "visible": "If enabled, all duties will be shown."
     },
     "tooltip": {
       "attestation": "Attestation",

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -150,7 +150,7 @@
       "attestation": "If enabled, attestations will be shown.",
       "proposal": "If enabled, blocks will be shown.",
       "slashing": "If enabled, slashings will be shown.",
-      "sync": "If enabled, sync-comm will be shown.",
+      "sync": "If enabled, sync committees will be shown.",
       "visible": "If enabled, all duties will be shown."
     },
     "tooltip": {

--- a/frontend/stores/dashboard/useValidatorDashboardOverviewStore.ts
+++ b/frontend/stores/dashboard/useValidatorDashboardOverviewStore.ts
@@ -47,5 +47,15 @@ export function useValidatorDashboardOverviewStore () {
     return !!overview.value.validators.online || !!overview.value.validators.exited || !!overview.value.validators.offline || !!overview.value.validators.pending || !!overview.value.validators.slashed
   })
 
-  return { overview, refreshOverview, hasValidators }
+  const validatorCount = computed(() => {
+    if (!overview.value) {
+      return undefined
+    }
+    if (!overview.value?.validators) {
+      return 0
+    }
+    return overview.value?.validators.exited + overview.value?.validators.offline + overview.value?.validators.online + overview.value?.validators.pending + overview.value?.validators.slashed
+  })
+
+  return { overview, refreshOverview, hasValidators, validatorCount }
 }

--- a/frontend/stores/dashboard/useValidatorDashboardOverviewStore.ts
+++ b/frontend/stores/dashboard/useValidatorDashboardOverviewStore.ts
@@ -51,10 +51,10 @@ export function useValidatorDashboardOverviewStore () {
     if (!overview.value) {
       return undefined
     }
-    if (!overview.value?.validators) {
+    if (!overview.value.validators) {
       return 0
     }
-    return overview.value?.validators.exited + overview.value?.validators.offline + overview.value?.validators.online + overview.value?.validators.pending + overview.value?.validators.slashed
+    return overview.value.validators.exited + overview.value.validators.offline + overview.value.validators.online + overview.value.validators.pending + overview.value.validators.slashed
   })
 
   return { overview, refreshOverview, hasValidators, validatorCount }

--- a/frontend/types/dashboard/slotViz.ts
+++ b/frontend/types/dashboard/slotViz.ts
@@ -1,2 +1,2 @@
-export type SlotVizCategories = 'attestation' | 'proposal' | 'slashing' | 'sync'
+export type SlotVizCategories = 'attestation' | 'proposal' | 'slashing' | 'sync' | 'visible' | 'initial'
 export type SlotVizIcons = SlotVizCategories | 'head_attestation' | 'source_attestation' | 'target_attestation'

--- a/frontend/types/multiBar.ts
+++ b/frontend/types/multiBar.ts
@@ -1,0 +1,9 @@
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core'
+
+export type MultiBarItem = {
+  icon?: IconDefinition
+  component?: Component,
+  value: string,
+  tooltip?: string,
+  className?: string
+}


### PR DESCRIPTION
This PR:
- adds a 'visible' icon to the Slot Viz filters: if disabled then no icons in the slot viz will  be shown 
- set the visible icon per default to hidden, if the dashboard has more then 60 validators. *
- adds tooltips to the Slot Viz filter icons

* Note: this will only be applied the first time the user navigates to the dashboard then it will be stored in the cookie
