### PR TITLE
prevent outside scroll while swiping dialog

### DIFF
--- a/frontend/assets/css/prime.scss
+++ b/frontend/assets/css/prime.scss
@@ -54,7 +54,8 @@
   border: 1px solid var(--primary-orange);
   border-radius: var(--border-radius);
   padding: var(--padding-large);
-  min-width: 375px;  
+  min-width: 375px; 
+  max-height: calc(100vh - 60px);
   touch-action: pan-x pan-y;
 
   .p-dialog-header {

--- a/frontend/assets/css/prime.scss
+++ b/frontend/assets/css/prime.scss
@@ -55,7 +55,7 @@
   border-radius: var(--border-radius);
   padding: var(--padding-large);
   min-width: 375px;  
-  touch-action: manipulation;
+  touch-action: pan-x pan-y;
 
   .p-dialog-header {
     color: var(--text-color);

--- a/frontend/assets/css/prime.scss
+++ b/frontend/assets/css/prime.scss
@@ -54,7 +54,8 @@
   border: 1px solid var(--primary-orange);
   border-radius: var(--border-radius);
   padding: var(--padding-large);
-  min-width: 375px;
+  min-width: 375px;  
+  touch-action: manipulation;
 
   .p-dialog-header {
     color: var(--text-color);

--- a/frontend/assets/css/prime.scss
+++ b/frontend/assets/css/prime.scss
@@ -55,7 +55,7 @@
   border-radius: var(--border-radius);
   padding: var(--padding-large);
   min-width: 375px; 
-  max-height: calc(100vh - 60px);
+  max-height: calc(100% - 60px);
   touch-action: pan-x pan-y;
 
   .p-dialog-header {

--- a/frontend/components/dashboard/validator/subset/ValidatorSubsetModal.vue
+++ b/frontend/components/dashboard/validator/subset/ValidatorSubsetModal.vue
@@ -163,6 +163,7 @@ const mapped = computed<ValidatorSubset[]>(() => {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: var(--padding);
     overflow: hidden;
   }
 

--- a/frontend/components/dashboard/validator/subset/ValidatorSubsetModal.vue
+++ b/frontend/components/dashboard/validator/subset/ValidatorSubsetModal.vue
@@ -142,7 +142,6 @@ const mapped = computed<ValidatorSubset[]>(() => {
 <style lang="scss" scoped>
 .validator_subset_modal_container {
   width: 410px;
-  height: 489px;
   display: flex;
   flex-direction: column;
   flex-grow: 1;
@@ -174,7 +173,8 @@ const mapped = computed<ValidatorSubset[]>(() => {
   .accordion {
     position: relative;
     flex-grow: 1;
-    height: 453px;
+    max-height: 453px;
+    min-height: 200px;
     overflow-y: auto;
     overflow-x: hidden;
     word-break: break-all;

--- a/frontend/composables/useSwipe.ts
+++ b/frontend/composables/useSwipe.ts
@@ -28,7 +28,6 @@ export const useSwipe = (swipeOptions?: SwipeOptions, bounce = true) => {
       return
     }
     event.stopImmediatePropagation()
-    event.preventDefault()
     isSwiping.value = true
     touchStartX.value = event.changedTouches[0].screenX
     touchStartY.value = event.changedTouches[0].screenY
@@ -38,7 +37,6 @@ export const useSwipe = (swipeOptions?: SwipeOptions, bounce = true) => {
       return
     }
     event.stopImmediatePropagation()
-    event.preventDefault()
     isSwiping.value = false
     touchEndX.value = event.changedTouches[0].screenX
     touchEndY.value = event.changedTouches[0].screenY
@@ -53,7 +51,6 @@ export const useSwipe = (swipeOptions?: SwipeOptions, bounce = true) => {
       return
     }
     event.stopImmediatePropagation()
-    event.preventDefault()
     if (!bounce || !touchableElement.value) {
       return
     }
@@ -109,6 +106,10 @@ export const useSwipe = (swipeOptions?: SwipeOptions, bounce = true) => {
     }
   }
 
+  const onPointerDown = (event: PointerEvent) => {
+    event.stopImmediatePropagation()
+  }
+
   const setElement = (elem: HTMLElement, callback: SwipeCallback) => {
     clearElement()
     touchableElement.value = elem
@@ -118,6 +119,7 @@ export const useSwipe = (swipeOptions?: SwipeOptions, bounce = true) => {
       touchableElement.value.addEventListener('touchend', onTouchEnd, false)
       touchableElement.value.addEventListener('touchcancel', onTouchEnd, false)
       touchableElement.value.addEventListener('touchmove', onTouchMove, false)
+      touchableElement.value.addEventListener('pointerdown', onPointerDown, false)
     }
   }
 
@@ -125,8 +127,9 @@ export const useSwipe = (swipeOptions?: SwipeOptions, bounce = true) => {
     if (touchableElement.value) {
       touchableElement.value.removeEventListener('touchstart', onTouchStart)
       touchableElement.value.removeEventListener('touchend', onTouchEnd)
-      touchableElement.value.removeEventListener('touchcancel', onTouchEnd, false)
+      touchableElement.value.removeEventListener('touchcancel', onTouchEnd)
       touchableElement.value.removeEventListener('touchmove', onTouchMove)
+      touchableElement.value.removeEventListener('pointerdown', onPointerDown)
       touchableElement.value = undefined
     }
   }

--- a/frontend/composables/useSwipe.ts
+++ b/frontend/composables/useSwipe.ts
@@ -27,6 +27,8 @@ export const useSwipe = (swipeOptions?: SwipeOptions, bounce = true) => {
     if (!isValidTarget(event)) {
       return
     }
+    event.stopImmediatePropagation()
+    event.preventDefault()
     isSwiping.value = true
     touchStartX.value = event.changedTouches[0].screenX
     touchStartY.value = event.changedTouches[0].screenY
@@ -35,6 +37,8 @@ export const useSwipe = (swipeOptions?: SwipeOptions, bounce = true) => {
     if (!isSwiping.value) {
       return
     }
+    event.stopImmediatePropagation()
+    event.preventDefault()
     isSwiping.value = false
     touchEndX.value = event.changedTouches[0].screenX
     touchEndY.value = event.changedTouches[0].screenY
@@ -48,6 +52,8 @@ export const useSwipe = (swipeOptions?: SwipeOptions, bounce = true) => {
     if (!isSwiping.value) {
       return
     }
+    event.stopImmediatePropagation()
+    event.preventDefault()
     if (!bounce || !touchableElement.value) {
       return
     }


### PR DESCRIPTION
This PR:

- tries to prevent zoom/scrooling the background while swiping a dialog on mobile
- it also adds a little padding to the sub header of the validator list modal