### PR TITLE
Bids 2857/manage notifications modal

### DIFF
--- a/frontend/components/dashboard/DashboardHeader.vue
+++ b/frontend/components/dashboard/DashboardHeader.vue
@@ -98,7 +98,7 @@ const items = computed<MenuBarEntry[]>(() => {
   }))
   const disabledTooltip = !showInDevelopment ? $t('common.coming_soon') : undefined
   const onNotificationsPage = dashboardType.value === 'notifications'
-  addToSortedItems(2, [{ label: $t('dashboard.notifications'), route: !onNotificationsPage ? '/notifications' : undefined, disabledTooltip, active: onNotificationsPage }])
+  addToSortedItems(2, [{ label: $t('dashboard.notifications.title'), route: !onNotificationsPage ? '/notifications' : undefined, disabledTooltip, active: onNotificationsPage }])
 
   // if we are in a public dashboard and change the validators then the route does not get updated
   const fixedRoute = router.resolve({ name: route.name!, params: { id: dashboardKey.value } })

--- a/frontend/components/dashboard/notifications/NotificationsManagementModal.vue
+++ b/frontend/components/dashboard/notifications/NotificationsManagementModal.vue
@@ -1,0 +1,87 @@
+<script lang="ts" setup>
+import {
+  faCog,
+  faGaugeSimpleMax,
+  faMonitorWaveform,
+  faBolt,
+  faNetworkWired
+} from '@fortawesome/pro-solid-svg-icons'
+
+const { t: $t } = useI18n()
+
+const visible = defineModel<boolean>()
+</script>
+
+<template>
+  <BcDialog
+    v-model="visible"
+    :header="$t('dashboard.notifications.management.title')"
+    class="notifications-management-modal-container"
+  >
+    <TabView lazy class="notifications-management-tab-view">
+      <TabPanel>
+        <template #header>
+          <BcTabHeader :header="$t('dashboard.notifications.management.tabs.general')" :icon="faCog" />
+        </template>
+        General coming soon!
+      </TabPanel>
+      <TabPanel>
+        <template #header>
+          <BcTabHeader :header="$t('dashboard.notifications.management.tabs.dashboards')" :icon="faGaugeSimpleMax" />
+        </template>
+        Dashboards coming soon!
+      </TabPanel>
+      <TabPanel>
+        <template #header>
+          <BcTabHeader :header="$t('dashboard.notifications.management.tabs.machines')" :icon="faMonitorWaveform" />
+        </template>
+        Machines coming soon!
+      </TabPanel>
+      <TabPanel>
+        <template #header>
+          <BcTabHeader :header="$t('dashboard.notifications.management.tabs.clients')" :icon="faBolt" />
+        </template>
+        Clients coming soon!
+      </TabPanel>
+      <TabPanel>
+        <template #header>
+          <BcTabHeader :header="$t('dashboard.notifications.management.tabs.rocketpool')">
+            <template #icon>
+              <IconRocketPool />
+            </template>
+          </BcTabHeader>
+        </template>
+        Rocket Pool coming soon!
+      </TabPanel>
+      <TabPanel>
+        <template #header>
+          <BcTabHeader :header="$t('dashboard.notifications.management.tabs.network')" :icon="faNetworkWired" />
+        </template>
+        Network coming soon!
+      </TabPanel>
+    </TabView>
+    <Button class="done-button" label="Done" />
+  </BcDialog>
+</template>
+
+<style lang="scss" scoped>
+:global(.notifications-management-modal-container) {
+  width: 1400px;
+  height: 786px;
+}
+
+.done-button{
+  position: absolute;
+  bottom: calc(var(--padding-large) + var(--padding));
+  right: calc(var(--padding-large) + var(--padding));
+}
+
+:global(.notifications-management-tab-view >.p-tabview-panels) {
+  min-height: 652px;
+}
+
+.p-tabview {
+  margin-top: var(--padding-large);
+}
+
+</style>

