### PR TITLE
slotviz: hide empty groups, summary: hide proposal popout in details

### DIFF
--- a/frontend/components/dashboard/ValidatorSlotViz.vue
+++ b/frontend/components/dashboard/ValidatorSlotViz.vue
@@ -34,7 +34,7 @@ const groups = computed(() => {
   if (!overview.value?.groups) {
     return []
   }
-  return orderBy(overview.value.groups, [g => g.name.toLowerCase()], 'asc')
+  return orderBy(overview.value.groups.filter(g => !!g.count), [g => g.name.toLowerCase()], 'asc')
 })
 
 const selectAll = () => {

--- a/frontend/components/dashboard/table/SummaryDetails.vue
+++ b/frontend/components/dashboard/table/SummaryDetails.vue
@@ -77,6 +77,7 @@ const rowClass = (data: SummaryRow) => {
           :property="prop.prop"
           :time-frame="timeFrame"
           :row="props.row"
+          :in-detail-view="true"
         />
       </div>
     </div>

--- a/frontend/components/dashboard/table/SummaryValue.vue
+++ b/frontend/components/dashboard/table/SummaryValue.vue
@@ -28,6 +28,7 @@ interface Props {
   data?: VDBGroupSummaryData,
   row: VDBSummaryTableRow,
   absolute?: boolean,
+  inDetailView?: boolean,
 }
 const props = defineProps<Props>()
 
@@ -50,7 +51,7 @@ const data = computed(() => {
       efficiency: {
         status_count: row.proposals
       },
-      context: 'proposal'
+      context: !props.inDetailView ? 'proposal' : undefined
     }
   } else if (col && SummaryDetailsEfficiencyProps.includes(props.property as SummaryDetailsEfficiencyProp)) {
     const tooltip: { title: string, text: string } | undefined = $tm(`dashboard.validator.tooltip.${props.property}`)


### PR DESCRIPTION
This PR:
- hides empty groups in the slot viz
- hides the popout for the propsal row in the summary details