### PR TITLE
Remove OVH from translations

### DIFF
--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -687,7 +687,7 @@
         "tooltip":{
           "lower": "{name}'s efficiency is below the network average of {average}",
           "higher": "{name}'s efficiency is above the network average of {average}",
-          "equal":"{name}'s OVH’s efficiency is at the network average of {average}",
+          "equal":"{name}'s efficiency is at the network average of {average}",
           "amount_of_validators": "(amount of validators)",
           "amount_of_rounds": "(amount of rounds)",
           "estimated_loss": "Estimated loss based on avg. network performance.",


### PR DESCRIPTION
This PR
* removes the faulty "OVH's" from the translation files for this use-case:
![image](https://github.com/user-attachments/assets/4fcce42e-0211-4236-a5b2-79b36c223ce6)
