### PR TITLE
Bids 3186/pricing adaptations

### DIFF
--- a/frontend/components/pricing/PremiumCompare.vue
+++ b/frontend/components/pricing/PremiumCompare.vue
@@ -16,7 +16,7 @@ type CompareValue = {
   class?: string
 }
 
-type RowType = 'header' | 'group' | 'perc'
+type RowType = 'header' | 'group' | 'perc' | 'label'
 
 type CompareRow = {
   type: RowType,
@@ -36,10 +36,15 @@ const rows = computed(() => {
       return { value: perks.ad_free }
     }
     let value = get(perks, property)
-    if (value === 0) {
+
+    if (!value) {
       value = false
     } else if (property.includes('_seconds')) {
-      value = formatTimeDuration(value as number, $t)
+      if (value === Number.MAX_SAFE_INTEGER) {
+        value = $t('pricing.full_history')
+      } else {
+        value = formatTimeDuration(value as number, $t)
+      }
     }
 
     let tooltip: string | undefined
@@ -52,7 +57,7 @@ const rows = computed(() => {
       tooltip
     }
   }
-  const addRow = (type: RowType, property?: string, className?: string, subText?: string, hidePositiveValues = false) => {
+  const addRow = (type: RowType, property?: string, className?: string, subText?: string, hidePositiveValues = false, translationKey?: string) => {
     const row: CompareRow = { type, subText, className }
     switch (type) {
       case 'header':
@@ -62,8 +67,12 @@ const rows = computed(() => {
         row.label = $t(`pricing.groups.${property}`)
         row.values = sorted.map(_p => ({}))
         break
+      case 'label':
+        row.label = $t(translationKey || `pricing.percs.${property}`)
+        row.values = sorted.map(_p => ({}))
+        break
       case 'perc':
-        row.label = $t(`pricing.percs.${property}`)
+        row.label = $t(translationKey || `pricing.percs.${property}`)
         row.values = sorted.map((p) => {
           if (!property) {
             return {}
@@ -94,13 +103,18 @@ const rows = computed(() => {
   addRow('perc', 'validator_groups_per_dashboard')
   addRow('perc', 'share_custom_dashboards')
   addRow('perc', 'manage_dashboard_via_api', undefined, comingSoon)
-  addRow('perc', 'bulk_adding', undefined, $t('pricing.percs.bulk_adding_subtext'))
-  addRow('perc', 'heatmap_history_seconds', undefined, undefined, !showInDevelopment)
-  addRow('perc', 'summary_chart_history_seconds', 'last-in-group', undefined, !showInDevelopment)
+  addRow('perc', 'bulk_adding', 'last-in-group', $t('pricing.percs.bulk_adding_subtext'))
+  addRow('group', 'dashboard_charts')
+  addRow('label', 'summary_chart_history', 'first-in-group')
+  const chartProps = ['epoch', 'hourly', 'daily', 'weekly']
+  chartProps.forEach(p => addRow('perc', `chart_history_seconds.${p}`, undefined, undefined, undefined, `time_frames.${p}`))
+
+  addRow('label', 'heatmap_history', 'last-in-group', comingSoon)
 
   addRow('group', 'notification', undefined, showInDevelopment ? undefined : comingSoon)
   addRow('perc', 'email_notifications_per_day', 'first-in-group', undefined, !showInDevelopment)
   addRow('perc', 'configure_notifications_via_api')
+
   addRow('perc', 'validator_group_notifications', undefined, undefined, !showInDevelopment)
   addRow('perc', 'webhook_endpoints', 'last-in-group', undefined, !showInDevelopment)
 
@@ -207,6 +221,7 @@ const rows = computed(() => {
       min-width: fit-content;
       border-left: 1px solid transparent;
 
+      &.label,
       &.header,
       &.group {
         font-size: 18px;
@@ -221,6 +236,7 @@ const rows = computed(() => {
         }
       }
 
+      &.label,
       &.perc {
         min-height: 36px;
       }

--- a/frontend/components/pricing/PremiumCompare.vue
+++ b/frontend/components/pricing/PremiumCompare.vue
@@ -43,7 +43,7 @@ const rows = computed(() => {
       if (value === Number.MAX_SAFE_INTEGER) {
         value = $t('pricing.full_history')
       } else {
-        value = formatTimeDuration(value as number, $t)
+        value = $t('common.last_x', { duration: formatTimeDuration(value as number, $t) })
       }
     }
 

--- a/frontend/components/pricing/PremiumProductBox.vue
+++ b/frontend/components/pricing/PremiumProductBox.vue
@@ -50,8 +50,8 @@ const percentages = computed(() => {
   return {
     validatorDashboards: props.product.premium_perks.validator_dashboards / (bestProduct.premium_perks.validator_dashboards) * 100,
     validatorsPerDashboard: props.product.premium_perks.validators_per_dashboard / (bestProduct.premium_perks.validators_per_dashboard) * 100,
-    summaryChart: props.product.premium_perks.summary_chart_history_seconds / (bestProduct.premium_perks.summary_chart_history_seconds) * 100,
-    heatmapChart: props.product.premium_perks.heatmap_history_seconds / (bestProduct.premium_perks.heatmap_history_seconds) * 100
+    summaryChart: props.product.premium_perks.chart_history_seconds.hourly / (bestProduct.premium_perks.chart_history_seconds.hourly) * 100,
+    heatmapChart: props.product.premium_perks.chart_history_seconds.hourly / (bestProduct.premium_perks.chart_history_seconds.hourly) * 100
   }
 })
 

--- a/frontend/components/pricing/PremiumProductBox.vue
+++ b/frontend/components/pricing/PremiumProductBox.vue
@@ -46,12 +46,16 @@ const percentages = computed(() => {
   }
 
   const bestProduct = bestPremiumProduct.value
-
+  let chartPercent = 1
+  // TODO: remove check for chart_history_seconds once the API is live
+  if (props.product.premium_perks.chart_history_seconds) {
+    chartPercent = props.product.premium_perks.chart_history_seconds.hourly / (bestProduct.premium_perks.chart_history_seconds.hourly) * 100
+  }
   return {
     validatorDashboards: props.product.premium_perks.validator_dashboards / (bestProduct.premium_perks.validator_dashboards) * 100,
     validatorsPerDashboard: props.product.premium_perks.validators_per_dashboard / (bestProduct.premium_perks.validators_per_dashboard) * 100,
-    summaryChart: props.product.premium_perks.chart_history_seconds.hourly / (bestProduct.premium_perks.chart_history_seconds.hourly) * 100,
-    heatmapChart: props.product.premium_perks.chart_history_seconds.hourly / (bestProduct.premium_perks.chart_history_seconds.hourly) * 100
+    summaryChart: chartPercent,
+    heatmapChart: chartPercent
   }
 })
 

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -14,6 +14,7 @@
     "in_day": "In one day | In {count} days",
     "every_day": "Every day | Every {count} days",
     "every_x": "Every {duration}",
+    "last_x": "Last {duration}",
     "id": "ID",
     "average": "Average",
     "index": "Index",

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -132,7 +132,11 @@
     "last_24h": "Last 24h",
     "last_7d": "Last 7d",
     "last_30d": "Last 30d",
-    "all_time": "All time"
+    "all_time": "All time",
+    "epoch": "Epoch",
+    "hourly": "Hourly",
+    "daily": "Daily",
+    "weekly": "Weekly"
   },
   "statistics": {
     "last_24h": "24h",
@@ -737,6 +741,7 @@
     "per_validator": "{amount} per validator",
     "pectra_tooltip": "After Pectra hardfork: {effectiveBalance} ETH maximum effective balance",
     "get_started": "Get started now",
+    "full_history": "Full history",
     "premium_via_app_banner": "You have an active premium subscription from the App Store / Play Store. You can manage your active subscriptions from there.",
     "premium_product": {
       "popular": "Popular!",
@@ -763,7 +768,8 @@
       "general": "General",
       "dashboard": "Dashboard",
       "notification": "v2 Notification",
-      "mobille_app": "Mobile App"
+      "mobille_app": "Mobile App",
+      "dashboard_charts": "Validator Dashboard Charts"
     },
     "percs": {
       "ad_free": "Ad free",
@@ -775,8 +781,8 @@
       "manage_dashboard_via_api": "Manage dashboard via API",
       "bulk_adding": "Bulk adding",
       "bulk_adding_subtext": "(deposit address, withdrawal credentials, graffiti)",
-      "heatmap_history_seconds": "Heatmap history",
-      "summary_chart_history_seconds": "Summary chart history",
+      "heatmap_history": "Heatmap history",
+      "summary_chart_history": "Summary chart history",
       "email_notifications_per_day": "Email notifications per day",
       "configure_notifications_via_api": "Configure notifications via API",
       "validator_group_notifications": "Validator group notifications",


### PR DESCRIPTION
This PR,
based on [PR 539](https://github.com/gobitfly/beaconchain/pull/539)
- adapts the new API Chart Types for the pricing page. 

Note for tester: 
- the new API is not deployed yet so you will not see valid data for the chart props
- the heatmap part is reduced to the label with coming soon (compared to the Figma file) 
- values >= 1 day and < 1 year will be displayed in days (compared to the Figma file)