### PR TITLE
Nobids/improve dashboard creation button states

### DIFF
--- a/frontend/components/dashboard/creation/DashboardCreationController.vue
+++ b/frontend/components/dashboard/creation/DashboardCreationController.vue
@@ -5,7 +5,6 @@ import { ChainIDs } from '~/types/network'
 import { API_PATH } from '~/types/customFetch'
 
 const { createValidatorDashboard, createAccountDashboard } = useUserDashboardStore()
-const showInDevelopment = Boolean(useRuntimeConfig().public.showInDevelopment)
 const { dashboards } = useUserDashboardStore()
 const { user, isLoggedIn } = useUserStore()
 
@@ -30,7 +29,10 @@ const maxDashboards = computed(() => {
   return user.value?.premium_perks.validator_dashboards ?? 1
 })
 const accountsDisabled = computed(() => {
-  return !showInDevelopment || (dashboards.value?.account_dashboards?.length ?? 0) >= maxDashboards.value
+  // TODO: Once account dashboards are being tackled, use something like
+  // return !showInDevelopment || (dashboards.value?.account_dashboards?.length ?? 0) >= maxDashboards.value
+
+  return true
 })
 const validatorsDisabled = computed(() => {
   return (dashboards.value?.validator_dashboards?.length ?? 0) >= maxDashboards.value

--- a/frontend/components/dashboard/creation/DashboardCreationNetworkMask.vue
+++ b/frontend/components/dashboard/creation/DashboardCreationNetworkMask.vue
@@ -5,7 +5,7 @@ import { useNetworkStore } from '~/stores/useNetworkStore'
 
 const { t: $t } = useI18n()
 
-const { currentNetwork, isMainNet } = useNetworkStore()
+const { isMainNet } = useNetworkStore()
 
 const network = defineModel<ChainIDs>('network')
 const selection = ref<`${ChainIDs}` | ''>('')
@@ -32,7 +32,7 @@ const showNameOrDescription = (chainId: ChainIDs): string => {
 
 const buttonList = ValidatorDashboardNetworkList.map((chainId) => {
   // TODO: simply set `false` for everything once dashboards can be created for all the networks in `ValidatorDashboardNetworkList`
-  const isDisabled = !useRuntimeConfig().public.showInDevelopment && chainId !== currentNetwork.value
+  const isDisabled = chainId !== ChainIDs.Ethereum
   return {
     value: String(chainId),
     text: ChainInfo[chainId].family as string,


### PR DESCRIPTION
This PR
* Always disables the `Account` button during the dashboard creation flow (as account dashboards will not come during the next few weeks anyways)
* Always disables network buttons for networks != Ethereum for now (as we start with Ethereum and Ethereum will always be supported)

The `showInDevelopment` does not affect either of those buttons anymore for clarity.

:mega: Shout-out to @marcel-bitfly for his input!