### PR TITLE
Fix `clickable area` of `dashboard header buttons`

### DIFF
--- a/frontend/assets/css/prime_menubar.scss
+++ b/frontend/assets/css/prime_menubar.scss
@@ -15,17 +15,25 @@
       border: 1px solid var(--container-border-color);
       border-radius: var(--border-radius);
       height: 30px;
-      cursor: pointer;
       &:has(.router-link-active),
       &:has(.p-active) {
         color: var(--primary-color);
         border-color: var(--primary-color);
-      }
-
+      }     
       > .p-menuitem-content {
         padding: var(--padding-small) var(--padding-large);
         border-radius: var(--border-radius);
         height: 28px;
+
+        .text {
+          // this hack is necessary to make the clickable area as big as the parent
+          &::before{
+            cursor: pointer;
+            content: "";
+            position: absolute;
+            inset: 0;
+          }
+        }
         .button-content {
           margin-top: 1px;
           justify-content: center;
@@ -53,7 +61,16 @@
       white-space: nowrap;
       text-overflow: ellipsis;
       max-width: 200px;
-      cursor: pointer;
+      
+      .text {
+        // this hack is necessary to make the clickable area as big as the parent
+        &::before{
+          cursor: pointer;
+          content: "";
+          position: absolute;
+          inset: 0;
+        }
+      }
 
       &:not(:has(.p-active)):not(:has(.router-link-active)) {
         color: var(--text-color);

--- a/frontend/components/dashboard/DashboardHeader.vue
+++ b/frontend/components/dashboard/DashboardHeader.vue
@@ -168,7 +168,7 @@ const editDashboard = () => {
         </template>
       </Menubar>
       <Button v-if="!isShared" class="p-button-icon-only" @click="emit('showCreation')">
-        <IconPlus alt="Plus icon" width="100%" height="100%" />
+        <IconPlus title="Add new dashboard" width="100%" height="100%" />
       </Button>
     </div>
   </div>


### PR DESCRIPTION
This is a hack. Ideally buttons should be constructed in the correct format.
For example the text could define the `button size`, by having its own padding.
Preventing this issue.

See: BIDS-3200