### PR TITLE
Bids 3090/mobile adaptions for pricing

### DIFF
--- a/frontend/components/pricing/PremiumFeature.vue
+++ b/frontend/components/pricing/PremiumFeature.vue
@@ -102,11 +102,11 @@ defineProps<Props>()
         gap: 0;
 
         .name {
-          font-size: 10px;
+          font-size: 14px;
         }
 
         .additional-info-row {
-          font-size: 8px;
+          font-size: 12px;
         }
       }
     }

--- a/frontend/components/pricing/PremiumFeature.vue
+++ b/frontend/components/pricing/PremiumFeature.vue
@@ -102,11 +102,11 @@ defineProps<Props>()
         gap: 0;
 
         .name {
-          font-size: 14px;
+          font-size: 12px;
         }
 
         .additional-info-row {
-          font-size: 12px;
+          font-size: 10px;
         }
       }
     }

--- a/frontend/components/pricing/PremiumProductBox.vue
+++ b/frontend/components/pricing/PremiumProductBox.vue
@@ -319,10 +319,10 @@ const minorFeatures = computed<Feature[]>(() => {
   }
 
   @media (max-width: 1360px) {
-    width: 275px;
+    width: 240px;
 
     &[popular] {
-      width: 330px;
+      width: 300px;
     }
 
     .name-container {

--- a/frontend/components/pricing/PremiumProductBox.vue
+++ b/frontend/components/pricing/PremiumProductBox.vue
@@ -319,10 +319,10 @@ const minorFeatures = computed<Feature[]>(() => {
   }
 
   @media (max-width: 1360px) {
-    width: 210px;
+    width: 275px;
 
     &[popular] {
-      width: 275px;
+      width: 330px;
     }
 
     .name-container {

--- a/frontend/components/pricing/PremiumProductBox.vue
+++ b/frontend/components/pricing/PremiumProductBox.vue
@@ -31,7 +31,7 @@ const prices = computed(() => {
     monthly_based_on_yearly: formatPremiumProductPrice($t, props.product.price_per_year_eur / 12),
     yearly: formatPremiumProductPrice($t, props.product.price_per_year_eur),
     saving: formatPremiumProductPrice($t, savingAmount, savingDigits),
-    perValidator: formatPremiumProductPrice($t, mainPrice / props.product.premium_perks.validators_per_dashboard, 5)
+    perValidator: formatPremiumProductPrice($t, mainPrice / props.product.premium_perks.validators_per_dashboard / props.product.premium_perks.validator_dashboards, 6)
   }
 })
 


### PR DESCRIPTION
This PR
* Increases some font sizes in the premium product boxes on `/pricing` on mobile
* Changes the `cost per validator` calculation from [`price` / `validators per dashboard`] to [`price` / `validators per dashboard` / `validator dashboards`] and shows an extra digit for that value

All changes have been discussed with @Buttaa.