--- a/frontend/components/dashboard/notifications/NotificationsManagementModal.vue
+++ b/frontend/components/dashboard/notifications/NotificationsManagementModal.vue
@@ -10,6 +10,9 @@ import {
 const { t: $t } = useI18n()
 
 const visible = defineModel<boolean>()
+
+const showInDevelopment = Boolean(useRuntimeConfig().public.showInDevelopment)
+
 </script>
 
 <template>
@@ -25,25 +28,25 @@ const visible = defineModel<boolean>()
         </template>
         General coming soon!
       </TabPanel>
-      <TabPanel>
+      <TabPanel :disabled="!showInDevelopment">
         <template #header>
           <BcTabHeader :header="$t('dashboard.notifications.management.tabs.dashboards')" :icon="faGaugeSimpleMax" />
         </template>
         Dashboards coming soon!
       </TabPanel>
-      <TabPanel>
+      <TabPanel :disabled="!showInDevelopment">
         <template #header>
           <BcTabHeader :header="$t('dashboard.notifications.management.tabs.machines')" :icon="faMonitorWaveform" />
         </template>
         Machines coming soon!
       </TabPanel>
-      <TabPanel>
+      <TabPanel :disabled="!showInDevelopment">
         <template #header>
           <BcTabHeader :header="$t('dashboard.notifications.management.tabs.clients')" :icon="faBolt" />
         </template>
         Clients coming soon!
       </TabPanel>
-      <TabPanel>
+      <TabPanel :disabled="!showInDevelopment">
         <template #header>
           <BcTabHeader :header="$t('dashboard.notifications.management.tabs.rocketpool')">
             <template #icon>
@@ -53,7 +56,7 @@ const visible = defineModel<boolean>()
         </template>
         Rocket Pool coming soon!
       </TabPanel>
-      <TabPanel>
+      <TabPanel :disabled="!showInDevelopment">
         <template #header>
           <BcTabHeader :header="$t('dashboard.notifications.management.tabs.network')" :icon="faNetworkWired" />
         </template>

--- a/frontend/components/dashboard/notifications/NotificationsManagementModal.vue
+++ b/frontend/components/dashboard/notifications/NotificationsManagementModal.vue
@@ -60,7 +60,7 @@ const visible = defineModel<boolean>()
         Network coming soon!
       </TabPanel>
     </TabView>
-    <Button class="done-button" label="Done" />
+    <Button class="done-button" :label="$t('navigation.done')" @click="visible=false" />
   </BcDialog>
 </template>
 
@@ -70,18 +70,18 @@ const visible = defineModel<boolean>()
   height: 786px;
 }
 
-.done-button{
-  position: absolute;
-  bottom: calc(var(--padding-large) + var(--padding));
-  right: calc(var(--padding-large) + var(--padding));
-}
-
 :global(.notifications-management-tab-view >.p-tabview-panels) {
   min-height: 652px;
 }
 
 .p-tabview {
   margin-top: var(--padding-large);
+}
+
+.done-button{
+  position: absolute;
+  bottom: calc(var(--padding-large) + var(--padding));
+  right: calc(var(--padding-large) + var(--padding));
 }
 
 </style>

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -301,7 +301,6 @@
     "account_dashboard": "Account Dashboard",
     "public_validator_dashboard": "Dashboard",
     "public_account_dashboard": "Dashboard",
-    "notifications": "Notifications",
     "share": "Share",
     "shared": "Shared",
     "share_dashboard": "Share Dashboard",
@@ -566,6 +565,20 @@
           "result": "Result",
           "rewards": "Rewards",
           "validator": "Validator"
+        }
+      }
+    },
+    "notifications": {
+      "title": "Notifications",
+      "management": {
+        "title": "Manage Notifications",
+        "tabs": {
+          "general": "General",
+          "dashboards": "Dashboards",
+          "machines": "Machines",
+          "clients": "Clients",
+          "rocketpool": "Rocket Pool",
+          "network": "Network"
         }
       }
     }

--- a/frontend/pages/notifications.vue
+++ b/frontend/pages/notifications.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import {
-  faUser,
+  faGaugeSimpleMax,
   faMonitorWaveform,
   faBolt,
   faNetworkWired
 } from '@fortawesome/pro-solid-svg-icons'
 import { BcDialogConfirm } from '#components'
 import type { HashTabs } from '~/types/hashTabs'
+import NotificationsManagementModal from '~/components/dashboard/notifications/NotificationsManagementModal.vue'
 
 useDashboardKeyProvider('notifications')
 const { refreshDashboards } = useUserDashboardStore()
@@ -17,6 +18,8 @@ const { t: $t } = useI18n()
 await useAsyncData('user_dashboards', () => refreshDashboards(), { watch: [isLoggedIn] })
 
 const showInDevelopment = Boolean(useRuntimeConfig().public.showInDevelopment)
+
+const manageNotificationsModalVisisble = ref(false)
 
 const tabs: HashTabs = {
   dashboards: {
@@ -60,7 +63,7 @@ const openManageNotifications = () => {
       }
     })
   } else {
-    alert('TODO: Open Manage Notifications')
+    manageNotificationsModalVisisble.value = true
   }
 }
 
@@ -75,13 +78,14 @@ const openManageNotifications = () => {
           TODO: Overview
         </div>
       </template>
+      <NotificationsManagementModal v-model="manageNotificationsModalVisisble" />
       <div class="button-row">
         <Button :label="$t('notifications.manage')" @click="openManageNotifications" />
       </div>
       <TabView lazy class="notifications-tab-view" :active-index="activeIndex" @update:active-index="setActiveIndex">
         <TabPanel>
           <template #header>
-            <BcTabHeader :header="$t('notifications.tabs.dashboards')" :icon="faUser" />
+            <BcTabHeader :header="$t('notifications.tabs.dashboards')" :icon="faGaugeSimpleMax" />
           </template>
           <div>TODO: Dashboards Table</div>
         </TabPanel>


### PR DESCRIPTION
This PR
* Adds a draft for the "Manage Notifications" modal and opens it when the user clicks the "Manage Notifications" button
* Fixes the "Dashboard" icon used on `/notifications`