### PR TITLE
fix watch error in SlotVizViewer

### DIFF
--- a/frontend/components/slot/viz/SlotVizViewer.vue
+++ b/frontend/components/slot/viz/SlotVizViewer.vue
@@ -71,7 +71,7 @@ const currentSlotId = computed(() => {
   return Math.max(mostRecentScheduledSlotId.value ?? 0, tsToSlot((props.timestamp ?? 0) / 1000) - 1)
 })
 
-watch(props, () => {
+watch(() => props, () => {
   if (props.initiallyHideVisible !== undefined) {
     const initialIndex = selectedCategories.value.indexOf('initial')
     if (initialIndex < 0) {


### PR DESCRIPTION
This PR
- fixes an error thrown by a watch in the SlotVizViewer

![image](https://github.com/gobitfly/beaconchain/assets/125363940/7fee5b3f-816e-46f0-bf1f-13fb1f03d824)
