### PR TITLE
Bids 3085/summary table fine tuning

### DIFF
--- a/frontend/components/bc/format/FormatPercent.vue
+++ b/frontend/components/bc/format/FormatPercent.vue
@@ -89,12 +89,11 @@ const data = computed(() => {
   }
 
   .direction-icon {
-    width: 13px;
     display: inline-flex;
     justify-content: center;
 
     svg {
-      height: 8px;
+      height: 14px;
       width: auto;
     }
   }

--- a/frontend/components/dashboard/OverviewBox.vue
+++ b/frontend/components/dashboard/OverviewBox.vue
@@ -3,11 +3,29 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import {
   faInfoCircle
 } from '@fortawesome/pro-regular-svg-icons'
+import {
+  faArrowUpRightFromSquare
+} from '@fortawesome/pro-solid-svg-icons'
 import { type OverviewTableData } from '~/types/dashboard/overview'
+import { DashboardValidatorSubsetModal } from '#components'
 interface Props {
   data: OverviewTableData
 }
 const props = defineProps<Props>()
+const dialog = useDialog()
+
+const { dashboardKey } = useDashboardKey()
+const { getDashboardLabel } = useUserDashboardStore()
+
+const openValidatorModal = () => {
+  dialog.open(DashboardValidatorSubsetModal, {
+    data: {
+      context: 'dashboard',
+      dashboardName: getDashboardLabel(dashboardKey.value, 'validator'),
+      dashboardKey: dashboardKey.value
+    }
+  })
+}
 
 </script>
 <template>
@@ -21,6 +39,12 @@ const props = defineProps<Props>()
           <!-- eslint-disable-next-line vue/no-v-html -->
           <span v-html="props.data.value?.label" />
         </BcTooltip>
+        <FontAwesomeIcon
+          v-if="data?.addValidatorModal"
+          class="link popout"
+          :icon="faArrowUpRightFromSquare"
+          @click="openValidatorModal"
+        />
       </div>
     </div>
     <div v-for="(infos, index) in props.data.additonalValues" :key="index" class="additional">
@@ -49,6 +73,12 @@ const props = defineProps<Props>()
   display: flex;
   align-items: center;
 
+  .popout {
+    width: 14px;
+    margin-left: var(--padding);
+    flex-shrink: 0;
+  }
+
   .main,
   .additional {
     display: flex;
@@ -71,7 +101,7 @@ const props = defineProps<Props>()
 
 }
 
-.info-label-list{
+.info-label-list {
   text-align: left;
 }
 

--- a/frontend/components/dashboard/ValidatorOverview.vue
+++ b/frontend/components/dashboard/ValidatorOverview.vue
@@ -33,7 +33,8 @@ const dataList = computed(() => {
   const v = overview.value
 
   const active: OverviewTableData = {
-    label: $t(`${tPath}your_online_validators`)
+    label: $t(`${tPath}your_online_validators`),
+    addValidatorModal: true
   }
   const efficiency: OverviewTableData = {
     label: $t(`${tPath}24h_efficiency`)

--- a/frontend/components/dashboard/table/DashboardTableSummary.vue
+++ b/frontend/components/dashboard/table/DashboardTableSummary.vue
@@ -22,9 +22,9 @@ const showInDevelopment = Boolean(useRuntimeConfig().public.showInDevelopment)
 const { summary, query: lastQuery, isLoading, getSummary } = useValidatorDashboardSummaryStore()
 const { value: query, temp: tempQuery, bounce: setQuery } = useDebounceValue<TableQueryParams | undefined>(undefined, 500)
 
-const showAbsoluteValues = ref(true)
+const showAbsoluteValues = ref<boolean | null>(null)
 
-const { overview, hasValidators } = useValidatorDashboardOverviewStore()
+const { overview, hasValidators, validatorCount } = useValidatorDashboardOverviewStore()
 const { groups } = useValidatorDashboardGroups()
 
 const timeFrames = computed(() => SummaryTimeFrames.map(t => ({ name: $t(`time_frames.${t}`), id: t })))
@@ -46,6 +46,12 @@ const loadData = (q?: TableQueryParams) => {
   }
   setQuery(q, true, true)
 }
+
+watch(validatorCount, (count) => {
+  if (count !== undefined && showAbsoluteValues.value === null) {
+    showAbsoluteValues.value = count < 100_000
+  }
+}, { immediate: true })
 
 watch([dashboardKey, overview], () => {
   loadData()
@@ -91,7 +97,7 @@ const searchPlaceholder = computed(() => $t(isPublic.value && (groups.value?.len
 <template>
   <div>
     <BcTableControl
-      v-model="showAbsoluteValues"
+      v-model:="showAbsoluteValues"
       :search-placeholder="searchPlaceholder"
       :chart-disabled="!showInDevelopment"
       @set-search="setSearch"
@@ -172,7 +178,7 @@ const searchPlaceholder = computed(() => $t(isPublic.value && (groups.value?.len
               </template>
               <template #body="slotProps">
                 <DashboardTableSummaryValidators
-                  :absolute="showAbsoluteValues"
+                  :absolute="showAbsoluteValues ?? true"
                   :row="slotProps.data"
                   :group-id="slotProps.data.group_id"
                   :dashboard-key="dashboardKey"
@@ -207,7 +213,7 @@ const searchPlaceholder = computed(() => $t(isPublic.value && (groups.value?.len
                 <DashboardTableSummaryValue
                   :class="slotProps.data.className"
                   property="attestations"
-                  :absolute="showAbsoluteValues"
+                  :absolute="showAbsoluteValues ?? true"
                   :time-frame="selectedTimeFrame"
                   :row="slotProps.data"
                 />
@@ -224,7 +230,7 @@ const searchPlaceholder = computed(() => $t(isPublic.value && (groups.value?.len
                   :class="slotProps.data.className"
                   property="proposals"
                   class="no-space-between-value"
-                  :absolute="showAbsoluteValues"
+                  :absolute="showAbsoluteValues ?? true"
                   :time-frame="selectedTimeFrame"
                   :row="slotProps.data"
                 />
@@ -241,7 +247,7 @@ const searchPlaceholder = computed(() => $t(isPublic.value && (groups.value?.len
                   :class="slotProps.data.className"
                   property="reward"
                   class="no-space-between-value"
-                  :absolute="showAbsoluteValues"
+                  :absolute="showAbsoluteValues ?? true"
                   :time-frame="selectedTimeFrame"
                   :row="slotProps.data"
                 />
@@ -252,7 +258,7 @@ const searchPlaceholder = computed(() => $t(isPublic.value && (groups.value?.len
                 :table-visibility="colsVisible"
                 :row="slotProps.data"
                 :time-frame="selectedTimeFrame"
-                :absolute="showAbsoluteValues"
+                :absolute="showAbsoluteValues ?? true"
               />
             </template>
             <template #empty>

--- a/frontend/components/dashboard/table/DashboardTableSummary.vue
+++ b/frontend/components/dashboard/table/DashboardTableSummary.vue
@@ -185,6 +185,7 @@ const searchPlaceholder = computed(() => $t(isPublic.value && (groups.value?.len
               v-if="colsVisible.efficiency"
               field="efficiency"
               :sortable="showInDevelopment"
+              body-class="efficiency-column"
               :header="$t('dashboard.validator.col.efficiency')"
             >
               <template #body="slotProps">
@@ -288,16 +289,24 @@ const searchPlaceholder = computed(() => $t(isPublic.value && (groups.value?.len
   gap: var(--padding);
 }
 
-.validators-header{
-  position: relative;
+.validators-header {
   .info {
     position: absolute;
-    top: 8px;
-    right: -50px;
+    top: 16px;
+    right: var(--padding-large);
 
     svg {
       width: 14px;
       height: 14px;
+    }
+  }
+
+  @media (min-width: 730px) {
+    position: relative;
+
+    .info {
+      top: 8px;
+      right: -50px;
     }
   }
 }
@@ -323,6 +332,11 @@ const searchPlaceholder = computed(() => $t(isPublic.value && (groups.value?.len
 
   .status-column {
     @include utils.set-all-width(90px);
+  }
+
+  .status-column,
+  .efficiency-column {
+    padding: 7px !important;
   }
 
   .validator-column {

--- a/frontend/components/dashboard/table/DashboardTableSummary.vue
+++ b/frontend/components/dashboard/table/DashboardTableSummary.vue
@@ -340,7 +340,7 @@ const searchPlaceholder = computed(() => $t(isPublic.value && (groups.value?.len
   }
 
   .validator-column {
-    @include utils.set-all-width(200px);
+    @include utils.set-all-width(240px);
     padding: 3px 7px !important;
 
     @media (max-width: 570px) {

--- a/frontend/components/dashboard/table/DashboardTableValidators.vue
+++ b/frontend/components/dashboard/table/DashboardTableValidators.vue
@@ -44,7 +44,7 @@ const openValidatorModal = () => {
 }
 
 const groupName = computed(() => {
-  return getGroupLabel($t, props.groupId, groups.value)
+  return getGroupLabel($t, props.groupId, groups.value, $t('common.total'))
 })
 
 const cappedValidators = computed(() => sortValidatorIds(props.validators).slice(0, 10))

--- a/frontend/components/dashboard/table/SummaryDetails.vue
+++ b/frontend/components/dashboard/table/SummaryDetails.vue
@@ -32,29 +32,14 @@ const data = computed<SummaryRow[][]>(() => {
     props.forEach(p => addToList(index, p))
   }
 
-  if (!props.tableVisibility.efficiency) {
-    addToList(0, 'efficiency')
-  }
-  if (!props.tableVisibility.attestations) {
-    addToList(0, 'attestations')
-  } else {
-    addToList(0, undefined, 'attestations')
-  }
-  addPropsTolist(0, ['attestations_head', 'attestations_source', 'attestations_target', 'attestation_efficiency', 'attestation_avg_incl_dist'])
+  const rewardCols: SummaryDetailsEfficiencyCombinedProp[] = ['reward', 'missed_rewards']
+  let addCols: SummaryDetailsEfficiencyCombinedProp[] = props.tableVisibility.attestations ? [] : rewardCols
+  addPropsTolist(0, ['efficiency', ...addCols, 'attestations', 'attestations_head', 'attestations_source', 'attestations_target', 'attestation_efficiency', 'attestation_avg_incl_dist'])
 
-  addPropsTolist(1, ['sync', 'validators_sync'])
+  addPropsTolist(1, ['sync', 'validators_sync', 'proposals', 'validators_proposal', 'slashings', 'validators_slashings'])
 
-  if (!props.tableVisibility.proposals) {
-    addToList(1, 'proposals')
-  } else {
-    addToList(1, undefined, 'proposals')
-  }
-  addPropsTolist(1, ['validators_proposal', 'slashings', 'validators_slashings'])
-
-  addPropsTolist(2, ['apr', 'luck', 'missed_rewards'])
-  if (!props.tableVisibility.reward) {
-    addToList(2, 'reward')
-  }
+  addCols = !props.tableVisibility.attestations ? [] : rewardCols
+  addPropsTolist(2, ['apr', 'luck', ...addCols])
 
   return list
 })
@@ -66,11 +51,11 @@ const rowClass = (data: SummaryRow) => {
   const classNames: Partial<Record<SummaryDetailsEfficiencyCombinedProp, string>> = {
     efficiency: 'bold',
     attestations: 'bold',
-    sync: 'bold spacing-top',
+    sync: props.tableVisibility.efficiency ? 'bold' : 'bold spacing-top',
     proposals: 'bold spacing-top',
     slashings: 'bold spacing-top',
-    apr: 'bold',
-    luck: 'bold spacing-top',
+    apr: props.tableVisibility.attestations ? '' : 'spacing-top',
+    luck: 'spacing-top',
     attestations_head: 'spacing-top'
   }
   return classNames[data.prop]
@@ -134,7 +119,7 @@ const rowClass = (data: SummaryRow) => {
     }
 
     @media (max-width: 1014px) {
-      width: 344px;
+      width: 50%;
 
       &:last-child {
         border-top: var(--container-border);

--- a/frontend/components/dashboard/table/SummaryStatus.vue
+++ b/frontend/components/dashboard/table/SummaryStatus.vue
@@ -99,12 +99,12 @@ const mapped = computed(() => {
 
     &.current-sync {
       color: var(--positive-color);
-      animation: pulse-animation 1s linear infinite;
+      animation: status-rotation 2s linear infinite;
     }
 
     &.scheduled-sync {
       color: var(--positive-color);
-      animation: status-rotation .75s linear infinite;
+      animation: pulse-animation 2s linear infinite;
     }
   }
 }

--- a/frontend/components/dashboard/table/SummaryValidators.vue
+++ b/frontend/components/dashboard/table/SummaryValidators.vue
@@ -81,7 +81,12 @@ const mapped = computed(() => {
         <BcFormatPercent v-else :value="status.count" :base="mapped.total" />
       </div>
     </BcTooltip>
-    <FontAwesomeIcon v-if="!isTooltip" class="link popout" :icon="faArrowUpRightFromSquare" @click="openValidatorModal" />
+    <FontAwesomeIcon
+      v-if="!isTooltip"
+      class="link popout"
+      :icon="faArrowUpRightFromSquare"
+      @click="openValidatorModal"
+    />
   </div>
   <div v-else>
     -
@@ -96,6 +101,11 @@ const mapped = computed(() => {
   align-items: center;
   flex-wrap: nowrap;
   gap: var(--padding);
+
+  @media (max-width: 729px) {
+    justify-content: space-between;
+    padding-right: 13px;
+  }
 
   .status-list {
     display: flex;

--- a/frontend/components/dashboard/table/SummaryValidators.vue
+++ b/frontend/components/dashboard/table/SummaryValidators.vue
@@ -42,7 +42,7 @@ const openValidatorModal = () => {
 }
 
 const groupName = computed(() => {
-  return getGroupLabel($t, props.groupId, groups.value)
+  return getGroupLabel($t, props.groupId, groups.value, $t('common.total'))
 })
 
 const mapped = computed(() => {

--- a/frontend/components/dashboard/table/SummaryValue.vue
+++ b/frontend/components/dashboard/table/SummaryValue.vue
@@ -123,7 +123,7 @@ const data = computed(() => {
 })
 
 const groupName = computed(() => {
-  return getGroupLabel($t, props.row.group_id, groups.value)
+  return getGroupLabel($t, props.row.group_id, groups.value, $t('common.total'))
 })
 
 const openValidatorModal = () => {

--- a/frontend/components/dashboard/validator/subset/ValidatorSubsetModal.vue
+++ b/frontend/components/dashboard/validator/subset/ValidatorSubsetModal.vue
@@ -18,6 +18,7 @@ interface Props {
   context: DashboardValidatorContext,
   timeFrame?: SummaryTimeFrame,
   dashboardKey?: DashboardKey,
+  dashboardName?: string,
   groupName?: string,
   groupId?: number,
   summary?: {
@@ -117,7 +118,7 @@ const mapped = computed<ValidatorSubset[]>(() => {
       <DashboardValidatorSubsetSubHeader
         v-if="props"
         :context="props.context"
-        :group-name="props.groupName"
+        :sub-title="props.groupName || props.dashboardName"
         :summary="props.summary"
       />
       <BcContentFilter v-model="filter" :search-placeholder="$t('common.index')" @filter-changed="(f:string)=>filter=f" />
@@ -162,6 +163,7 @@ const mapped = computed<ValidatorSubset[]>(() => {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    overflow-x: hidden;
   }
 
   .spinner {

--- a/frontend/components/dashboard/validator/subset/ValidatorSubsetModal.vue
+++ b/frontend/components/dashboard/validator/subset/ValidatorSubsetModal.vue
@@ -163,7 +163,7 @@ const mapped = computed<ValidatorSubset[]>(() => {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    overflow-x: hidden;
+    overflow: hidden;
   }
 
   .spinner {

--- a/frontend/components/dashboard/validator/subset/ValidatorSubsetSubHeader.vue
+++ b/frontend/components/dashboard/validator/subset/ValidatorSubsetSubHeader.vue
@@ -5,7 +5,7 @@ import type { DashboardValidatorContext } from '~/types/dashboard/summary'
 
 interface Props {
   context: DashboardValidatorContext,
-  groupName?: string,
+  subTitle?: string,
   summary?: {
     data?: VDBGroupSummaryData,
     row: VDBSummaryTableRow
@@ -60,7 +60,7 @@ const infos = computed(() => {
 
 <template>
   <div class="subset-header">
-    {{ props?.groupName }}
+    <span class="sub-title">{{ props?.subTitle }}</span>
     <DashboardTableSummaryValidators
       v-if="props.summary && (context === 'group' || context === 'dashboard')"
       :is-tooltip="true"
@@ -82,10 +82,19 @@ const infos = computed(() => {
 </template>
 
 <style lang="scss" scoped>
+@use "~/assets/css/fonts.scss";
+@use "~/assets/css/utils.scss";
+
 .subset-header {
   display: flex;
   align-items: center;
   gap: var(--padding);
+  overflow-x: hidden;
+
+  .sub-title {
+    @include fonts.subtitle_text;
+    @include utils.truncate-text
+  }
 
   .info {
     display: flex;

--- a/frontend/components/dashboard/validator/subset/ValidatorSubsetSubHeader.vue
+++ b/frontend/components/dashboard/validator/subset/ValidatorSubsetSubHeader.vue
@@ -89,7 +89,7 @@ const infos = computed(() => {
   display: flex;
   align-items: center;
   gap: var(--padding);
-  overflow-x: hidden;
+  overflow: hidden;
 
   .sub-title {
     @include fonts.subtitle_text;

--- a/frontend/components/slot/viz/SlotVizViewer.vue
+++ b/frontend/components/slot/viz/SlotVizViewer.vue
@@ -154,7 +154,11 @@ watch(() => props, () => {
     @media (max-width: 800px) {
       column-gap: var(--padding-small);
       grid-template:
-        [row1-start] "network network network"[row1-end] [row2-start] "info filter-row header-right"[row2-end] / max-content 1fr max-content;
+        [row1-start] "network network network"[row1-end] [row2-start] "info filter-row header-right"[row2-end] / max-content max-content 1fr;
+    }
+
+    @media (max-width: 490px) {
+      padding-right: var(--padding);
     }
 
     .network {
@@ -183,9 +187,10 @@ watch(() => props, () => {
       width: 196px;
       margin-top: auto;
       margin-bottom: auto;
+      margin-left: auto;
 
       @media (max-width: 490px) {
-        width: 87px;
+        width: 104px;
       }
     }
 
@@ -210,6 +215,10 @@ watch(() => props, () => {
     overflow-y: hidden;
     min-height: 180px;
     grid-template-columns: 49px max-content;
+
+    @media (max-width: 490px) {
+      padding-right: var(--padding);
+    }
 
     .row {
       display: flex;

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -379,13 +379,18 @@
           "offline": "Offline",
           "pending": "Pending",
           "deposited": "Deposited",
+          "depositing": "Depositing",
           "sync_current": "Current Sync Committee",
           "sync_upcoming": "Upcoming Sync Committee",
           "sync_past": "Past Sync Committee",
           "has_slashed": "Slashed",
           "got_slashed": "Got slashed",
           "proposal_proposed": "Proposed",
-          "proposal_missed": "Missed"
+          "proposal_missed": "Missed",
+          "exiting": "Exiting",
+          "exited":"Exited",
+          "withdrawing":"Withdrawing",
+          "withdrawn":"Withdrawn"
         }
       },
       "blocks": {

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -499,7 +499,7 @@
           "apr": "APR",
           "luck": "Luck",
           "reward": "Reward",
-          "missed_rewards": "Total missed rewards"
+          "missed_rewards": "Missed rewards"
         },
         "status": {
           "current_sync": "No active sync participation | One validator is in the current sync committee | {count} validators are in the current sync committee",

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -48,7 +48,8 @@
     "live": "Live",
     "current": "Current",
     "upcoming": "Upcoming", 
-    "past": "Past"
+    "past": "Past",
+    "total": "Total"
   },
   "seo": {
     "title": "Open Source Ethereum Blockchain Explorer",

--- a/frontend/types/customFetch.ts
+++ b/frontend/types/customFetch.ts
@@ -203,7 +203,7 @@ export const mapping: Record<string, MappingData> = {
   [API_PATH.DASHBOARD_OVERVIEW]: {
     path: '/validator-dashboards/{dashboardKey}',
     getPath: values => `/validator-dashboards/${values?.dashboardKey}`,
-    mock: false
+    mock: true
   },
   [API_PATH.DASHBOARD_SLOTVIZ]: {
     path: '/validator-dashboards/{dashboardKey}/slot-viz',

--- a/frontend/types/customFetch.ts
+++ b/frontend/types/customFetch.ts
@@ -203,7 +203,7 @@ export const mapping: Record<string, MappingData> = {
   [API_PATH.DASHBOARD_OVERVIEW]: {
     path: '/validator-dashboards/{dashboardKey}',
     getPath: values => `/validator-dashboards/${values?.dashboardKey}`,
-    mock: true
+    mock: false
   },
   [API_PATH.DASHBOARD_SLOTVIZ]: {
     path: '/validator-dashboards/{dashboardKey}/slot-viz',

--- a/frontend/types/dashboard/overview.ts
+++ b/frontend/types/dashboard/overview.ts
@@ -2,6 +2,7 @@ import type { ExtendedLabel } from '~/types/value'
 
 export type OverviewTableData = {
   label: string,
+  addValidatorModal?: boolean,
   value?: ExtendedLabel,
   additonalValues?: ExtendedLabel[][],
   infos?: {


### PR DESCRIPTION
This PR

Summary Table
- bigger Efficiency Icons 
- flip animation of status icons (current vs scheduled) and make the anmiations slower

- align icons in the validator header and row to the right on mobile view - so they align with the detail icons
- always show all inforamtion in the details, no matter if the column is visible or not
- remove 'Total' from 'Total missed rewards'
- remove bold from apr luck in details
- detail groups on mid size now get 50% width instead of a fixed width
- ... some more minor style fixes

Dashobar Overview
- add open validator list modal