### PR TITLE
fix mobile summary detail scroll, hide chart in non dev mode

### DIFF
--- a/frontend/components/dashboard/table/DashboardTableSummary.vue
+++ b/frontend/components/dashboard/table/DashboardTableSummary.vue
@@ -17,6 +17,7 @@ const { dashboardKey, isPublic } = useDashboardKey()
 const cursor = ref<Cursor>()
 const pageSize = ref<number>(10)
 const { t: $t } = useI18n()
+const showInDevelopment = Boolean(useRuntimeConfig().public.showInDevelopment)
 const chartFilter = ref<SummaryChartFilter>({ aggregation: 'hourly', efficiency: 'all', groupIds: [] })
 
 const { summary, query: lastQuery, isLoading, getSummary } = useValidatorDashboardSummaryStore()
@@ -99,6 +100,7 @@ const searchPlaceholder = computed(() => $t(isPublic.value && (groups.value?.len
     <BcTableControl
       v-model:="showAbsoluteValues"
       :search-placeholder="searchPlaceholder"
+      :chart-disabled="!showInDevelopment"
       @set-search="setSearch"
     >
       <template #header-center="{tableIsShown}">
@@ -269,7 +271,7 @@ const searchPlaceholder = computed(() => $t(isPublic.value && (groups.value?.len
       </template>
       <template #chart>
         <div class="chart-container">
-          <DashboardChartSummaryChart :filter="chartFilter" />
+          <DashboardChartSummaryChart v-if="showInDevelopment" :filter="chartFilter" />
         </div>
       </template>
     </BcTableControl>

--- a/frontend/components/dashboard/table/SummaryDetails.vue
+++ b/frontend/components/dashboard/table/SummaryDetails.vue
@@ -134,7 +134,7 @@ const rowClass = (data: SummaryRow) => {
     }
 
     @media (max-width: 729px) {
-      width: 100%;
+      width: 340px;
 
       &:not(:first-child) {
         border-left: unset;


### PR DESCRIPTION
This PR
- hides the chart in the summary table in non prod
- fixes the scroll issue in the summary details table on mobile if there are multiple validators. 