### PR TITLE
BIDS-3208/dashboard notifications backend

### DIFF
--- a/backend/pkg/commons/db/bigtable.go
+++ b/backend/pkg/commons/db/bigtable.go
@@ -194,7 +194,7 @@ func (bigtable *Bigtable) GetClient() *gcp_bigtable.Client {
 	return bigtable.client
 }
 
-func (bigtable *Bigtable) SaveMachineMetric(process string, userID uint64, machine string, data []byte) error {
+func (bigtable *Bigtable) SaveMachineMetric(process string, userID types.UserId, machine string, data []byte) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 
@@ -234,7 +234,7 @@ func (bigtable *Bigtable) SaveMachineMetric(process string, userID uint64, machi
 	return nil
 }
 
-func (bigtable Bigtable) getMachineMetricNamesMap(userID uint64, searchDepth int) (map[string]bool, error) {
+func (bigtable Bigtable) getMachineMetricNamesMap(userID types.UserId, searchDepth int) (map[string]bool, error) {
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Second*30))
 	defer cancel()
 
@@ -265,7 +265,7 @@ func (bigtable Bigtable) getMachineMetricNamesMap(userID uint64, searchDepth int
 	return machineNames, nil
 }
 
-func (bigtable Bigtable) GetMachineMetricsMachineNames(userID uint64) ([]string, error) {
+func (bigtable Bigtable) GetMachineMetricsMachineNames(userID types.UserId) ([]string, error) {
 	tmr := time.AfterFunc(REPORT_TIMEOUT, func() {
 		log.WarnWithFields(log.Fields{
 			"userId":   userID,
@@ -288,7 +288,7 @@ func (bigtable Bigtable) GetMachineMetricsMachineNames(userID uint64) ([]string,
 	return result, nil
 }
 
-func (bigtable Bigtable) GetMachineMetricsMachineCount(userID uint64) (uint64, error) {
+func (bigtable Bigtable) GetMachineMetricsMachineCount(userID types.UserId) (uint64, error) {
 	tmr := time.AfterFunc(REPORT_TIMEOUT, func() {
 		log.WarnWithFields(log.Fields{
 			"userId":   userID,
@@ -310,7 +310,7 @@ func (bigtable Bigtable) GetMachineMetricsMachineCount(userID uint64) (uint64, e
 	return uint64(card), nil
 }
 
-func (bigtable Bigtable) GetMachineMetricsNode(userID uint64, limit, offset int) ([]*types.MachineMetricNode, error) {
+func (bigtable Bigtable) GetMachineMetricsNode(userID types.UserId, limit, offset int) ([]*types.MachineMetricNode, error) {
 	tmr := time.AfterFunc(REPORT_TIMEOUT, func() {
 		log.WarnWithFields(log.Fields{
 			"userId":   userID,
@@ -335,7 +335,7 @@ func (bigtable Bigtable) GetMachineMetricsNode(userID uint64, limit, offset int)
 	)
 }
 
-func (bigtable Bigtable) GetMachineMetricsValidator(userID uint64, limit, offset int) ([]*types.MachineMetricValidator, error) {
+func (bigtable Bigtable) GetMachineMetricsValidator(userID types.UserId, limit, offset int) ([]*types.MachineMetricValidator, error) {
 	tmr := time.AfterFunc(REPORT_TIMEOUT, func() {
 		log.WarnWithFields(log.Fields{
 			"userId":   userID,
@@ -360,7 +360,7 @@ func (bigtable Bigtable) GetMachineMetricsValidator(userID uint64, limit, offset
 	)
 }
 
-func (bigtable Bigtable) GetMachineMetricsSystem(userID uint64, limit, offset int) ([]*types.MachineMetricSystem, error) {
+func (bigtable Bigtable) GetMachineMetricsSystem(userID types.UserId, limit, offset int) ([]*types.MachineMetricSystem, error) {
 	tmr := time.AfterFunc(REPORT_TIMEOUT, func() {
 		log.WarnWithFields(log.Fields{
 			"userId":   userID,
@@ -385,7 +385,7 @@ func (bigtable Bigtable) GetMachineMetricsSystem(userID uint64, limit, offset in
 	)
 }
 
-func getMachineMetrics[T types.MachineMetricSystem | types.MachineMetricNode | types.MachineMetricValidator](bigtable Bigtable, process string, userID uint64, limit, offset int, marshler func(data []byte, machine string) *T) ([]*T, error) {
+func getMachineMetrics[T types.MachineMetricSystem | types.MachineMetricNode | types.MachineMetricValidator](bigtable Bigtable, process string, userID types.UserId, limit, offset int, marshler func(data []byte, machine string) *T) ([]*T, error) {
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Second*30))
 	defer cancel()
 
@@ -429,7 +429,7 @@ func getMachineMetrics[T types.MachineMetricSystem | types.MachineMetricNode | t
 	return res, nil
 }
 
-func (bigtable Bigtable) GetMachineRowKey(userID uint64, process string, machine string) string {
+func (bigtable Bigtable) GetMachineRowKey(userID types.UserId, process string, machine string) string {
 	return fmt.Sprintf("u:%s:p:%s:m:%s", bigtable.reversePaddedUserID(userID), process, machine)
 }
 
@@ -437,7 +437,7 @@ func (bigtable Bigtable) GetMachineRowKey(userID uint64, process string, machine
 // machineData contains the latest machine data in CurrentData
 // and 5 minute old data in fiveMinuteOldData (defined in limit)
 // as well as the insert timestamps of both
-func (bigtable Bigtable) GetMachineMetricsForNotifications(rowKeys gcp_bigtable.RowList) (map[uint64]map[string]*types.MachineMetricSystemUser, error) {
+func (bigtable Bigtable) GetMachineMetricsForNotifications(rowKeys gcp_bigtable.RowList) (map[types.UserId]map[string]*types.MachineMetricSystemUser, error) {
 	tmr := time.AfterFunc(REPORT_TIMEOUT, func() {
 		log.WarnWithFields(log.Fields{
 			"rowKeys":  rowKeys,
@@ -449,7 +449,7 @@ func (bigtable Bigtable) GetMachineMetricsForNotifications(rowKeys gcp_bigtable.
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Second*200))
 	defer cancel()
 
-	res := make(map[uint64]map[string]*types.MachineMetricSystemUser) // userID -> machine -> data
+	res := make(map[types.UserId]map[string]*types.MachineMetricSystemUser) // userID -> machine -> data
 
 	limit := 5
 
@@ -509,7 +509,7 @@ func (bigtable Bigtable) GetMachineMetricsForNotifications(rowKeys gcp_bigtable.
 }
 
 //nolint:unparam
-func machineMetricRowParts(r string) (bool, uint64, string, string) {
+func machineMetricRowParts(r string) (bool, types.UserId, string, string) {
 	keySplit := strings.Split(r, ":")
 
 	userID, err := strconv.ParseUint(keySplit[1], 10, 64)
@@ -526,7 +526,7 @@ func machineMetricRowParts(r string) (bool, uint64, string, string) {
 
 	process := keySplit[3]
 
-	return true, userID, machine, process
+	return true, types.UserId(userID), machine, process
 }
 
 func (bigtable *Bigtable) SaveValidatorBalances(epoch uint64, validators []*types.Validator) error {
@@ -2678,8 +2678,8 @@ func GetCurrentDayClIncome(validator_indices []uint64) (map[uint64]int64, error)
 	return dayIncome, nil
 }
 
-func (bigtable *Bigtable) reversePaddedUserID(userID uint64) string {
-	return fmt.Sprintf("%09d", ^uint64(0)-userID)
+func (bigtable *Bigtable) reversePaddedUserID(userID types.UserId) string {
+	return fmt.Sprintf("%09d", ^uint64(0)-uint64(userID))
 }
 
 func (bigtable *Bigtable) reversedPaddedEpoch(epoch uint64) string {

--- a/backend/pkg/commons/types/frontend.go
+++ b/backend/pkg/commons/types/frontend.go
@@ -20,6 +20,8 @@ import (
 )
 
 type EventName string
+type EventFilter string
+type NotificationsPerUserId map[UserId]map[EventName]map[EventFilter]Notification
 
 const (
 	ValidatorBalanceDecreasedEventName               EventName = "validator_balance_decreased"

--- a/backend/pkg/commons/types/frontend.go
+++ b/backend/pkg/commons/types/frontend.go
@@ -41,7 +41,7 @@ func (npui NotificationsPerUserId) AddNotification(n Notification) {
 		npui[n.GetUserId()] = make(map[EventName]map[EventFilter]Notification)
 	}
 	if _, ok := npui[n.GetUserId()][n.GetEventName()]; !ok {
-		npui[n.GetUserId()][EventName(n.GetEventFilter())] = make(map[EventFilter]Notification)
+		npui[n.GetUserId()][n.GetEventName()] = make(map[EventFilter]Notification)
 	}
 	npui[n.GetUserId()][n.GetEventName()][EventFilter(n.GetEventFilter())] = n
 }
@@ -344,7 +344,7 @@ func (n NotificationBaseImpl) GetUserId() UserId {
 type Subscription struct {
 	ID          *uint64    `db:"id,omitempty"`
 	UserID      *UserId    `db:"user_id,omitempty"`
-	EventName   string     `db:"event_name"`
+	EventName   EventName  `db:"event_name"`
 	EventFilter string     `db:"event_filter"`
 	LastSent    *time.Time `db:"last_sent_ts"`
 	LastEpoch   *uint64    `db:"last_sent_epoch"`

--- a/backend/pkg/commons/types/frontend.go
+++ b/backend/pkg/commons/types/frontend.go
@@ -279,6 +279,67 @@ type Notification interface {
 	GetUserId() UserId
 }
 
+type NotificationBaseImpl struct {
+	LatestState     string
+	SubscriptionID  uint64
+	EventName       EventName
+	Epoch           uint64
+	Info            string
+	Title           string
+	EventFilter     string
+	EmailAttachment *EmailAttachment
+	UnsubscribeHash sql.NullString
+	InfoMarkdown    string
+	UserID          UserId
+}
+
+func (n NotificationBaseImpl) GetLatestState() string {
+	return n.LatestState
+}
+
+func (n NotificationBaseImpl) GetSubscriptionID() uint64 {
+	return n.SubscriptionID
+}
+
+func (n NotificationBaseImpl) GetEventName() EventName {
+	return n.EventName
+}
+
+func (n NotificationBaseImpl) GetEpoch() uint64 {
+	return n.Epoch
+}
+
+func (n NotificationBaseImpl) GetInfo(includeUrl bool) string {
+	return n.Info
+}
+
+func (n NotificationBaseImpl) GetTitle() string {
+	return n.Title
+}
+
+func (n NotificationBaseImpl) GetEventFilter() string {
+	return n.EventFilter
+}
+
+func (n NotificationBaseImpl) GetEmailAttachment() *EmailAttachment {
+	return n.EmailAttachment
+}
+
+func (n NotificationBaseImpl) GetUnsubscribeHash() string {
+	if n.UnsubscribeHash.Valid {
+		return n.UnsubscribeHash.String
+	}
+	return ""
+}
+
+func (n NotificationBaseImpl) GetInfoMarkdown() string {
+	return n.InfoMarkdown
+}
+
+func (n NotificationBaseImpl) GetUserId() UserId {
+	return n.UserID
+}
+
 // func UnMarschal
 
 type Subscription struct {

--- a/backend/pkg/commons/types/frontend.go
+++ b/backend/pkg/commons/types/frontend.go
@@ -27,7 +27,6 @@ type EventFilter string
 type NotificationsPerUserId map[UserId]map[EventName]map[EventFilter]Notification
 
 func (npui NotificationsPerUserId) AddNotification(n Notification) {
-
 	if n.GetUserId() == 0 {
 		log.Fatal(fmt.Errorf("Notification user id is 0"), fmt.Sprintf("Notification: %v", n), 0)
 	}

--- a/backend/pkg/commons/types/frontend.go
+++ b/backend/pkg/commons/types/frontend.go
@@ -266,6 +266,22 @@ type Subscription struct {
 	EventThreshold  float64        `db:"event_threshold"`
 	UnsubscribeHash sql.NullString `db:"unsubscribe_hash" swaggertype:"string"`
 	State           sql.NullString `db:"internal_state" swaggertype:"string"`
+	GroupId         *uint32
+	DashboardId     *uint32
+}
+
+type ValidatorDashboardConfig struct {
+	DashboardsByUserId map[uint64]map[uint32]*ValidatorDashboard
+}
+
+type ValidatorDashboard struct {
+	Name   string `db:"name"`
+	Groups map[uint32]*ValidatorDashboardGroup
+}
+
+type ValidatorDashboardGroup struct {
+	Name       string `db:"name"`
+	Validators [][]byte
 }
 
 type TaggedValidators struct {

--- a/backend/pkg/commons/types/frontend.go
+++ b/backend/pkg/commons/types/frontend.go
@@ -273,7 +273,6 @@ type Notification interface {
 	GetTitle() string
 	GetEventFilter() string
 	GetEmailAttachment() *EmailAttachment
-	GetUnsubscribeHash() string
 	GetInfoMarkdown() string
 	GetUserId() UserId
 }
@@ -287,7 +286,6 @@ type NotificationBaseImpl struct {
 	Title           string
 	EventFilter     string
 	EmailAttachment *EmailAttachment
-	UnsubscribeHash sql.NullString
 	InfoMarkdown    string
 	UserID          UserId
 }
@@ -324,13 +322,6 @@ func (n NotificationBaseImpl) GetEmailAttachment() *EmailAttachment {
 	return n.EmailAttachment
 }
 
-func (n NotificationBaseImpl) GetUnsubscribeHash() string {
-	if n.UnsubscribeHash.Valid {
-		return n.UnsubscribeHash.String
-	}
-	return ""
-}
-
 func (n NotificationBaseImpl) GetInfoMarkdown() string {
 	return n.InfoMarkdown
 }
@@ -349,13 +340,12 @@ type Subscription struct {
 	LastSent    *time.Time `db:"last_sent_ts"`
 	LastEpoch   *uint64    `db:"last_sent_epoch"`
 	// Channels        pq.StringArray `db:"channels"`
-	CreatedTime     time.Time      `db:"created_ts"`
-	CreatedEpoch    uint64         `db:"created_epoch"`
-	EventThreshold  float64        `db:"event_threshold"`
-	UnsubscribeHash sql.NullString `db:"unsubscribe_hash" swaggertype:"string"`
-	State           sql.NullString `db:"internal_state" swaggertype:"string"`
-	GroupId         *int64
-	DashboardId     *int64
+	CreatedTime    time.Time      `db:"created_ts"`
+	CreatedEpoch   uint64         `db:"created_epoch"`
+	EventThreshold float64        `db:"event_threshold"`
+	State          sql.NullString `db:"internal_state" swaggertype:"string"`
+	GroupId        *int64
+	DashboardId    *int64
 }
 
 type UserId uint64
@@ -562,7 +552,6 @@ type Email struct {
 	Title                 string
 	Body                  template.HTML
 	SubscriptionManageURL template.HTML
-	UnsubURL              template.HTML
 }
 
 type UserWebhook struct {

--- a/backend/pkg/commons/types/frontend.go
+++ b/backend/pkg/commons/types/frontend.go
@@ -12,6 +12,7 @@ import (
 	"firebase.google.com/go/messaging"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/gobitfly/beaconchain/pkg/consapi/types"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
 	"golang.org/x/text/cases"
@@ -164,7 +165,7 @@ type EventNameDesc struct {
 }
 
 type MachineMetricSystemUser struct {
-	UserID                    uint64
+	UserID                    UserId
 	Machine                   string
 	CurrentData               *MachineMetricSystem
 	CurrentDataInsertTs       int64
@@ -255,7 +256,7 @@ type Notification interface {
 
 type Subscription struct {
 	ID          *uint64    `db:"id,omitempty"`
-	UserID      *uint64    `db:"user_id,omitempty"`
+	UserID      *UserId    `db:"user_id,omitempty"`
 	EventName   string     `db:"event_name"`
 	EventFilter string     `db:"event_filter"`
 	LastSent    *time.Time `db:"last_sent_ts"`
@@ -266,22 +267,25 @@ type Subscription struct {
 	EventThreshold  float64        `db:"event_threshold"`
 	UnsubscribeHash sql.NullString `db:"unsubscribe_hash" swaggertype:"string"`
 	State           sql.NullString `db:"internal_state" swaggertype:"string"`
-	GroupId         *uint32
-	DashboardId     *uint32
+	GroupId         *int64
+	DashboardId     *int64
 }
 
+type UserId uint64
+type DashboardId uint64
+type DashboardGroupId uint64
 type ValidatorDashboardConfig struct {
-	DashboardsByUserId map[uint64]map[uint32]*ValidatorDashboard
+	DashboardsByUserId map[UserId]map[DashboardId]*ValidatorDashboard
 }
 
 type ValidatorDashboard struct {
 	Name   string `db:"name"`
-	Groups map[uint32]*ValidatorDashboardGroup
+	Groups map[DashboardGroupId]*ValidatorDashboardGroup
 }
 
 type ValidatorDashboardGroup struct {
 	Name       string `db:"name"`
-	Validators [][]byte
+	Validators []types.ValidatorIndex
 }
 
 type TaggedValidators struct {

--- a/backend/pkg/notification/db.go
+++ b/backend/pkg/notification/db.go
@@ -38,7 +38,6 @@ func GetSubsForEventFilter(eventName types.EventName, lastSentFilter string, las
 		goqu.C("last_sent_epoch"),
 		goqu.C("created_epoch"),
 		goqu.C("event_threshold"),
-		goqu.L("ENCODE(unsubscribe_hash, 'hex') as unsubscribe_hash"),
 		goqu.C("internal_state"),
 	).Where(goqu.C("event_name").Eq(utils.GetNetwork() + ":" + string(eventName)))
 
@@ -68,15 +67,7 @@ func GetSubsForEventFilter(eventName types.EventName, lastSentFilter string, las
 		if _, ok := subMap[sub.EventFilter]; !ok {
 			subMap[sub.EventFilter] = make([]types.Subscription, 0)
 		}
-		subMap[sub.EventFilter] = append(subMap[sub.EventFilter], types.Subscription{
-			UserID:         sub.UserID,
-			ID:             sub.ID,
-			LastEpoch:      sub.LastEpoch,
-			EventFilter:    sub.EventFilter,
-			CreatedEpoch:   sub.CreatedEpoch,
-			EventThreshold: sub.EventThreshold,
-			State:          sub.State,
-		})
+		subMap[sub.EventFilter] = append(subMap[sub.EventFilter], sub)
 	}
 	return subMap, nil
 }

--- a/backend/pkg/notification/db.go
+++ b/backend/pkg/notification/db.go
@@ -40,14 +40,14 @@ func GetSubsForEventFilter(eventName types.EventName) (map[string][]types.Subscr
 	return subMap, nil
 }
 
-func GetUserPushTokenByIds(ids []uint64) (map[uint64][]string, error) {
-	pushByID := map[uint64][]string{}
+func GetUserPushTokenByIds(ids []types.UserId) (map[types.UserId][]string, error) {
+	pushByID := map[types.UserId][]string{}
 	if len(ids) == 0 {
 		return pushByID, nil
 	}
 	var rows []struct {
-		ID    uint64 `db:"user_id"`
-		Token string `db:"notification_token"`
+		ID    types.UserId `db:"user_id"`
+		Token string       `db:"notification_token"`
 	}
 
 	err := db.FrontendWriterDB.Select(&rows, "SELECT DISTINCT ON (user_id, notification_token) user_id, notification_token FROM users_devices WHERE (user_id = ANY($1) AND user_id NOT IN (SELECT user_id from users_notification_channels WHERE active = false and channel = $2)) AND notify_enabled = true AND active = true AND notification_token IS NOT NULL AND LENGTH(notification_token) > 20 ORDER BY user_id, notification_token, id DESC", pq.Array(ids), types.PushNotificationChannel)
@@ -67,14 +67,14 @@ func GetUserPushTokenByIds(ids []uint64) (map[uint64][]string, error) {
 }
 
 // GetUserEmailsByIds returns the emails of users.
-func GetUserEmailsByIds(ids []uint64) (map[uint64]string, error) {
-	mailsByID := map[uint64]string{}
+func GetUserEmailsByIds(ids []types.UserId) (map[types.UserId]string, error) {
+	mailsByID := map[types.UserId]string{}
 	if len(ids) == 0 {
 		return mailsByID, nil
 	}
 	var rows []struct {
-		ID    uint64 `db:"id"`
-		Email string `db:"email"`
+		ID    types.UserId `db:"id"`
+		Email string       `db:"email"`
 	}
 	//
 	err := db.FrontendWriterDB.Select(&rows, "SELECT id, email FROM users WHERE id = ANY($1) AND id NOT IN (SELECT user_id from users_notification_channels WHERE active = false and channel = $2)", pq.Array(ids), types.EmailNotificationChannel)

--- a/backend/pkg/notification/notifications.go
+++ b/backend/pkg/notification/notifications.go
@@ -1207,7 +1207,7 @@ func collectBlockProposalNotifications(notificationsByUserID map[uint64]map[type
 		ExecRewardETH float64
 	}
 
-	_, subMap, err := GetSubsForEventFilter(eventName)
+	subMap, err := GetSubsForEventFilter(eventName)
 	if err != nil {
 		return fmt.Errorf("error getting subscriptions for (missed) block proposals %w", err)
 	}
@@ -1394,7 +1394,7 @@ func (n *validatorProposalNotification) GetInfoMarkdown() string {
 }
 
 func collectAttestationAndOfflineValidatorNotifications(notificationsByUserID map[uint64]map[types.EventName][]types.Notification, epoch uint64) error {
-	_, subMap, err := GetSubsForEventFilter(types.ValidatorMissedAttestationEventName)
+	subMap, err := GetSubsForEventFilter(types.ValidatorMissedAttestationEventName)
 	if err != nil {
 		return fmt.Errorf("error getting subscriptions for missted attestations %w", err)
 	}
@@ -1573,7 +1573,7 @@ func collectAttestationAndOfflineValidatorNotifications(notificationsByUserID ma
 		return fmt.Errorf("retrieved more than %v online validators notifications: %v, exiting", onlineValidatorsLimit, len(onlineValidators))
 	}
 
-	_, subMap, err = GetSubsForEventFilter(types.ValidatorIsOfflineEventName)
+	subMap, err = GetSubsForEventFilter(types.ValidatorIsOfflineEventName)
 	if err != nil {
 		return fmt.Errorf("failed to get subs for %v: %v", types.ValidatorIsOfflineEventName, err)
 	}
@@ -2022,7 +2022,7 @@ func (n *validatorWithdrawalNotification) GetInfoMarkdown() string {
 // collectWithdrawalNotifications collects all notifications validator withdrawals
 func collectWithdrawalNotifications(notificationsByUserID map[uint64]map[types.EventName][]types.Notification, epoch uint64) error {
 	// get all users that are subscribed to this event (scale: a few thousand rows depending on how many users we have)
-	_, subMap, err := GetSubsForEventFilter(types.ValidatorReceivedWithdrawalEventName)
+	subMap, err := GetSubsForEventFilter(types.ValidatorReceivedWithdrawalEventName)
 	if err != nil {
 		return fmt.Errorf("error getting subscriptions for missed attestations %w", err)
 	}
@@ -2947,7 +2947,7 @@ func collectRocketpoolRewardClaimRoundNotifications(notificationsByUserID map[ui
 }
 
 func collectRocketpoolRPLCollateralNotifications(notificationsByUserID map[uint64]map[types.EventName][]types.Notification, eventName types.EventName, epoch uint64) error {
-	pubkeys, subMap, err := GetSubsForEventFilter(eventName)
+	subMap, err := GetSubsForEventFilter(eventName)
 	if err != nil {
 		return fmt.Errorf("error getting subscriptions for RocketpoolRPLCollateral %w", err)
 	}
@@ -2964,7 +2964,7 @@ func collectRocketpoolRPLCollateralNotifications(notificationsByUserID map[uint6
 	stakeInfoPerNode := make([]dbResult, 0)
 	batchSize := 5000
 	keys := make([][]byte, 0, batchSize)
-	for pubkey := range pubkeys {
+	for pubkey := range subMap {
 		b, err := hex.DecodeString(pubkey)
 		if err != nil {
 			log.Error(err, fmt.Sprintf("error decoding pubkey %s", pubkey), 0)


### PR DESCRIPTION
basic refactoring of the notification collector code:
-) use a `map[UserId]map[EventName]map[EventFilter]Notification` type for collecting notifications to make it impossible to send duplicate notifications
-) harmonize adding notifications via an instance method `AddNotification`
-) improve map key typing by using named types (UserId, EventName, EventFilter)
-) us composition for the different notifciation type structs
-) harmonize retrieving subscriptions using the `GetSubsForEventFilter` function
-) added code comments for clarity
-) removes unsubscribe hash from email notifications as they anyway do not work right now

See the various todos for open tasks.

Large todo: merge and queue notifications so that there is only one notification per user & epoch which includes data on all subscribed events