### PR TITLE
summary table - hide 1h option in prod

### DIFF
--- a/frontend/components/dashboard/table/DashboardTableSummary.vue
+++ b/frontend/components/dashboard/table/DashboardTableSummary.vue
@@ -28,7 +28,7 @@ const showAbsoluteValues = ref<boolean | null>(null)
 const { overview, hasValidators, validatorCount } = useValidatorDashboardOverviewStore()
 const { groups } = useValidatorDashboardGroups()
 
-const timeFrames = computed(() => SummaryTimeFrames.map(t => ({ name: $t(`time_frames.${t}`), id: t })))
+const timeFrames = computed(() => SummaryTimeFrames.filter(t => showInDevelopment || t !== 'last_1h').map(t => ({ name: $t(`time_frames.${t}`), id: t })))
 const selectedTimeFrame = ref<SummaryTimeFrame>('last_24h')
 
 const { width } = useWindowSize()


### PR DESCRIPTION
This PR:
-  hides the 1h option in the dropdown of the summary table for non dev environment 