### PR TITLE
optimize the switch from a shared dashboard to /dashboard

### DIFF
--- a/frontend/stores/dashboard/useUserDashboardStore.ts
+++ b/frontend/stores/dashboard/useUserDashboardStore.ts
@@ -120,7 +120,7 @@ export function useUserDashboardStore () {
   // Update the hash (=hashed list of id's) of a specific local dashboard
   function updateHash (type: DashboardType, hash: string) {
     if (!isPublicDashboardKey(hash) || isSharedKey(hash)) {
-      warn('updateHash: invalid public hashed key: ', hash)
+      warn('invalid public hashed key: ', hash)
       return
     }
     if (type === 'validator') {

--- a/frontend/stores/dashboard/useUserDashboardStore.ts
+++ b/frontend/stores/dashboard/useUserDashboardStore.ts
@@ -6,6 +6,7 @@ import { type DashboardKey, type DashboardType, type CookieDashboard, COOKIE_DAS
 import { COOKIE_KEY } from '~/types/cookie'
 import { API_PATH } from '~/types/customFetch'
 import type { ChainIDs } from '~/types/network'
+import { isPublicDashboardKey, isSharedKey } from '~/utils/dashboard/key'
 
 const userDashboardStore = defineStore('user_dashboards_store', () => {
   const data = ref<UserDashboardsData | undefined | null>()
@@ -118,6 +119,10 @@ export function useUserDashboardStore () {
 
   // Update the hash (=hashed list of id's) of a specific local dashboard
   function updateHash (type: DashboardType, hash: string) {
+    if (!isPublicDashboardKey(hash) || isSharedKey(hash)) {
+      warn('updateHash: invalid public hashed key: ', hash)
+      return
+    }
     if (type === 'validator') {
       const cd:CookieDashboard = { id: COOKIE_DASHBOARD_ID.VALIDATOR, name: '', ...dashboards.value?.validator_dashboards?.[0], hash }
       data.value = {

--- a/frontend/stores/dashboard/useValidatorDashboardBlocksStore.ts
+++ b/frontend/stores/dashboard/useValidatorDashboardBlocksStore.ts
@@ -22,6 +22,8 @@ export function useValidatorDashboardBlocksStore () {
   async function getBlocks (dashboardKey: DashboardKey, query?: TableQueryParams) {
     if (!dashboardKey) {
       data.value = undefined
+      isLoading.value = false
+      storedQuery.value = undefined
       return undefined
     }
     isLoading.value = true

--- a/frontend/stores/dashboard/useValidatorDashboardClDepositsStore.ts
+++ b/frontend/stores/dashboard/useValidatorDashboardClDepositsStore.ts
@@ -38,6 +38,8 @@ export function useValidatorDashboardClDepositsStore () {
   ) {
     if (!dashboardKey) {
       data.value = undefined
+      isLoadingDeposits.value = false
+      storedQuery.value = undefined
       return undefined
     }
     storedQuery.value = query
@@ -62,6 +64,7 @@ export function useValidatorDashboardClDepositsStore () {
   async function getTotalAmount (dashboardKey: DashboardKey) {
     if (!dashboardKey) {
       total.value = undefined
+      isLoadingTotal.value = false
       return undefined
     }
     isLoadingTotal.value = true

--- a/frontend/stores/dashboard/useValidatorDashboardElDepositsStore.ts
+++ b/frontend/stores/dashboard/useValidatorDashboardElDepositsStore.ts
@@ -38,6 +38,8 @@ export function useValidatorDashboardElDepositsStore () {
   ) {
     if (!dashboardKey) {
       data.value = undefined
+      isLoadingDeposits.value = false
+      storedQuery.value = undefined
       return undefined
     }
     storedQuery.value = query
@@ -62,6 +64,7 @@ export function useValidatorDashboardElDepositsStore () {
   async function getTotalAmount (dashboardKey: DashboardKey) {
     if (!dashboardKey) {
       total.value = undefined
+      isLoadingTotal.value = false
       return undefined
     }
     isLoadingTotal.value = true

--- a/frontend/stores/dashboard/useValidatorDashboardRewardsStore.ts
+++ b/frontend/stores/dashboard/useValidatorDashboardRewardsStore.ts
@@ -25,6 +25,8 @@ export function useValidatorDashboardRewardsStore () {
   async function getRewards (dashboardKey: DashboardKey, query?: TableQueryParams) {
     if (!dashboardKey) {
       data.value = undefined
+      isLoading.value = false
+      storedQuery.value = undefined
       return undefined
     }
     isLoading.value = true

--- a/frontend/stores/dashboard/useValidatorDashboardSummaryStore.ts
+++ b/frontend/stores/dashboard/useValidatorDashboardSummaryStore.ts
@@ -24,6 +24,8 @@ export function useValidatorDashboardSummaryStore () {
   async function getSummary (dashboardKey: DashboardKey, timeFrame: SummaryTimeFrame, query?: TableQueryParams) {
     if (!dashboardKey) {
       data.value = undefined
+      isLoading.value = false
+      storedQuery.value = undefined
       return undefined
     }
     isLoading.value = true

--- a/frontend/stores/dashboard/useValidatorDashboardWithdrawalsStore.ts
+++ b/frontend/stores/dashboard/useValidatorDashboardWithdrawalsStore.ts
@@ -25,6 +25,8 @@ export function useValidatorDashboardWithdrawalsStore () {
   async function getWithdrawals (dashboardKey: DashboardKey, query?: TableQueryParams) {
     if (!dashboardKey) {
       data.value = undefined
+      isLoadingWithdrawals.value = false
+      storedQuery.value = undefined
       return undefined
     }
 
@@ -44,6 +46,7 @@ export function useValidatorDashboardWithdrawalsStore () {
   async function getTotalAmount (dashboardKey: DashboardKey) {
     if (!dashboardKey) {
       total.value = undefined
+      isLoadingTotal.value = false
       return undefined
     }
 

--- a/frontend/utils/html.ts
+++ b/frontend/utils/html.ts
@@ -5,7 +5,7 @@ export function isParent (parent:HTMLElement | null, child:HTMLElement | null): 
   let node = child.parentNode
 
   // keep iterating unless null
-  while (node !== null) {
+  while (node) {
     if (node === parent) {
       return true
     }


### PR DESCRIPTION
This PR:
- makes sure that we don't set the shared dashboard key in the cookie dashboard
- fixes the issue in the Validator Summary tables when you switch from a shared dashboard to an empty dashboard .*
- fixes an error in the html utils where we check for an elements parent that sometimes cause an error in the console

.* to recreate the problem: Be not logged in. Create an empty dashboard (don't add validators). Open a shared dashboard and then click the 'go to dashboard' button in the bottom. Result before the bugfix: the shard key was put in the dashboard cookie and the summary table still showed the shared dashboard data. And sometimes this was leading to the browser to be frozen. 