### PR TITLE
Bids 3162/summary chart v2 5

### DIFF
--- a/frontend/components/bc/BcDropdown.vue
+++ b/frontend/components/bc/BcDropdown.vue
@@ -1,14 +1,15 @@
 <script setup lang="ts">
 
 interface Props {
-  variant?: 'default' | 'table' | 'header'
+  variant?: 'default' | 'table' | 'header',
+  panelClass?: string
 }
 
 defineProps<Props>()
 </script>
 
 <template>
-  <Dropdown :class="variant" :panel-class="variant">
+  <Dropdown :class="variant" :panel-class="[variant, panelClass]">
     <template #value="slotProps">
       <slot name="value" v-bind="slotProps" />
     </template>

--- a/frontend/components/bc/premium/BcPremiumGem.vue
+++ b/frontend/components/bc/premium/BcPremiumGem.vue
@@ -7,7 +7,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
 <template>
   <BcTooltip :text="$t('premium.subscribe')">
-    <BcLink :to="`/pricing`" target="_blank">
+    <BcLink :to="`/pricing`" target="_blank" class="link">
       <div>
         <FontAwesomeIcon :icon="faGem" class="gem" />
       </div>
@@ -19,5 +19,10 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 .gem {
   color: var(--primary-color);
   cursor: pointer;
+}
+
+.link {
+  cursor: pointer;
+  pointer-events: all;
 }
 </style>

