### PR TITLE
Adapt 'validator status' presentation

### DIFF
--- a/frontend/components/playground/DashboardValidatorManageValidators.vue
+++ b/frontend/components/playground/DashboardValidatorManageValidators.vue
@@ -49,25 +49,34 @@ const openEpochDuties = () => {
   </div>
   <div class="status-holder">
     <div class="status">
-      <ValidatorTableStatus status="online" />
-    </div>
-    <div class="status">
-      <ValidatorTableStatus status="exiting" />
-    </div>
-    <div class="status">
-      <ValidatorTableStatus status="withdrawn" />
-    </div>
-    <div class="status">
-      <ValidatorTableStatus status="offline" />
-    </div>
-    <div class="status">
-      <ValidatorTableStatus status="pending" :position="12345" />
+      <ValidatorTableStatus status="slashed" />
     </div>
     <div class="status">
       <ValidatorTableStatus status="exited" />
     </div>
     <div class="status">
-      <ValidatorTableStatus status="slashed" />
+      <ValidatorTableStatus status="deposited" />
+    </div>
+    <div class="status">
+      <ValidatorTableStatus status="pending" :position="12345" />
+    </div>
+    <div class="status">
+      <ValidatorTableStatus status="slashing_offline" />
+    </div>
+    <div class="status">
+      <ValidatorTableStatus status="slashing_online" />
+    </div>
+    <div class="status">
+      <ValidatorTableStatus status="exiting_offline" />
+    </div>
+    <div class="status">
+      <ValidatorTableStatus status="exiting_online" />
+    </div>
+    <div class="status">
+      <ValidatorTableStatus status="active_offline" />
+    </div>
+    <div class="status">
+      <ValidatorTableStatus status="active_online" />
     </div>
   </div>
   <div class="icon_holder">

--- a/frontend/components/validator/table/ValidatorTableStatus.vue
+++ b/frontend/components/validator/table/ValidatorTableStatus.vue
@@ -10,16 +10,22 @@ interface Props {
   position?: number,
   hideLabel?: boolean
 }
-defineProps<Props>()
+const props = defineProps<Props>()
+
+const iconColor = computed(() => {
+  if (props.status.includes('online')) { return 'green' }
+  if (props.status.includes('offline')) { return 'red' }
+  return 'orange'
+})
 
 </script>
 <template>
   <div class="wrapper">
+    <FontAwesomeIcon :icon="faPowerOff" :class="iconColor" />
     <span v-if="!hideLabel" class="status">
       {{ $t(`validator_state.${status}`) }}
       <span v-if="position"> #<BcFormatNumber :value="position" /></span>
     </span>
-    <FontAwesomeIcon :icon="faPowerOff" :class="status" />
   </div>
 </template>
 <style lang="scss" scoped>
@@ -33,19 +39,14 @@ defineProps<Props>()
     text-wrap: nowrap;
   }
 
-  .online{
+  .green{
     color: var(--positive-color);
   }
-  .deposited,
-  .pending {
-    color: var(--orange-color);
-  }
-  .exiting,
-  .withdrawn,
-  .offline,
-  .exited,
-  .slashed{
+  .red{
     color: var(--negative-color);
+  }
+  .orange{
+    color: var(--orange-color);
   }
 }
 </style>

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -115,15 +115,16 @@
     "unlock": "Unlock Full Features"
   },
   "validator_state": {
-    "active": "active",
-    "withdrawn": "withdrawn",
-    "deposited": "deposited",
-    "online": "active",
-    "offline": "offline",
-    "pending": "pending",
+    "slashed": "slashed",
     "exited": "exited",
-    "exiting": "exiting",
-    "slashed": "slashed"
+    "deposited": "deposited",
+    "pending": "pending",
+    "slashing_offline": "slashing",
+    "slashing_online": "slashing",
+    "exiting_offline": "exiting",
+    "exiting_online": "exiting",
+    "active_offline": "active",
+    "active_online": "active"
   },
   "slot_state": {
     "orphaned": "Orphaned",

--- a/frontend/types/api/validator_dashboard.ts
+++ b/frontend/types/api/validator_dashboard.ts
@@ -241,7 +241,7 @@ export type InternalGetValidatorDashboardTotalWithdrawalsResponse = ApiDataRespo
  * ------------------------------------------------------------
  * Manage Modal
  */
-export interface VDBManageValidatorsTableRow {
+export interface  VDBManageValidatorsTableRow {
   index: number /* uint64 */;
   public_key: PubKey;
   group_id: number /* uint64 */;


### PR DESCRIPTION
New 'types` were added, some where renamend.
When including 'online` they should appear green.
When including 'offline` they should appear red.
Otherwise orange.

See: BIDS-3218