### PR TITLE
api: dont try to parse null as decimal in el apr

### DIFF
--- a/backend/pkg/api/data_access/vdb_summary.go
+++ b/backend/pkg/api/data_access/vdb_summary.go
@@ -867,7 +867,7 @@ func (d *DataAccessService) internal_getElClAPR(validators []t.VDBValidator, day
 
 	query = `
 	SELECT 
-		SUM(COALESCE(rb.value / 1e18, fee_recipient_reward, 0))
+		COALESCE(SUM(COALESCE(rb.value / 1e18, fee_recipient_reward)), 0)
 	FROM blocks 
 	LEFT JOIN execution_payloads ON blocks.exec_block_hash = execution_payloads.block_hash
 	LEFT JOIN relays_blocks rb ON blocks.exec_block_hash = rb.exec_block_hash


### PR DESCRIPTION
fixes apr calculation failing if no blocks exist within requested time range