### PR TITLE
Fix `DashboardOverviewBox` does not show data

### DIFF
--- a/frontend/components/dashboard/OverviewBox.vue
+++ b/frontend/components/dashboard/OverviewBox.vue
@@ -22,7 +22,8 @@ const openValidatorModal = () => {
     data: {
       context: 'dashboard',
       dashboardName: getDashboardLabel(dashboardKey.value, 'validator'),
-      dashboardKey: dashboardKey.value
+      dashboardKey: dashboardKey.value,
+      timeFrame: 'last_24h'
     }
   })
 }


### PR DESCRIPTION
Request  to `DASHBOARD_VALIDATOR_INDICES` needed  `period query parameter`. 
For now it was `hard coded` to `last_24h`.

See: BIDS-3227