### PR TITLE
(BIDS-3181) Adaptative width of cell 1 in the dropdown of the searchbar

### DIFF
--- a/frontend/components/bc/searchbar/SearchbarMain.vue
+++ b/frontend/components/bc/searchbar/SearchbarMain.vue
@@ -6,6 +6,8 @@
 import { warn } from 'vue'
 import { levenshteinDistance } from '~/utils/misc'
 import {
+  MinimumTimeBetweenAPIcalls,
+  LayoutThreshold,
   Category,
   ResultType,
   type HowToFillresultSuggestionOutput,
@@ -36,9 +38,6 @@ import {
 import { ChainIDs, ChainInfo } from '~/types/network'
 import { API_PATH } from '~/types/customFetch'
 import { useNetworkStore } from '~/stores/useNetworkStore'
-
-const MinimumTimeBetweenAPIcalls = 400 // ms
-const layoutThreshold = 500 // px  (tells when the bar must switch between its narrow and large layouts)
 
 const dropdownLayout = ref<SearchbarDropdownLayout>('narrow-dropdown')
 
@@ -217,7 +216,7 @@ watch(availableNetworks, reconfigureSearchbar)
 let resizingObserver: ResizeObserver
 if (process.client) {
   resizingObserver = new ResizeObserver((entries) => {
-    const newLayout : SearchbarDropdownLayout = (entries[0].borderBoxSize[0].inlineSize < layoutThreshold) ? 'narrow-dropdown' : 'large-dropdown'
+    const newLayout : SearchbarDropdownLayout = (entries[0].borderBoxSize[0].inlineSize < LayoutThreshold) ? 'narrow-dropdown' : 'large-dropdown'
     if (newLayout !== dropdownLayout.value) { // reassigning 'narrow-dropdown' to 'narrow-dropdown' (for ex) is not guaranteed to preserve the pointer, so this trick makes sure that we do not trigger Vue watchers for nothing (draining the battery and slowing down the UI)
       dropdownLayout.value = newLayout
     }

--- a/frontend/components/bc/searchbar/SuggestionRow.vue
+++ b/frontend/components/bc/searchbar/SuggestionRow.vue
@@ -366,7 +366,7 @@ const deactivationClass = props.suggestion.lacksPremiumSubscription ? 'deactivat
   @include common-to-all-rowstyles;
 
   &.large-dropdown {
-    grid-template-columns: 40px 126px 1fr min-content min-content;
+    grid-template-columns: 40px minmax(126px, min-content) 1fr min-content min-content;
   }
   &.narrow-dropdown {
     grid-template-columns: 40px 1fr min-content min-content;

--- a/frontend/types/searchbar.ts
+++ b/frontend/types/searchbar.ts
@@ -2,6 +2,9 @@ import type { ComposerTranslation } from '@nuxtjs/i18n/dist/runtime/composables'
 import { ChainIDs } from '~/types/network'
 import { type ApiErrorResponse, type SearchResult, type InternalPostSearchResponse } from '~/types/api/common'
 
+export const MinimumTimeBetweenAPIcalls = 400 // ms
+export const LayoutThreshold = 500 // px  (tells when the bar must switch between its narrow and large layouts)
+
 export enum SearchbarShape { // do not change the litterals, they are used as class names
   Small = 'small',
   Medium = 'medium',


### PR DESCRIPTION
Now:
- the normal width of this cell is 126px as before: so all results look like they are organized in columns,
- in very rare cases when the content is bigger, the column can grow up to 140px (this breaks the harmony of the layout but it is rare and better than overflowing).

This can be observed by typing `0x9baA3244565d51D9C7897c0EB6679eD4890e536E` in the dialog box to add validators:
![image](https://github.com/user-attachments/assets/96a817ac-233c-4ec3-94c1-dff1cd8dbcf3)
top : normal layout
bottom : layout for exceptionally large contents