### PR TITLE
fix pager text wrap on validator subset modal and add deposited state

### DIFF
--- a/frontend/components/bc/table/TablePager.vue
+++ b/frontend/components/bc/table/TablePager.vue
@@ -181,6 +181,7 @@ watch(() => data.value.lastPage && data.value.lastPage < data.value.page, (match
       height: 30px;
       padding: 0 22px;
       border-radius: 0;
+      white-space: nowrap;
 
       &:has(svg) {
         padding: 0 15px;

--- a/frontend/components/dashboard/validator/subset/ValidatorSubsetList.vue
+++ b/frontend/components/dashboard/validator/subset/ValidatorSubsetList.vue
@@ -104,10 +104,10 @@ function mapDutyLinks (dutyObjects?: number[]) {
 
 <template>
   <div class="validator-list">
-    <div class="copy_button" @click="copyValidatorsToClipboard">
-      <FontAwesomeIcon :icon="faCopy" />
-    </div>
     <div class="list">
+      <div class="copy_button" @click="copyValidatorsToClipboard">
+        <FontAwesomeIcon :icon="faCopy" />
+      </div>
       <template v-for="v in currentPage" :key="v.index">
         <BcLink :to="`/validator/${v.index}`" target="_blank" class="link">
           {{ v.index }}
@@ -129,6 +129,7 @@ function mapDutyLinks (dutyObjects?: number[]) {
     </div>
     <div v-if="paging" class="page-row">
       <BcTablePager
+        class="pager"
         :cursor="cursor"
         :page-size="VALIDATORS_PER_PAGE"
         :paging="paging"
@@ -143,7 +144,6 @@ function mapDutyLinks (dutyObjects?: number[]) {
 @use '~/assets/css/main.scss';
 
 .validator-list {
-  position: relative;
   flex-grow: 1;
   background-color: var(--subcontainer-background);
   padding: var(--padding) var(--padding) 7px var(--padding);
@@ -153,6 +153,11 @@ function mapDutyLinks (dutyObjects?: number[]) {
 
   .list {
     min-height: 30px;
+    position: relative;
+  }
+
+  .pager {
+    margin: 0;
   }
 
   .round-brackets>span:last-child:not(.label),
@@ -189,8 +194,8 @@ function mapDutyLinks (dutyObjects?: number[]) {
     display: flex;
     justify-content: center;
     align-items: center;
-    bottom: var(--padding);
-    right: var(--padding);
+    bottom: var(--padding-small);
+    right: var(--padding-small);
 
     cursor: pointer;
 

--- a/frontend/components/validator/table/ValidatorTableStatus.vue
+++ b/frontend/components/validator/table/ValidatorTableStatus.vue
@@ -16,12 +16,10 @@ defineProps<Props>()
 <template>
   <div class="wrapper">
     <span v-if="!hideLabel" class="status">
-      <!--TODO: remove .replaceAll once backend data is fixed-->
-      {{ $t(`validator_state.${status.replaceAll('\'', '')}`) }}
+      {{ $t(`validator_state.${status}`) }}
       <span v-if="position"> #<BcFormatNumber :value="position" /></span>
     </span>
-    <!--TODO: remove .replaceAll once backend data is fixed-->
-    <FontAwesomeIcon :icon="faPowerOff" :class="status.replaceAll('\'', '')" />
+    <FontAwesomeIcon :icon="faPowerOff" :class="status" />
   </div>
 </template>
 <style lang="scss" scoped>
@@ -38,6 +36,7 @@ defineProps<Props>()
   .online{
     color: var(--positive-color);
   }
+  .deposited,
   .pending {
     color: var(--orange-color);
   }

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -117,6 +117,7 @@
   "validator_state": {
     "active": "active",
     "withdrawn": "withdrawn",
+    "deposited": "deposited",
     "online": "active",
     "offline": "offline",
     "pending": "pending",


### PR DESCRIPTION
This PR:
- fixes the issue of wrapping text in the pager inside the validator subset modal
- moves the copybutton inside the list
- adds 'deposited' state to validator state translations