### PR TITLE
Fix VDBRewardesTableDuty

### DIFF
--- a/frontend/components/dashboard/table/DashboardTableValueDuty.vue
+++ b/frontend/components/dashboard/table/DashboardTableValueDuty.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import type { VDBRewardesTableDuty } from '~/types/api/validator_dashboard'
+import type { VDBRewardsTableDuty } from '~/types/api/validator_dashboard'
 
 interface Props {
-  duty: VDBRewardesTableDuty;
+  duty: VDBRewardsTableDuty;
 }
 defineProps<Props>()
 


### PR DESCRIPTION
This PR
* fixes a typo in `VDBRewardesTableDuty` (=>`VDBRewardsTableDuty`) to solve one error popping up in npm