### PR TITLE
fix(dashboard): enable 1h timeframe, fix types error and loading bug

### DIFF
--- a/frontend/components/dashboard/DashboardControls.vue
+++ b/frontend/components/dashboard/DashboardControls.vue
@@ -8,7 +8,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
 import type { DynamicDialogCloseOptions } from 'primevue/dynamicdialogoptions'
 import { BcDialogConfirm, DashboardShareModal, DashboardShareCodeModal } from '#components'
-import type { DashboardKey } from '~/types/dashboard'
+import type { DashboardKey, Dashboard } from '~/types/dashboard'
 import type { MenuBarEntry } from '~/types/menuBar'
 import { API_PATH } from '~/types/customFetch'
 
@@ -152,8 +152,8 @@ const deleteAction = async (key: DashboardKey, deleteDashboard: boolean, forward
 
   if (forward) {
     // try to forward the user to a private dashboard
-    let preferedDashboards = dashboards.value?.validator_dashboards ?? []
-    let fallbackDashboards = dashboards.value?.account_dashboards ?? []
+    let preferedDashboards: Dashboard[] = dashboards.value?.validator_dashboards ?? []
+    let fallbackDashboards: Dashboard[] = dashboards.value?.account_dashboards ?? []
     let fallbackUrl = '/account-dashboard/'
     if (dashboardType.value === 'account') {
       preferedDashboards = dashboards.value?.account_dashboards ?? []

--- a/frontend/components/dashboard/table/DashboardTableSummary.vue
+++ b/frontend/components/dashboard/table/DashboardTableSummary.vue
@@ -17,7 +17,6 @@ const { dashboardKey, isPublic } = useDashboardKey()
 const cursor = ref<Cursor>()
 const pageSize = ref<number>(10)
 const { t: $t } = useI18n()
-const showInDevelopment = Boolean(useRuntimeConfig().public.showInDevelopment)
 const chartFilter = ref<SummaryChartFilter>({ aggregation: 'hourly', efficiency: 'all', groupIds: [] })
 
 const { summary, query: lastQuery, isLoading, getSummary } = useValidatorDashboardSummaryStore()
@@ -28,7 +27,7 @@ const showAbsoluteValues = ref<boolean | null>(null)
 const { overview, hasValidators, validatorCount } = useValidatorDashboardOverviewStore()
 const { groups } = useValidatorDashboardGroups()
 
-const timeFrames = computed(() => SummaryTimeFrames.filter(t => showInDevelopment || t !== 'last_1h').map(t => ({ name: $t(`time_frames.${t}`), id: t })))
+const timeFrames = computed(() => SummaryTimeFrames.map(t => ({ name: $t(`time_frames.${t}`), id: t })))
 const selectedTimeFrame = ref<SummaryTimeFrame>('last_24h')
 
 const { width } = useWindowSize()

--- a/frontend/pages/dashboard/[[id]]/index.vue
+++ b/frontend/pages/dashboard/[[id]]/index.vue
@@ -57,7 +57,8 @@ await useAsyncData('user_dashboards', () => refreshDashboards(), { watch: [isLog
 
 const { error: validatorOverviewError } = await useAsyncData('validator_overview', () => refreshOverview(dashboardKey.value), { watch: [dashboardKey] })
 watch(validatorOverviewError, (error) => {
-  if (error && dashboardKey.value) {
+  // we temporary blacklist dashboard id's that threw an error 
+  if (error && dashboardKey.value && !(!!dashboards.value?.account_dashboards?.find(d => d.id.toString() === dashboardKey.value) || !!dashboards.value?.validator_dashboards?.find(d => !d.is_archived && d.id.toString() === dashboardKey.value))) {
     if (!errorDashboardKeys.includes(dashboardKey.value)) {
       errorDashboardKeys.push(dashboardKey.value)
     }
@@ -66,7 +67,7 @@ watch(validatorOverviewError, (error) => {
 }, { immediate: true })
 
 const dashboardCreationControllerModal = ref<typeof DashboardCreationController>()
-function showDashboardCreationDialog () {
+function showDashboardCreationDialog() {
   dashboardCreationControllerModal.value?.show()
 }
 
@@ -112,11 +113,8 @@ watch([dashboardKey, isLoggedIn], ([newKey, newLoggedIn], [oldKey]) => {
     </BcPageWrapper>
   </div>
   <div v-else>
-    <DashboardCreationController
-      ref="dashboardCreationControllerModal"
-      class="modal-controller"
-      :display-mode="'modal'"
-    />
+    <DashboardCreationController ref="dashboardCreationControllerModal" class="modal-controller"
+      :display-mode="'modal'" />
     <BcPageWrapper>
       <template #top>
         <DashboardHeader :dashboard-title="overview?.name" @show-creation="showDashboardCreationDialog()" />

--- a/frontend/pages/dashboard/[[id]]/index.vue
+++ b/frontend/pages/dashboard/[[id]]/index.vue
@@ -57,7 +57,7 @@ await useAsyncData('user_dashboards', () => refreshDashboards(), { watch: [isLog
 
 const { error: validatorOverviewError } = await useAsyncData('validator_overview', () => refreshOverview(dashboardKey.value), { watch: [dashboardKey] })
 watch(validatorOverviewError, (error) => {
-  // we temporary blacklist dashboard id's that threw an error 
+  // we temporary blacklist dashboard id's that threw an error
   if (error && dashboardKey.value && !(!!dashboards.value?.account_dashboards?.find(d => d.id.toString() === dashboardKey.value) || !!dashboards.value?.validator_dashboards?.find(d => !d.is_archived && d.id.toString() === dashboardKey.value))) {
     if (!errorDashboardKeys.includes(dashboardKey.value)) {
       errorDashboardKeys.push(dashboardKey.value)
@@ -67,7 +67,7 @@ watch(validatorOverviewError, (error) => {
 }, { immediate: true })
 
 const dashboardCreationControllerModal = ref<typeof DashboardCreationController>()
-function showDashboardCreationDialog() {
+function showDashboardCreationDialog () {
   dashboardCreationControllerModal.value?.show()
 }
 
@@ -113,8 +113,11 @@ watch([dashboardKey, isLoggedIn], ([newKey, newLoggedIn], [oldKey]) => {
     </BcPageWrapper>
   </div>
   <div v-else>
-    <DashboardCreationController ref="dashboardCreationControllerModal" class="modal-controller"
-      :display-mode="'modal'" />
+    <DashboardCreationController
+      ref="dashboardCreationControllerModal"
+      class="modal-controller"
+      :display-mode="'modal'"
+    />
     <BcPageWrapper>
       <template #top>
         <DashboardHeader :dashboard-title="overview?.name" @show-creation="showDashboardCreationDialog()" />

--- a/frontend/stores/dashboard/useUserDashboardStore.ts
+++ b/frontend/stores/dashboard/useUserDashboardStore.ts
@@ -70,7 +70,7 @@ export function useUserDashboardStore () {
   async function createValidatorDashboard (name: string, network: ChainIDs, dashboardKey?: string):Promise<CookieDashboard |undefined> {
     if (!isLoggedIn.value) {
       // Create local Validator dashboard
-      const cd:CookieDashboard = { id: COOKIE_DASHBOARD_ID.VALIDATOR, name: '', hash: dashboardKey ?? ''}
+      const cd:CookieDashboard = { id: COOKIE_DASHBOARD_ID.VALIDATOR, name: '', hash: dashboardKey ?? '' }
       data.value = {
         account_dashboards: dashboards.value?.account_dashboards || [],
         validator_dashboards: [cd as ValidatorDashboard]

--- a/frontend/stores/dashboard/useUserDashboardStore.ts
+++ b/frontend/stores/dashboard/useUserDashboardStore.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { warn } from 'vue'
-import type { GetUserDashboardsResponse, UserDashboardsData } from '~/types/api/dashboard'
+import type { GetUserDashboardsResponse, UserDashboardsData, ValidatorDashboard } from '~/types/api/dashboard'
 import type { VDBPostReturnData } from '~/types/api/validator_dashboard'
 import { type DashboardKey, type DashboardType, type CookieDashboard, COOKIE_DASHBOARD_ID } from '~/types/dashboard'
 import { COOKIE_KEY } from '~/types/cookie'
@@ -70,10 +70,10 @@ export function useUserDashboardStore () {
   async function createValidatorDashboard (name: string, network: ChainIDs, dashboardKey?: string):Promise<CookieDashboard |undefined> {
     if (!isLoggedIn.value) {
       // Create local Validator dashboard
-      const cd:CookieDashboard = { id: COOKIE_DASHBOARD_ID.VALIDATOR, name: '', hash: dashboardKey ?? '' }
+      const cd:CookieDashboard = { id: COOKIE_DASHBOARD_ID.VALIDATOR, name: '', hash: dashboardKey ?? ''}
       data.value = {
         account_dashboards: dashboards.value?.account_dashboards || [],
-        validator_dashboards: [cd]
+        validator_dashboards: [cd as ValidatorDashboard]
       }
       saveToCookie(data.value)
       return cd
@@ -85,7 +85,7 @@ export function useUserDashboardStore () {
         account_dashboards: dashboards.value?.account_dashboards || [],
         validator_dashboards: [
           ...(dashboards.value?.validator_dashboards || []),
-          { id: res.data.id, name: res.data.name }
+          { id: res.data.id, name: res.data.name, is_archived: false, validator_count: 0, group_count: 1 }
         ]
       }
       return res.data
@@ -127,7 +127,7 @@ export function useUserDashboardStore () {
       const cd:CookieDashboard = { id: COOKIE_DASHBOARD_ID.VALIDATOR, name: '', ...dashboards.value?.validator_dashboards?.[0], hash }
       data.value = {
         account_dashboards: dashboards.value?.account_dashboards || [],
-        validator_dashboards: [cd]
+        validator_dashboards: [cd as ValidatorDashboard]
       }
     } else {
       const cd:CookieDashboard = { id: COOKIE_DASHBOARD_ID.ACCOUNT, name: '', ...dashboards.value?.account_dashboards?.[0], hash }


### PR DESCRIPTION
This PR: 
- enabled the 1h timeframe for the dashboard summary
- fixes a type error introduced by new props on the Validator Dashboard api types
- fixes a bug where we infinitely try to load our own validator dashboards when we encounter an error while loading the overview. 
  - new logic only tries to load our own validator dashboard if the dashboard we tried was not our own (like shared) or was archived.

BIDS-3293