### PR TITLE
enable sorting, and fix period query param

### DIFF
--- a/frontend/components/dashboard/table/DashboardTableSummary.vue
+++ b/frontend/components/dashboard/table/DashboardTableSummary.vue
@@ -42,7 +42,7 @@ const colsVisible = computed<SummaryTableVisibility>(() => {
 })
 const loadData = (q?: TableQueryParams) => {
   if (!q) {
-    q = query.value ? { ...query.value } : { limit: pageSize.value, sort: 'group_id:desc' }
+    q = query.value ? { ...query.value } : { limit: pageSize.value, sort: 'efficiency:desc' }
   }
   setQuery(q, true, true)
 }
@@ -134,7 +134,7 @@ const searchPlaceholder = computed(() => $t(isPublic.value && (groups.value?.len
           >
             <Column
               field="group_id"
-              :sortable="showInDevelopment"
+              :sortable="true"
               body-class="group-id-column bold"
               header-class="group-id-column"
               :header="$t('dashboard.validator.col.group')"
@@ -145,7 +145,6 @@ const searchPlaceholder = computed(() => $t(isPublic.value && (groups.value?.len
             </Column>
             <Column
               field="status"
-              :sortable="showInDevelopment"
               header-class="status-column"
               body-class="status-column"
               :header="$t('dashboard.validator.col.status')"
@@ -158,7 +157,7 @@ const searchPlaceholder = computed(() => $t(isPublic.value && (groups.value?.len
               field="validators"
               body-class="validator-column"
               header-class="validator-column"
-              :sortable="showInDevelopment && colsVisible.validatorsSortable"
+              :sortable="colsVisible.validatorsSortable"
             >
               <template #header>
                 <div class="validators-header">
@@ -190,7 +189,7 @@ const searchPlaceholder = computed(() => $t(isPublic.value && (groups.value?.len
             <Column
               v-if="colsVisible.efficiency"
               field="efficiency"
-              :sortable="showInDevelopment"
+              :sortable="true"
               body-class="efficiency-column"
               :header="$t('dashboard.validator.col.efficiency')"
             >
@@ -205,8 +204,8 @@ const searchPlaceholder = computed(() => $t(isPublic.value && (groups.value?.len
             </Column>
             <Column
               v-if="colsVisible.attestations"
-              field="attestions"
-              :sortable="showInDevelopment"
+              field="attestations"
+              :sortable="true"
               :header="$t('dashboard.validator.summary.row.attestations')"
             >
               <template #body="slotProps">
@@ -222,7 +221,7 @@ const searchPlaceholder = computed(() => $t(isPublic.value && (groups.value?.len
             <Column
               v-if="colsVisible.proposals"
               field="proposals"
-              :sortable="showInDevelopment"
+              :sortable="true"
               :header="$t('dashboard.validator.summary.row.proposals')"
             >
               <template #body="slotProps">
@@ -239,7 +238,7 @@ const searchPlaceholder = computed(() => $t(isPublic.value && (groups.value?.len
             <Column
               v-if="colsVisible.reward"
               field="reward"
-              :sortable="showInDevelopment"
+              :sortable="true"
               :header="$t('dashboard.validator.col.rewards')"
             >
               <template #body="slotProps">

--- a/frontend/components/dashboard/validator/subset/ValidatorSubsetModal.vue
+++ b/frontend/components/dashboard/validator/subset/ValidatorSubsetModal.vue
@@ -71,7 +71,7 @@ watch(props, async (p) => {
         break
     }
 
-    const res = await fetch<InternalGetValidatorDashboardSummaryValidatorsResponse>(API_PATH.DASHBOARD_VALIDATOR_INDICES, { query: { period: p?.timeFrame?.replace('last_', ''), duty, group_id: p?.groupId } }, { dashboardKey: `${p?.dashboardKey}` })
+    const res = await fetch<InternalGetValidatorDashboardSummaryValidatorsResponse>(API_PATH.DASHBOARD_VALIDATOR_INDICES, { query: { period: p?.timeFrame, duty, group_id: p?.groupId } }, { dashboardKey: `${p?.dashboardKey}` })
     data.value = res.data
     isLoading.value = false
   }

--- a/frontend/stores/dashboard/useValidatorDashboardSummaryDetailsStore.ts
+++ b/frontend/stores/dashboard/useValidatorDashboardSummaryDetailsStore.ts
@@ -26,7 +26,7 @@ export function useValidatorDashboardSummaryDetailsStore (dashboardKey: Dashboar
       data.value = {}
       storeTimeFrame.value = timeFrame
     }
-    const res = await fetch<InternalGetValidatorDashboardGroupSummaryResponse>(API_PATH.DASHBOARD_SUMMARY_DETAILS, { query: { time_frame: timeFrame } }, { dashboardKey, groupId })
+    const res = await fetch<InternalGetValidatorDashboardGroupSummaryResponse>(API_PATH.DASHBOARD_SUMMARY_DETAILS, { query: { period: timeFrame } }, { dashboardKey, groupId })
     data.value = { ...data.value, [getKey()]: res.data }
     return res.data
   }

--- a/frontend/stores/dashboard/useValidatorDashboardSummaryStore.ts
+++ b/frontend/stores/dashboard/useValidatorDashboardSummaryStore.ts
@@ -29,7 +29,7 @@ export function useValidatorDashboardSummaryStore () {
     isLoading.value = true
     storedQuery.value = query
 
-    const res = await fetch<InternalGetValidatorDashboardSummaryResponse>(API_PATH.DASHBOARD_SUMMARY, { query: { timeFrame } }, { dashboardKey }, query)
+    const res = await fetch<InternalGetValidatorDashboardSummaryResponse>(API_PATH.DASHBOARD_SUMMARY, { query: { period: timeFrame } }, { dashboardKey }, query)
     isLoading.value = false
     if (JSON.stringify(storedQuery.value) !== JSON.stringify(query)) {
       return // in case some query params change while loading


### PR DESCRIPTION
This PR:
- enables sorting of the summary table 
- uses the correct `period` query param for the summary table calls
- sets the default sort of the summary table to efficiency 