### PR TITLE
add group ids query parameter to dashboard slot viz endpoint

### DIFF
--- a/backend/pkg/api/data_access/dummy.go
+++ b/backend/pkg/api/data_access/dummy.go
@@ -203,7 +203,7 @@ func (d *DummyService) RemoveValidatorDashboardPublicId(publicDashboardId t.VDBI
 	return nil
 }
 
-func (d *DummyService) GetValidatorDashboardSlotViz(dashboardId t.VDBId) ([]t.SlotVizEpoch, error) {
+func (d *DummyService) GetValidatorDashboardSlotViz(dashboardId t.VDBId, groupIds []uint64) ([]t.SlotVizEpoch, error) {
 	r := struct {
 		Epochs []t.SlotVizEpoch `faker:"slice_len=4"`
 	}{}

--- a/backend/pkg/api/data_access/vdb_helpers.go
+++ b/backend/pkg/api/data_access/vdb_helpers.go
@@ -42,7 +42,7 @@ type ValidatorDashboardRepository interface {
 	RemoveValidatorDashboardPublicId(publicDashboardId t.VDBIdPublic) error
 	GetValidatorDashboardPublicIdCount(dashboardId t.VDBIdPrimary) (uint64, error)
 
-	GetValidatorDashboardSlotViz(dashboardId t.VDBId) ([]t.SlotVizEpoch, error)
+	GetValidatorDashboardSlotViz(dashboardId t.VDBId, groupIds []uint64) ([]t.SlotVizEpoch, error)
 
 	GetValidatorDashboardSummary(dashboardId t.VDBId, cursor string, colSort t.Sort[enums.VDBSummaryColumn], search string, limit uint64) ([]t.VDBSummaryTableRow, *t.Paging, error)
 	GetValidatorDashboardGroupSummary(dashboardId t.VDBId, groupId int64) (*t.VDBGroupSummaryData, error)

--- a/backend/pkg/api/data_access/vdb_slotviz.go
+++ b/backend/pkg/api/data_access/vdb_slotviz.go
@@ -6,7 +6,8 @@ import (
 	"github.com/gobitfly/beaconchain/pkg/commons/utils"
 )
 
-func (d *DataAccessService) GetValidatorDashboardSlotViz(dashboardId t.VDBId) ([]t.SlotVizEpoch, error) {
+func (d *DataAccessService) GetValidatorDashboardSlotViz(dashboardId t.VDBId, groupIds []uint64) ([]t.SlotVizEpoch, error) {
+	// TODO if `groupIds`` is empty, get all groups; otherwise only fetch data for the specific groups
 	validatorsArray, err := d.getDashboardValidators(dashboardId)
 	if err != nil {
 		return nil, err

--- a/backend/pkg/api/handlers/common.go
+++ b/backend/pkg/api/handlers/common.go
@@ -314,11 +314,16 @@ func (v *validationError) checkGroupId(param string, allowEmpty bool) int64 {
 
 // checkExistingGroupId validates if the given group id is not empty and a positive integer.
 func (v *validationError) checkExistingGroupId(param string) uint64 {
-	id := v.checkGroupId(param, forbidEmpty)
-	if id < 0 {
-		v.add("group_id", fmt.Sprintf("given value '%s' is not a valid group id", param))
+	return v.checkUint(param, "group_id")
+}
+
+func (v *validationError) checkGroupIdList(groupIds string) []uint64 {
+	groupIdsSlice := strings.Split(groupIds, ",")
+	var ids []uint64
+	for _, id := range groupIdsSlice {
+		ids = append(ids, v.checkUint(id, "group_ids"))
 	}
-	return uint64(id)
+	return ids
 }
 
 func (v *validationError) checkValidatorDashboardPublicId(publicId string) types.VDBIdPublic {

--- a/backend/pkg/api/handlers/internal.go
+++ b/backend/pkg/api/handlers/internal.go
@@ -700,13 +700,16 @@ func (h *HandlerService) InternalDeleteValidatorDashboardPublicId(w http.Respons
 }
 
 func (h *HandlerService) InternalGetValidatorDashboardSlotViz(w http.ResponseWriter, r *http.Request) {
+	var v validationError
 	dashboardId, err := h.handleDashboardId(mux.Vars(r)["dashboard_id"])
 	if err != nil {
 		handleErr(w, err)
 		return
 	}
 
-	data, err := h.dai.GetValidatorDashboardSlotViz(*dashboardId)
+	groupIds := v.checkGroupIdList(r.URL.Query().Get("group_ids"))
+
+	data, err := h.dai.GetValidatorDashboardSlotViz(*dashboardId, groupIds)
 	if err != nil {
 		handleErr(w, err)
 		return

--- a/frontend/stores/dashboard/useValidatorSlotVizStore.ts
+++ b/frontend/stores/dashboard/useValidatorSlotVizStore.ts
@@ -17,7 +17,7 @@ export function useValidatorSlotVizStore () {
   async function refreshSlotViz (dashboardKey: DashboardKey, groups?: number[]) {
     let query
     if (groups?.length) {
-      query = { groups: groups.join(',') }
+      query = { group_ids: groups.join(',') }
     }
     const res = await fetch<InternalGetValidatorDashboardSlotVizResponse>(API_PATH.DASHBOARD_SLOTVIZ, { headers: {}, query }, { dashboardKey: dashboardKey || 'MQ' })
 


### PR DESCRIPTION
Adds the `group_ids`  query parameter to the slot viz endpoint.
![image](https://github.com/gobitfly/beaconchain/assets/109136188/1e87b1b8-7e62-416c-8947-08f5e8fc376e)
