### PR TITLE
redirect validator dashboard with query params

### DIFF
--- a/frontend/composables/useDashboardKeyProvider.ts
+++ b/frontend/composables/useDashboardKeyProvider.ts
@@ -2,7 +2,7 @@ import { pullAll, union } from 'lodash-es'
 import { provide, warn } from 'vue'
 import { COOKIE_KEY } from '~/types/cookie'
 import type { DashboardKey, DashboardKeyData, DashboardType } from '~/types/dashboard'
-import { isPublicKey, isSharedKey } from '~/utils/dashboard/key'
+import { isPublicDashboardKey, isSharedKey } from '~/utils/dashboard/key'
 export function useDashboardKeyProvider (type: DashboardType = 'validator', mockKey: DashboardKey = '') {
   const route = useRoute()
   const router = useRouter()
@@ -33,7 +33,7 @@ export function useDashboardKeyProvider (type: DashboardType = 'validator', mock
         return
       }
       // only use the dashboard cookie key as default if you are not logged in and it's not private
-      if (!isLoggedIn.value && isPublicKey(dashboardKeyCookie.value) && !isSharedKey(dashboardKeyCookie.value)) {
+      if (!isLoggedIn.value && isPublicDashboardKey(dashboardKeyCookie.value) && !isSharedKey(dashboardKeyCookie.value)) {
         setDashboardKey(`${dashboardKeyCookie.value}`)
       }
       return
@@ -47,7 +47,7 @@ export function useDashboardKeyProvider (type: DashboardType = 'validator', mock
   initialCheck()
 
   const isPublic = computed(() => {
-    return isPublicKey(dashboardKey.value)
+    return isPublicDashboardKey(dashboardKey.value)
   })
 
   const isShared = computed(() => {

--- a/frontend/middleware/redirect.global.ts
+++ b/frontend/middleware/redirect.global.ts
@@ -1,6 +1,6 @@
 import type { RouteLocationNormalizedLoaded } from 'vue-router'
 
-export default function ({ name, params }: RouteLocationNormalizedLoaded) {
+export default function ({ name, params, query }: RouteLocationNormalizedLoaded) {
   const config = useRuntimeConfig()
   const showInDevelopment = Boolean(config.public.showInDevelopment)
   const v1Domain = config.public.v1Domain || 'https://beaconcha.in'
@@ -36,6 +36,18 @@ export default function ({ name, params }: RouteLocationNormalizedLoaded) {
         `${v1Domain}/address/${params.id || params.slug?.[1]}`,
         { external: true }
       )
+    case 'dashboard':
+    case 'dashboard-id':
+      if (query.validators && typeof query.validators === 'string') {
+        const list = query.validators.split(',').filter((v) => {
+          return !isNaN(parseInt(v)) || isPublicKey(v)
+        }).slice(0, 20).join(',')
+        if (list.length) {
+          const hash = toBase64Url(list)
+          return navigateTo(`/dashboard/${hash}`)
+        }
+      }
+      break
     case 'validator-id':
     case 'validator':
       return navigateTo(

--- a/frontend/middleware/redirect.global.ts
+++ b/frontend/middleware/redirect.global.ts
@@ -40,7 +40,7 @@ export default function ({ name, params, query }: RouteLocationNormalizedLoaded)
     case 'dashboard-id':
       if (query.validators && typeof query.validators === 'string') {
         const list = query.validators.split(',').filter((v) => {
-          return !isNaN(parseInt(v)) || isPublicKey(v)
+          return isInt(v) || isPublicKey(v)
         }).slice(0, 20).join(',')
         if (list.length) {
           const hash = toBase64Url(list)

--- a/frontend/pages/dashboard/[[id]]/index.vue
+++ b/frontend/pages/dashboard/[[id]]/index.vue
@@ -11,7 +11,7 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { DashboardCreationController } from '#components'
 import type { CookieDashboard } from '~/types/dashboard'
-import { isPublicKey } from '~/utils/dashboard/key'
+import { isPublicDashboardKey } from '~/utils/dashboard/key'
 import type { HashTabs } from '~/types/hashTabs'
 
 const { isLoggedIn } = useUserStore()
@@ -80,7 +80,7 @@ watch([dashboardKey, isLoggedIn], ([newKey, newLoggedIn], [oldKey]) => {
   if (!newLoggedIn || !newKey) {
     // Some checks if we need to update the dashboard key or the public dashboard
     let cd = dashboards.value?.validator_dashboards?.[0] as CookieDashboard
-    const isPublic = isPublicKey(newKey)
+    const isPublic = isPublicDashboardKey(newKey)
     if (newLoggedIn) {
       // if we are logged in and have no dashboard key we only want to switch to the first dashboard if it is a private one
       if (cd && !cd.hash) {

--- a/frontend/utils/dashboard/key.ts
+++ b/frontend/utils/dashboard/key.ts
@@ -1,4 +1,4 @@
-export function isPublicKey (value?: string): boolean {
+export function isPublicDashboardKey (value?: string): boolean {
   if (!value) {
     return true
   }

--- a/frontend/utils/ether.ts
+++ b/frontend/utils/ether.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
+import { REGEXP_PUBLIC_KEX } from './regexp'
 
 export const OneGwei = BigNumber.from('1000000000')
 export const OneEther = BigNumber.from('1000000000000000000')
@@ -9,4 +10,8 @@ export function lessThanGwei (value: BigNumber, decimals: number = 0): boolean {
 
 export function lessThanEth (value: BigNumber, decimals: number = 0): boolean {
   return value.lt(OneEther.div(Math.pow(10, decimals)))
+}
+
+export function isPublicKey (value: string):boolean {
+  return !!value && REGEXP_PUBLIC_KEX.test(value)
 }

--- a/frontend/utils/misc.ts
+++ b/frontend/utils/misc.ts
@@ -33,3 +33,11 @@ export function generateUUID () {
       return v.toString(16)
     })
 }
+
+export function isInt (value?: string): boolean {
+  if (!value) {
+    return false
+  }
+  const parsed = parseInt(value)
+  return !isNaN(parsed) && `${parsed}` === value
+}

--- a/frontend/utils/regexp.ts
+++ b/frontend/utils/regexp.ts
@@ -4,4 +4,4 @@ export const REGEXP_VALID_EMAIL = /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&
 
 export const REGEXP_VALID_NAME = /^(?=.*[a-zA-Z0-9])[a-zA-Z0-9 ]*$/
 
-export const REGEXP_PUBLIC_KEX = /^(1|3)[A-Za-z0-9]{39}$/
+export const REGEXP_PUBLIC_KEX = /^(0x)?[A-Fa-f0-9]{96}$/

--- a/frontend/utils/regexp.ts
+++ b/frontend/utils/regexp.ts
@@ -3,3 +3,5 @@ export const REGEXP_HAS_NUMBERS = /^(?!0+$)\d+$/
 export const REGEXP_VALID_EMAIL = /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/i
 
 export const REGEXP_VALID_NAME = /^(?=.*[a-zA-Z0-9])[a-zA-Z0-9 ]*$/
+
+export const REGEXP_PUBLIC_KEX = /^(1|3)[A-Za-z0-9]{39}$/


### PR DESCRIPTION
This PR:
- implements redirecting of the validator dashboard if the validator list comes as query params

Example:
/dashboard?validators=5,0x832b8286f5d6535fd941c6c4ed8b9b20d214fc6aa726ce4fba1c9dbb4f278132646304f550e557231b6932aa02cf08d3
-> /dashboard/NSwweDgzMmI4Mjg2ZjVkNjUzNWZkOTQxYzZjNGVkOGI5YjIwZDIxNGZjNmFhNzI2Y2U0ZmJhMWM5ZGJiNGYyNzgxMzI2NDYzMDRmNTUwZTU1NzIzMWI2OTMyYWEwMmNmMDhkMw#summary