### PR TITLE
(BIDS-3032) preparing the arrival of new es-lint rules

### DIFF
--- a/frontend/components/dashboard/creation/DashboardCreationController.vue
+++ b/frontend/components/dashboard/creation/DashboardCreationController.vue
@@ -7,6 +7,7 @@ import { API_PATH } from '~/types/customFetch'
 const { createValidatorDashboard, createAccountDashboard } = useUserDashboardStore()
 const { dashboards } = useUserDashboardStore()
 const { user, isLoggedIn } = useUserStore()
+const { currentNetwork } = useNetworkStore()
 
 interface Props {
   displayMode: DashboardCreationDisplayMode,
@@ -52,7 +53,7 @@ function show (forcedType : DashboardType|'' = '', forcedNetwork: ChainIDs = 0) 
       type.value = 'account'
     }
   }
-  network.value = forcedNetwork
+  network.value = forcedNetwork || currentNetwork.value
   state.value = 'type'
   name.value = isLoggedIn.value ? '' : 'cookie'
 }

--- a/frontend/components/dashboard/creation/DashboardCreationNetworkMask.vue
+++ b/frontend/components/dashboard/creation/DashboardCreationNetworkMask.vue
@@ -7,15 +7,16 @@ const { currentNetwork, availableNetworks, isNetworkDisabled } = useNetworkStore
 const { t: $t } = useI18n()
 
 const network = defineModel<ChainIDs>('network', { required: true })
-const selection = ref<`${ChainIDs}` | ''>('')
+const selection = usePrimitiveRefBridge<ChainIDs, `${ChainIDs}`|''>(network)
 
-watch(selection, (value) => { network.value = Number(value) as ChainIDs }, { immediate: true })
+const buttonList = shallowRef<any[]>([])
 
-const buttonList = computed(() => {
-  const list = [] as any[]
+watch(currentNetwork, (id) => { network.value = id })
+watch(availableNetworks, () => {
+  buttonList.value = [] as any[]
   availableNetworks.value.forEach((chainId) => {
     if (isL1(chainId)) {
-      list.push({
+      buttonList.value.push({
         value: String(chainId),
         text: ChainInfo[chainId].nameParts[0],
         subText: isNetworkDisabled(chainId) ? $t('common.coming_soon') : ChainInfo[chainId].nameParts[1],
@@ -26,9 +27,7 @@ const buttonList = computed(() => {
       })
     }
   })
-  selection.value = `${currentNetwork.value}`
-  return list
-})
+}, { immediate: true })
 
 const emit = defineEmits<{(e: 'next'): void, (e: 'back'): void }>()
 


### PR DESCRIPTION
This PR removes a warning that Marcel encountered during the update of Nuxt.

Additionally, I replace the unsafe connection between two reactive variables with a simple bridge.