### PR TITLE
(BIDS-3046) Metamask errors related to searchbar

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -72,9 +72,7 @@ export default defineNuxtConfig({
     vueI18n: './i18n.config.ts'
   },
   routeRules: {
-    '/': {
-      redirect: '/dashboard'
-    }
+
   },
   nitro: {
     compressPublicAssets: true

--- a/frontend/types/customFetch.ts
+++ b/frontend/types/customFetch.ts
@@ -238,7 +238,7 @@ export const mapping: Record<string, MappingData> = {
     path: '/search',
     method: 'POST',
     mockFunction: simulateAPIresponseForTheSearchBar,
-    mock: false
+    mock: true
   },
   [API_PATH.AVAILABLE_NETWORKS]: {
     path: '/available-networks',


### PR DESCRIPTION
This PR must not be merged. Its goal is only to provide a branch allowing us test the error reported in BIDS-3046 with Firefox.

This branch
- sets `mock: true` in _types/customFetch.ts_,
- empties `routeRules` in _nuxt.config.ts_,
 
so that we can see search results on the index page.

---
Personally, I do not get any error message with Firefox when the drop-down opens:

**Can the reviewer confirm?** (you need to install Metamask **in Firefox** and create a wallet first, unless you already have that)

![Screenshot from 2024-06-17 14-24-18](https://github.com/gobitfly/beaconchain/assets/150015231/4b2a0bdb-0a0d-4755-97d1-e66e282c99d4)
(the messages in the console come before, when the page loads, and are not related to Metamask)