### PR TITLE
validator summary: change live tooltip to two instead of three

### DIFF
--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -599,7 +599,7 @@
           "amount_of_validators": "(amount of validators)",
           "amount_of_rounds": "(amount of rounds)",
           "estimated_loss": "Estimated loss based on avg. network performance.",
-          "live": "Validators missing three consecutive attestations are considered offline."
+          "live": "Validators missing two consecutive attestations are considered offline."
         }
       },
       "tabs": {


### PR DESCRIPTION
This PR:
- changes the translation for the live tooltip in the summary table to `two` instead of `three` consecutive attesations