### PR TITLE
exporter: compare against custom limit instead of default one

### DIFF
--- a/backend/pkg/exporter/modules/slot_exporter.go
+++ b/backend/pkg/exporter/modules/slot_exporter.go
@@ -476,16 +476,16 @@ func ExportSlot(client rpc.Client, slot uint64, isHeadEpoch bool, tx *sqlx.Tx) e
 						EffectiveBalance:      v.EffectiveBalance,
 						Slashed:               v.Slashed,
 					}
-					if v.ActivationEpoch != db.FarFutureEpoch {
+					if v.ActivationEpoch != db.MaxSqlNumber {
 						r.ActivationEpoch = sql.NullInt64{Int64: int64(v.ActivationEpoch), Valid: true}
 					}
-					if v.ActivationEligibilityEpoch != db.FarFutureEpoch {
+					if v.ActivationEligibilityEpoch != db.MaxSqlNumber {
 						r.ActivationEligibilityEpoch = sql.NullInt64{Int64: int64(v.ActivationEligibilityEpoch), Valid: true}
 					}
-					if v.ExitEpoch != db.FarFutureEpoch {
+					if v.ExitEpoch != db.MaxSqlNumber {
 						r.ExitEpoch = sql.NullInt64{Int64: int64(v.ExitEpoch), Valid: true}
 					}
-					if v.WithdrawableEpoch != db.FarFutureEpoch {
+					if v.WithdrawableEpoch != db.MaxSqlNumber {
 						r.WithdrawableEpoch = sql.NullInt64{Int64: int64(v.WithdrawableEpoch), Valid: true}
 					}
 					RedisCachedValidatorsMapping.Mapping[v.Index] = &r

--- a/backend/pkg/exporter/modules/slot_exporter.go
+++ b/backend/pkg/exporter/modules/slot_exporter.go
@@ -489,7 +489,7 @@ func ExportSlot(client rpc.Client, slot uint64, isHeadEpoch bool, tx *sqlx.Tx) e
 						r.WithdrawableEpoch = sql.NullInt64{Int64: int64(v.WithdrawableEpoch), Valid: true}
 					}
 					RedisCachedValidatorsMapping.Mapping[v.Index] = &r
-					if v.Status == "pending_queued" {
+					if v.Status == "pending" {
 						a := int(v.ActivationEligibilityEpoch)
 						activationMapping[a] = append(activationMapping[a], v.Index)
 					}


### PR DESCRIPTION
i would _much_ rather have the epochs not get modified by `saveValidators` instead but this will work for now i suppose