### PR TITLE
(BIDS-3180) small visual fixes in the group and validator modals

### DIFF
--- a/frontend/components/bc/table/TablePager.vue
+++ b/frontend/components/bc/table/TablePager.vue
@@ -117,15 +117,17 @@ watch(() => data.value.lastPage && data.value.lastPage < data.value.page, (match
         @change="(event) => setPageSize(event.value)"
       />
     </div>
-    <div v-if="!stepperOnly" class="left-info">
-      <slot name="bc-table-footer-left">
-        <span v-if="props.paging?.total_count">
-          {{ $t('table.showing', { from: data.from, to: data.to, total: props.paging?.total_count }) }}
-        </span>
-      </slot>
-    </div>
-    <div v-if="$slots['bc-table-footer-right']" class="right-info">
-      <slot name="bc-table-footer-right" />
+    <div class="very-last">
+      <div v-if="!stepperOnly" class="left-info">
+        <slot name="bc-table-footer-left">
+          <span v-if="props.paging?.total_count">
+            {{ $t('table.showing', { from: data.from, to: data.to, total: props.paging?.total_count }) }}
+          </span>
+        </slot>
+      </div>
+      <div v-if="$slots['bc-table-footer-right']" class="right-info">
+        <slot name="bc-table-footer-right" />
+      </div>
     </div>
   </div>
 </template>
@@ -137,28 +139,23 @@ watch(() => data.value.lastPage && data.value.lastPage < data.value.page, (match
   position: relative;
   height: 78px;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   font-weight: var(--standard_text_medium_font_weight);
   margin: var(--padding) var(--padding-large);
 
-  .left-info {
+  .very-last {
     position: absolute;
-    left: 0;
-    top: 0;
-    height: 100%;
     display: flex;
-    align-items: center;
-  }
-
-  .right-info {
-    position: absolute;
-    right: 0;
-    top: 0;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    padding-left: var(--padding);
+    flex-direction: row;
+    width: 100%;
+    .left-info {
+      margin-right: auto;
+    }
+    .right-info {
+      margin-left: auto;
+    }
   }
 
   .pager {
@@ -222,15 +219,12 @@ watch(() => data.value.lastPage && data.value.lastPage < data.value.page, (match
   }
 
   @media screen and (max-width: 1399px) {
-    flex-direction: column;
     gap: var(--padding);
     height: unset;
-
-    .right-info,
-    .left-info {
-      position: relative;
-      height: unset;
-      padding-left: unset;
+    .very-last {
+      @media (max-width: 600px) {
+        position: relative;
+      }
     }
   }
 }

--- a/frontend/components/dashboard/GroupManagementModal.vue
+++ b/frontend/components/dashboard/GroupManagementModal.vue
@@ -215,8 +215,13 @@ const selectedSort = computed(() => sortOrder.value ? `${sortField.value}:${getS
                 />
               </template>
             </Column>
-            <Column field="id" :sortable="!isMobile" :header="$t('dashboard.validator.group_management.col.id')" />
-
+            <Column field="id" :sortable="!isMobile" :header="$t('dashboard.validator.group_management.col.id')">
+              <template #body="slotProps">
+                <div class="id-cell">
+                  {{ slotProps.data.id }}
+                </div>
+              </template>
+            </Column>
             <Column field="count" :sortable="!isMobile" :header="$t('dashboard.validator.group_management.col.count')">
               <template #body="slotProps">
                 <BcFormatNumber :value="slotProps.data.count" default="0" />
@@ -294,6 +299,10 @@ const selectedSort = computed(() => sortOrder.value ? `${sortField.value}:${getS
   max-width: 180px;
 }
 
+.id-cell {
+  @include utils.set-all-width(64px);
+}
+
 .small-title {
   @include utils.truncate-text;
   @include fonts.big_text;
@@ -335,7 +344,7 @@ const selectedSort = computed(() => sortOrder.value ? `${sortField.value}:${getS
 
 .left {
   display: flex;
-  align-items: center;
+  margin-top: 4px;
   gap: var(--padding-small);
 
   .labels {
@@ -354,10 +363,6 @@ const selectedSort = computed(() => sortOrder.value ? `${sortField.value}:${getS
   .gem {
     color: var(--primary-color);
   }
-}
-
-.public-key {
-  width: 134px;
 }
 
 .edit-icon {

--- a/frontend/components/dashboard/ValidatorManagementModal.vue
+++ b/frontend/components/dashboard/ValidatorManagementModal.vue
@@ -501,7 +501,7 @@ const premiumLimit = computed(() => (total.value) >= maxValidatorsPerDashboard.v
 
 .left {
   display: flex;
-  align-items: center;
+  margin-top: 4px;
   gap: var(--padding-small);
 
   .labels {


### PR DESCRIPTION
This PR:

- fixes the column title "Group Id" that was wrapped over two lines on very small screens:
![Screenshot from 2024-07-08 16-12-13](https://github.com/gobitfly/beaconchain/assets/150015231/9974a650-8bf9-4bef-a8e8-d1e8b7a833bc)

- on mobile again, corrects the position of the gem and the Close button at the bottom of tables. Before, they were stacked vertically instead of spread left and right. Now:

![image](https://github.com/gobitfly/beaconchain/assets/150015231/fd15cace-c3b4-44f1-9053-c2460f2499bb)