--- a/frontend/components/bc/table/BcTableControl.vue
+++ b/frontend/components/bc/table/BcTableControl.vue
@@ -32,17 +32,17 @@ const onInput = (value: string) => {
     <div class="bc-table-header">
       <div class="side left">
         <BcIconToggle v-if="$slots.chart" v-model="tableIsShown" :true-icon="faTable" :false-icon="faChartColumn" :disabled="chartDisabled" />
-        <BcIconToggle v-if="useAbsoluteValues !== null" v-model="useAbsoluteValues" :true-icon="faHashtag" :false-icon="faPercent" />
+        <BcIconToggle v-if="useAbsoluteValues !== null && tableIsShown" v-model="useAbsoluteValues" :true-icon="faHashtag" :false-icon="faPercent" />
         <slot name="header-left" />
       </div>
 
-      <slot name="header-center">
+      <slot name="header-center" :table-is-shown="tableIsShown">
         <div v-if="props.title" class="h1">
           {{ props.title }}
         </div>
       </slot>
       <div class="side right">
-        <slot name="header-right" />
+        <slot name="header-right" :table-is-shown="tableIsShown" />
         <BcContentFilter
           v-if="props.searchPlaceholder && tableIsShown"
           :search-placeholder="props.searchPlaceholder"

--- a/frontend/components/dashboard/chart/DashboardChartSummaryChartFilter.vue
+++ b/frontend/components/dashboard/chart/DashboardChartSummaryChartFilter.vue
@@ -30,8 +30,8 @@ const efficiencyList = EfficiencyTypes.map(e => ({
 watch(efficiency, (e) => { chartFilter.value.efficiency = e })
 
 /** groups */
-const total = ref(chartFilter.value.groupIds.includes(SUMMARY_CHART_GROUP_TOTAL))
-const average = ref(chartFilter.value.groupIds.includes(SUMMARY_CHART_GROUP_NETWORK_AVERAGE))
+const total = ref(!chartFilter.value.initialised || chartFilter.value.groupIds.includes(SUMMARY_CHART_GROUP_TOTAL))
+const average = ref(!chartFilter.value.initialised || chartFilter.value.groupIds.includes(SUMMARY_CHART_GROUP_NETWORK_AVERAGE))
 const groups = computed(() => {
   if (!overview.value?.groups) {
     return []
@@ -42,12 +42,6 @@ const selectedGroups = ref<number[]>([])
 watch(groups, (list) => {
   // when groups change we reset the selected groups
   selectedGroups.value = list.map(g => g.id)
-  if (total.value) {
-    selectedGroups.value.push(SUMMARY_CHART_GROUP_TOTAL)
-  }
-  if (average.value) {
-    selectedGroups.value.push(SUMMARY_CHART_GROUP_NETWORK_AVERAGE)
-  }
 }, { immediate: true })
 
 watch([selectedGroups, total, average], ([list, t, a]) => {
@@ -59,7 +53,8 @@ watch([selectedGroups, total, average], ([list, t, a]) => {
     groupIds.push(SUMMARY_CHART_GROUP_NETWORK_AVERAGE)
   }
   chartFilter.value.groupIds = groupIds
-})
+  chartFilter.value.initialised = true
+}, { immediate: true })
 
 const selectAllGroups = () => {
   selectedGroups.value = groups.value.map(g => g.id)

--- a/frontend/components/dashboard/chart/DashboardChartSummaryChartFilter.vue
+++ b/frontend/components/dashboard/chart/DashboardChartSummaryChartFilter.vue
@@ -1,0 +1,165 @@
+<script lang="ts" setup>
+import { orderBy } from 'lodash-es'
+import { type AggregationTimeframe, AggregationTimeframes, type EfficiencyType, EfficiencyTypes, SUMMARY_CHART_GROUP_NETWORK_AVERAGE, SUMMARY_CHART_GROUP_TOTAL, type SummaryChartFilter } from '~/types/dashboard/summary'
+import { getGroupLabel } from '~/utils/dashboard/group'
+
+const { t: $t } = useI18n()
+
+const { overview } = useValidatorDashboardOverviewStore()
+
+const chartFilter = defineModel<SummaryChartFilter>({ required: true })
+
+/** aggregation */
+const aggregation = ref<AggregationTimeframe>(chartFilter.value.aggregation)
+
+const aggregationList = AggregationTimeframes.map(a => ({
+  id: a,
+  label: $t(`time_frames.${a}`)
+}))
+
+watch(aggregation, (a) => { chartFilter.value.aggregation = a })
+const aggregationDisabled = ({ id }: { id: AggregationTimeframe }) => (overview.value?.chart_history_seconds[id] ?? 0) === 0
+
+/** efficiency */
+const efficiency = ref<EfficiencyType>(chartFilter.value.efficiency)
+
+const efficiencyList = EfficiencyTypes.map(e => ({
+  id: e,
+  label: $t(`dashboard.validator.summary.chart.efficiency.${e}`)
+}))
+watch(efficiency, (e) => { chartFilter.value.efficiency = e })
+
+/** groups */
+const total = ref(chartFilter.value.groupIds.includes(SUMMARY_CHART_GROUP_TOTAL))
+const average = ref(chartFilter.value.groupIds.includes(SUMMARY_CHART_GROUP_NETWORK_AVERAGE))
+const groups = computed(() => {
+  if (!overview.value?.groups) {
+    return []
+  }
+  return orderBy(overview.value.groups.filter(g => !!g.count), [g => g.name.toLowerCase()], 'asc')
+})
+const selectedGroups = ref<number[]>([])
+watch(groups, (list) => {
+  // when groups change we reset the selected groups
+  selectedGroups.value = list.map(g => g.id)
+  if (total.value) {
+    selectedGroups.value.push(SUMMARY_CHART_GROUP_TOTAL)
+  }
+  if (average.value) {
+    selectedGroups.value.push(SUMMARY_CHART_GROUP_NETWORK_AVERAGE)
+  }
+}, { immediate: true })
+
+watch([selectedGroups, total, average], ([list, t, a]) => {
+  const groupIds: number[] = [...list]
+  if (t) {
+    groupIds.push(SUMMARY_CHART_GROUP_TOTAL)
+  }
+  if (a) {
+    groupIds.push(SUMMARY_CHART_GROUP_NETWORK_AVERAGE)
+  }
+  chartFilter.value.groupIds = groupIds
+})
+
+const selectAllGroups = () => {
+  selectedGroups.value = groups.value.map(g => g.id)
+}
+
+const toggleGroups = () => {
+  if (selectedGroups.value.length < groups.value.length) {
+    selectAllGroups()
+  } else {
+    selectedGroups.value = []
+  }
+}
+
+const selectedLabel = computed(() => {
+  const list: string[] = orderBy(selectedGroups.value.map(id => getGroupLabel($t, id, groups.value)), [g => g.toLowerCase()], 'asc')
+
+  if (average.value) {
+    list.splice(0, 0, $t('dashboard.validator.summary.chart.average'))
+  }
+  if (total.value) {
+    list.splice(0, 0, $t('dashboard.validator.summary.chart.total'))
+  }
+  if (!list.length) {
+    return $t('dashboard.group.selection.all')
+  }
+  return list.join(', ')
+})
+</script>
+
+<template>
+  <div class="chart-filter-row">
+    <BcDropdown
+      v-model="aggregation"
+      :options="aggregationList"
+      option-value="id"
+      option-label="label"
+      :option-disabled="aggregationDisabled"
+      panel-class="summary-chart-aggregation-panel"
+      class="small"
+    >
+      <template #option="slotProps">
+        <span>{{ slotProps.label }}</span>
+        <BcPremiumGem class="premium-gem" @click.stop="() => undefined" />
+      </template>
+    </BcDropdown>
+    <BcDropdown v-model="efficiency" :options="efficiencyList" option-value="id" option-label="label" class="small" />
+
+    <MultiSelect
+      v-model="selectedGroups"
+      :options="groups"
+      option-label="name"
+      option-value="id"
+      :placeholder="$t('dashboard.group.selection.all')"
+    >
+      <template #header>
+        <div class="special-groups">
+          <Checkbox v-model="total" input-id="total" :binary="true" />
+          <label for="total">{{ $t("dashboard.validator.summary.chart.total") }}</label>
+        </div>
+        <div class="special-groups">
+          <Checkbox v-model="average" input-id="average" :binary="true" />
+          <label for="average">{{ $t("dashboard.validator.summary.chart.average") }}</label>
+        </div>
+        <span class="pointer" @click="toggleGroups">
+          {{ $t('dashboard.group.selection.all') }}
+        </span>
+      </template>
+      <template #value>
+        {{ selectedLabel }}
+      </template>
+    </MultiSelect>
+  </div>
+</template>
+<style lang="scss" scoped>
+.chart-filter-row {
+  display: flex;
+  gap: var(--padding);
+  :deep(>.p-multiselect),
+  :deep(>.p-dropdown){
+    max-width: 200px;
+    @media (max-width: 1000px) {
+      max-width: 76px;
+  }
+  }
+}
+
+.special-groups {
+  display: flex;
+  gap: var(--padding);
+  padding-left: var(--padding-small);
+  margin-bottom: var(--padding);
+}
+
+:global(.summary-chart-aggregation-panel .p-dropdown-item) {
+  display: flex;
+  gap: var(--padding-small);
+  align-items: center;
+}
+
+:global(.summary-chart-aggregation-panel .p-dropdown-item:not(.p-disabled) .premium-gem) {
+  display: none;
+}
+</style>

--- a/frontend/components/dashboard/chart/SummaryChart.vue
+++ b/frontend/components/dashboard/chart/SummaryChart.vue
@@ -39,6 +39,7 @@ const { tsToEpoch } = useNetworkStore()
 const { dashboardKey } = useDashboardKey()
 
 const data = ref<ChartData<number, number> | undefined >()
+const { value: filter, bounce: bounceFilter } = useDebounceValue(props.filter, 1000)
 const aggregation = ref<AggregationTimeframe>('hourly')
 const isLoading = ref(false)
 const loadData = async () => {
@@ -55,8 +56,15 @@ const loadData = async () => {
   data.value = res.data
 }
 
-watch([dashboardKey, () => props.filter], () => {
+watch([dashboardKey, filter], () => {
   loadData()
+}, { immediate: true })
+
+watch(() => props.filter, (filter) => {
+  if (!filter) {
+    return
+  }
+  bounceFilter({ ...filter, groupIds: [...filter.groupIds] }, true, true)
 }, { immediate: true, deep: true })
 
 const { groups } = useValidatorDashboardGroups()

--- a/frontend/components/dashboard/chart/SummaryChart.vue
+++ b/frontend/components/dashboard/chart/SummaryChart.vue
@@ -182,7 +182,7 @@ const option = computed(() => {
       padding: 0,
       borderColor: colors.value.background,
       formatter (params : any) : HTMLElement {
-        const ts = params[0].axisValue as number
+        const ts = parseInt(params[0].axisValue)
         const groupInfos = params.map((param: any) => {
           return {
             name: param.seriesName,

--- a/frontend/components/dashboard/chart/SummaryChartTooltip.vue
+++ b/frontend/components/dashboard/chart/SummaryChartTooltip.vue
@@ -1,9 +1,12 @@
 <script lang="ts" setup>
 import { type ComposerTranslation } from 'vue-i18n'
+import { type AggregationTimeframe, type EfficiencyType } from '~/types/dashboard/summary'
 
 interface Props {
   t: ComposerTranslation, // required as dynamically created components via render do not have the proper app context
-  startEpoch: number,
+  ts: number,
+  aggregation: AggregationTimeframe,
+  efficiencyType: EfficiencyType,
   groupInfos: {
     name: string,
     efficiency: number,
@@ -17,7 +20,7 @@ defineProps<Props>()
 
 <template>
   <div class="tooltip-container">
-    <DashboardChartTooltipHeader :t="t" :start-epoch="startEpoch" />
+    <DashboardChartTooltipHeader :t="t" :ts="ts" :aggregation="aggregation" :efficiency-type="efficiencyType" />
     <div v-for="(entry, index) in groupInfos" :key="index" class="line-container">
       <div class="circle" :style="{ 'background-color': entry.color }" />
       <div>

--- a/frontend/components/dashboard/chart/SummaryChartTooltip.vue
+++ b/frontend/components/dashboard/chart/SummaryChartTooltip.vue
@@ -26,9 +26,7 @@ defineProps<Props>()
       <div>
         {{ entry.name }}:
       </div>
-      <div class="efficiency">
-        {{ entry.efficiency }}%
-      </div>
+      <BcFormatPercent class="efficiency" :percent="entry.efficiency" />
     </div>
   </div>
 </template>

--- a/frontend/components/dashboard/chart/TooltipHeader.vue
+++ b/frontend/components/dashboard/chart/TooltipHeader.vue
@@ -46,11 +46,11 @@ const dateText = computed(() => {
   if (!startTs.value) {
     return
   }
-  const date = formatGoTimestamp(startTs.value, undefined, 'absolute', 'narrow', props.t('locales.date'), false)
+  const date = formatGoTimestamp(startTs.value, undefined, 'absolute', 'narrow', props.t('locales.date'), true)
   if (!endTs.value) {
     return date
   }
-  const endDate = formatGoTimestamp(endTs.value, undefined, 'absolute', 'narrow', props.t('locales.date'), false)
+  const endDate = formatGoTimestamp(endTs.value, undefined, 'absolute', 'narrow', props.t('locales.date'), true)
 
   return `${date} - ${endDate}`
 })

--- a/frontend/components/dashboard/table/DashboardTableSummary.vue
+++ b/frontend/components/dashboard/table/DashboardTableSummary.vue
@@ -9,7 +9,7 @@ import type { Cursor, TableQueryParams } from '~/types/datatable'
 import { useValidatorDashboardOverviewStore } from '~/stores/dashboard/useValidatorDashboardOverviewStore'
 import { DAHSHBOARDS_ALL_GROUPS_ID } from '~/types/dashboard'
 import { getGroupLabel } from '~/utils/dashboard/group'
-import { SummaryTimeFrames, type SummaryTableVisibility, type SummaryTimeFrame } from '~/types/dashboard/summary'
+import { SummaryTimeFrames, type SummaryChartFilter, type SummaryTableVisibility, type SummaryTimeFrame } from '~/types/dashboard/summary'
 import type { DashboardTableSummaryValidators } from '#build/components'
 
 const { dashboardKey, isPublic } = useDashboardKey()
@@ -18,6 +18,7 @@ const cursor = ref<Cursor>()
 const pageSize = ref<number>(10)
 const { t: $t } = useI18n()
 const showInDevelopment = Boolean(useRuntimeConfig().public.showInDevelopment)
+const chartFilter = ref<SummaryChartFilter>({ aggregation: 'hourly', efficiency: 'all', groupIds: [] })
 
 const { summary, query: lastQuery, isLoading, getSummary } = useValidatorDashboardSummaryStore()
 const { value: query, temp: tempQuery, bounce: setQuery } = useDebounceValue<TableQueryParams | undefined>(undefined, 500)
@@ -102,11 +103,12 @@ const searchPlaceholder = computed(() => $t(isPublic.value && (groups.value?.len
       :chart-disabled="!showInDevelopment"
       @set-search="setSearch"
     >
-      <template #header-center>
+      <template #header-center="{tableIsShown}">
         <h1 class="summary_title">
           {{ $t('dashboard.validator.summary.title') }}
         </h1>
         <BcDropdown
+          v-if="tableIsShown"
           v-model="selectedTimeFrame"
           :options="timeFrames"
           option-value="id"
@@ -114,6 +116,7 @@ const searchPlaceholder = computed(() => $t(isPublic.value && (groups.value?.len
           class="small"
           :placeholder="$t('dashboard.group.selection.placeholder')"
         />
+        <DashboardChartSummaryChartFilter v-else v-model="chartFilter" />
       </template>
       <template #table>
         <ClientOnly fallback-tag="span">
@@ -268,7 +271,7 @@ const searchPlaceholder = computed(() => $t(isPublic.value && (groups.value?.len
       </template>
       <template #chart>
         <div class="chart-container">
-          <DashboardChartSummaryChart v-if="showInDevelopment" />
+          <DashboardChartSummaryChart v-if="showInDevelopment" :filter="chartFilter" />
         </div>
       </template>
     </BcTableControl>

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -550,7 +550,14 @@
         },
         "chart": {
           "all_groups": "All Groups",
-          "efficiency": "Efficiency"
+          "average": "Network Average",
+          "total": "Total",
+          "efficiency": {
+            "all": "Efficiency",
+            "attestation": "Attestation Eff.",
+            "sync": "Sync Eff.",
+            "proposal": "Proposal Eff."
+          }
         },
         "tooltip":{
           "lower": "{name}'s efficiency is below the network average of {average}",

--- a/frontend/stores/useNetworkStore.ts
+++ b/frontend/stores/useNetworkStore.ts
@@ -75,6 +75,10 @@ export function useNetworkStore () {
     return networkTs.slotToEpoch(currentNetwork.value, slot)
   }
 
+  function tsToEpoch (ts: number): number {
+    return slotToEpoch(tsToSlot(ts))
+  }
+
   return {
     loadAvailableNetworks,
     availableNetworks,
@@ -87,6 +91,7 @@ export function useNetworkStore () {
     epochToTs,
     slotToTs,
     tsToSlot,
+    tsToEpoch,
     slotToEpoch
   }
 }

--- a/frontend/types/dashboard/summary.ts
+++ b/frontend/types/dashboard/summary.ts
@@ -1,3 +1,5 @@
+import { type ChartHistorySeconds } from '~/types/api/common'
+
 export const SummaryDetailsEfficiencyProps = ['attestations_head', 'attestations_source', 'attestations_target', 'slashings', 'sync'] as const
 export type SummaryDetailsEfficiencyProp = typeof SummaryDetailsEfficiencyProps[number]
 
@@ -28,4 +30,19 @@ export type SummaryTableVisibility = {
   reward: boolean,
   efficiency: boolean,
   validatorsSortable: boolean
+}
+
+export const SUMMARY_CHART_GROUP_TOTAL = -1
+export const SUMMARY_CHART_GROUP_NETWORK_AVERAGE = -2
+
+export type AggregationTimeframe = keyof ChartHistorySeconds
+export const AggregationTimeframes: AggregationTimeframe[] = ['epoch', 'hourly', 'daily', 'weekly']
+
+export const EfficiencyTypes = ['all', 'attestation', 'sync', 'proposal']
+export type EfficiencyType = typeof EfficiencyTypes[number]
+
+export type SummaryChartFilter = {
+  groupIds: number[]
+  aggregation: AggregationTimeframe
+  efficiency: EfficiencyType
 }

--- a/frontend/types/dashboard/summary.ts
+++ b/frontend/types/dashboard/summary.ts
@@ -42,7 +42,8 @@ export const EfficiencyTypes = ['all', 'attestation', 'sync', 'proposal']
 export type EfficiencyType = typeof EfficiencyTypes[number]
 
 export type SummaryChartFilter = {
-  groupIds: number[]
-  aggregation: AggregationTimeframe
-  efficiency: EfficiencyType
+  groupIds: number[],
+  aggregation: AggregationTimeframe,
+  efficiency: EfficiencyType,
+  initialised?: boolean,
 }

--- a/frontend/utils/format.ts
+++ b/frontend/utils/format.ts
@@ -7,6 +7,7 @@ import { ChainIDs, epochToTs, slotToTs } from '~/types/network'
 export const ONE_MINUTE = 60
 export const ONE_HOUR = ONE_MINUTE * 60
 export const ONE_DAY = ONE_HOUR * 24
+export const ONE_WEEK = ONE_DAY * 7
 export const ONE_YEAR = ONE_DAY * 365
 
 export interface NumberFormatConfig {


### PR DESCRIPTION
This PR:
Implements the Summary 2.5 chart changes
- New Filter options
  - aggregation (some options only available for permium users charts *)
  - efficiency
  - groups: Multi select + 2 special options (network average and total)
 - data points now based on timestamp an no longer on epochs

This PR did not
- Test the chart with new data (the backend does not throw an error with the new options, but still returns the old data) -> currently the dates / epochs in the chart are wrong displayed as they are based on timestamps but get epochs from the backend. 
- Remove the `showInDevelopment` flag as the Chart should only be made public after tests against the new backend. 
- Implement loading of partial time frame loading. We will first see how the chart performs when loading all the data and only when needed implement partial loading. As this would decrease usability and should only be done when we get into performance issues. 
  
  
*) add. info: the permissions for the chart depend on the user how created the dashboard and not on the logged-in user - important for shared dashboards.