### PR TITLE
Replace text for the tooltip. BIDS-3242.

### DIFF
--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -171,7 +171,7 @@
   },
   "slotViz": {
     "head": "Head",
-    "info_tootlip": "Slot Viz explanation",
+    "info_tootlip": "Click here for an extended information on how the slot visualization works",
     "filter": {
       "attestation": "If enabled, attestations will be shown.",
       "proposal": "If enabled, blocks will be shown.",


### PR DESCRIPTION
Replace the placeholder tooltip text with the approved text. 