### PR TITLE
refactor(i18n): replace `useI18n()` with `useTranslation()`

### DIFF
--- a/frontend/components/bc/BcFaq.vue
+++ b/frontend/components/bc/BcFaq.vue
@@ -7,7 +7,7 @@ interface Props {
   translationPath?: string
 }
 const props = defineProps<Props>()
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const questions = computed(() => {
   const list = []

--- a/frontend/components/bc/BcMaintenanceBanner.vue
+++ b/frontend/components/bc/BcMaintenanceBanner.vue
@@ -3,7 +3,7 @@ import { warn } from 'vue'
 
 const { public: { maintenanceTS } } = useRuntimeConfig()
 const { tick } = useInterval(60)
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const maintenanceLabel = computed(() => {
   if (!maintenanceTS) {

--- a/frontend/components/bc/CookieModal.vue
+++ b/frontend/components/bc/CookieModal.vue
@@ -3,7 +3,7 @@ import { COOKIE_KEY, type CookiesPreference } from '~/types/cookie'
 import { Target } from '~/types/links'
 
 const cookiePreference = useCookie<CookiesPreference>(COOKIE_KEY.COOKIES_PREFERENCE, { default: () => undefined })
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const setCookiePreference = (value: CookiesPreference) => {
   cookiePreference.value = value

--- a/frontend/components/bc/CopyToClipboard.vue
+++ b/frontend/components/bc/CopyToClipboard.vue
@@ -10,7 +10,7 @@ interface Props {
 }
 const props = defineProps<Props>()
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { value: tooltip, bounce, instant } = useDebounceValue<string>($t('clipboard.copy'), 2000)
 
 function copyToClipboard (): void {

--- a/frontend/components/bc/dialog/BcDialogConfirm.vue
+++ b/frontend/components/bc/dialog/BcDialogConfirm.vue
@@ -8,7 +8,7 @@ interface Props {
   severity?: 'default' | 'danger'
 }
 const { props, dialogRef } = useBcDialog<Props>({ showHeader: false })
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const noLabel = computed(() => props.value?.noLabel || $t('navigation.no'))
 const yesLabel = computed(() => props.value?.yesLabel || $t('navigation.yes'))

--- a/frontend/components/bc/footer/LinkList.vue
+++ b/frontend/components/bc/footer/LinkList.vue
@@ -13,7 +13,7 @@ import {
 
 import { Target } from '~/types/links'
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 type Row = { title: string, links: [string, IconDefinition, string, Target][] }
 const columns: Row[] = [
   {

--- a/frontend/components/bc/format/FormatTimePassed.vue
+++ b/frontend/components/bc/format/FormatTimePassed.vue
@@ -14,7 +14,7 @@ interface Props {
   unitLength?: StringUnitLength
 }
 const props = defineProps<Props>()
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { timestamp } = useDate()
 const { setting } = useGlobalSetting<AgeFormat>('age-format')
 

--- a/frontend/components/bc/header/MainHeader.vue
+++ b/frontend/components/bc/header/MainHeader.vue
@@ -19,7 +19,7 @@ const { slotToEpoch, currentNetwork, networkInfo } = useNetworkStore()
 const { doLogout, isLoggedIn } = useUserStore()
 const { currency, available, rates } = useCurrency()
 const { width } = useWindowSize()
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const colorMode = useColorMode()
 const isSmallScreen = computed(() => width.value < smallHeaderThreshold)

--- a/frontend/components/bc/header/MegaMenu.vue
+++ b/frontend/components/bc/header/MegaMenu.vue
@@ -56,7 +56,7 @@ import IconWebhook from '~/components/icon/megaMenu/WebHook.vue'
 import { Target } from '~/types/links'
 import { mobileHeaderThreshold, smallHeaderThreshold } from '~/types/header'
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { width } = useWindowSize()
 const { doLogout, isLoggedIn } = useUserStore()
 const route = useRoute()

--- a/frontend/components/bc/premium/BcPremiumModal.vue
+++ b/frontend/components/bc/premium/BcPremiumModal.vue
@@ -5,7 +5,7 @@ interface Props {
 }
 
 const { props, dialogRef, setHeader } = useBcDialog<Props>({ contentClass: 'premium-modal' })
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const hide = () => {
   dialogRef?.value.close()

--- a/frontend/components/bc/searchbar/CategorySelectors.vue
+++ b/frontend/components/bc/searchbar/CategorySelectors.vue
@@ -16,7 +16,7 @@ defineProps<{
 }>()
 const liveState = defineModel<CategoryFilter>({ required: true }) // each entry has a Category as key and the state of the option as value. The component will write directly into it, so the data of the parent is always up-to-date.
 
-const { t } = useI18n()
+const { t } = useTranslation()
 
 function selectionHasChanged (category : Category, selected : boolean) {
   liveState.value.set(category, selected)

--- a/frontend/components/bc/searchbar/NetworkSelector.vue
+++ b/frontend/components/bc/searchbar/NetworkSelector.vue
@@ -12,7 +12,7 @@ defineProps<{
 }>()
 const liveState = defineModel<NetworkFilter>({ required: true }) // each entry has a ChainIDs as key and the state of the option as value. The component will write directly into it, so the data of the parent is always up-to-date.
 
-const { t } = useI18n()
+const { t } = useTranslation()
 
 const headState = ref<{look : 'on'|'off', network : string}>({
   look: 'off',

--- a/frontend/components/bc/searchbar/SearchbarMain.vue
+++ b/frontend/components/bc/searchbar/SearchbarMain.vue
@@ -42,7 +42,7 @@ const dropdownLayout = ref<SearchbarDropdownLayout>('narrow-dropdown')
 
 defineExpose<ExposedSearchbarMethods>({ hideResult, closeDropdown, empty })
 
-const { t } = useI18n()
+const { t } = useTranslation()
 const { fetch } = useCustomFetch()
 const { availableNetworks } = useNetworkStore()
 

--- a/frontend/components/bc/searchbar/SuggestionRow.vue
+++ b/frontend/components/bc/searchbar/SuggestionRow.vue
@@ -29,7 +29,7 @@ const props = defineProps<{
   screenWidthCausingSuddenChange: number
 }>()
 
-const { t } = useI18n()
+const { t } = useTranslation()
 
 function formatSubcategoryCell () : string {
   const i18nPathOfSubcategoryTitle = getI18nPathOfTranslatableLitteral(SubCategoryInfo[TypeInfo[props.suggestion.type].subCategory].title)

--- a/frontend/components/bc/table/BcTableValidTag.vue
+++ b/frontend/components/bc/table/BcTableValidTag.vue
@@ -6,7 +6,7 @@ interface Props {
 }
 const props = defineProps<Props>()
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const data = computed<{color: TagColor, label: string}>(() => {
   return {

--- a/frontend/components/block/table/BlockTableStatus.vue
+++ b/frontend/components/block/table/BlockTableStatus.vue
@@ -9,7 +9,7 @@ interface Props {
 }
 const props = defineProps<Props>()
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const { latestState } = useLatestStateStore()
 

--- a/frontend/components/dashboard/DashboardControls.vue
+++ b/frontend/components/dashboard/DashboardControls.vue
@@ -16,7 +16,7 @@ const { isLoggedIn } = useUserStore()
 const { dashboardKey, isPublic, isPrivate, isShared, setDashboardKey, dashboardType, publicEntities } = useDashboardKey()
 const { refreshDashboards, dashboards, getDashboardLabel, updateHash } = useUserDashboardStore()
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { width } = useWindowSize()
 const dialog = useDialog()
 const { fetch } = useCustomFetch()

--- a/frontend/components/dashboard/DashboardHeader.vue
+++ b/frontend/components/dashboard/DashboardHeader.vue
@@ -19,7 +19,7 @@ interface Props {
 }
 const props = defineProps<Props>()
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const route = useRoute()
 const router = useRouter()
 const isValidatorDashboard = route.name === 'dashboard-id'

--- a/frontend/components/dashboard/DashboardRenameModal.vue
+++ b/frontend/components/dashboard/DashboardRenameModal.vue
@@ -3,7 +3,7 @@ import type { DashboardType } from '~/types/dashboard'
 import { API_PATH } from '~/types/customFetch'
 import type { ValidatorDashboard } from '~/types/api/dashboard'
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { fetch } = useCustomFetch()
 
 const name = defineModel<string>('name', { default: '' })

--- a/frontend/components/dashboard/DashboardShareCodeModal.vue
+++ b/frontend/components/dashboard/DashboardShareCodeModal.vue
@@ -9,7 +9,7 @@ interface Props {
   dashboard?: ValidatorDashboard; // Currently only validator dashboards are supported. For public dashboards this will be undefined
 }
 const { props, dialogRef } = useBcDialog<Props>()
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const router = useRouter()
 const url = useRequestURL()
 const { refreshDashboards } = useUserDashboardStore()

--- a/frontend/components/dashboard/DashboardShareModal.vue
+++ b/frontend/components/dashboard/DashboardShareModal.vue
@@ -10,7 +10,7 @@ interface Props {
   dashboard: ValidatorDashboard; // Currently only validator dashboards are supported
 }
 const { props, dialogRef } = useBcDialog<Props>()
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { refreshDashboards } = useUserDashboardStore()
 const { fetch } = useCustomFetch()
 

--- a/frontend/components/dashboard/GroupManagementModal.vue
+++ b/frontend/components/dashboard/GroupManagementModal.vue
@@ -14,7 +14,7 @@ import type { Cursor, SortOrder } from '~/types/datatable'
 import { getSortOrder } from '~/utils/table'
 import { API_PATH } from '~/types/customFetch'
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { fetch } = useCustomFetch()
 const dialog = useDialog()
 

--- a/frontend/components/dashboard/SharedDashboardModal.vue
+++ b/frontend/components/dashboard/SharedDashboardModal.vue
@@ -4,7 +4,7 @@ import { COOKIE_KEY, type CookiesPreference } from '~/types/cookie'
 const cookiePreference = useCookie<CookiesPreference>(COOKIE_KEY.COOKIES_PREFERENCE, { default: () => undefined })
 const { isShared } = useDashboardKey()
 const { dashboards } = useUserDashboardStore()
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const route = useRoute()
 
 const dismissed = ref(false)

--- a/frontend/components/dashboard/ValidatorEpochDutiesModal.vue
+++ b/frontend/components/dashboard/ValidatorEpochDutiesModal.vue
@@ -7,7 +7,7 @@ import type { ValidatorHistoryDuties } from '~/types/api/common'
 import type { PathValues } from '~/types/customFetch'
 import { API_PATH } from '~/types/customFetch'
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { fetch } = useCustomFetch()
 
 const { width } = useWindowSize()

--- a/frontend/components/dashboard/ValidatorManagementModal.vue
+++ b/frontend/components/dashboard/ValidatorManagementModal.vue
@@ -16,7 +16,7 @@ import { type SearchBar, SearchbarShape, SearchbarColors, SearchbarPurpose, type
 import { API_PATH, type PathValues } from '~/types/customFetch'
 import { useNetworkStore } from '~/stores/useNetworkStore'
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { fetch } = useCustomFetch()
 const { currentNetwork } = useNetworkStore()
 

--- a/frontend/components/dashboard/ValidatorOverview.vue
+++ b/frontend/components/dashboard/ValidatorOverview.vue
@@ -6,7 +6,7 @@ import { type OverviewTableData } from '~/types/dashboard/overview'
 import { TimeFrames, type NumberOrString } from '~/types/value'
 import { totalElClNumbers } from '~/utils/bigMath'
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { converter } = useValue()
 
 const tPath = 'dashboard.validator.overview.'

--- a/frontend/components/dashboard/ValidatorSlotViz.vue
+++ b/frontend/components/dashboard/ValidatorSlotViz.vue
@@ -4,7 +4,7 @@ import { orderBy } from 'lodash-es'
 import { useValidatorSlotVizStore } from '~/stores/dashboard/useValidatorSlotVizStore'
 import { getGroupLabel } from '~/utils/dashboard/group'
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { dashboardKey } = useDashboardKey()
 const { validatorCount, overview } = useValidatorDashboardOverviewStore()
 const { networkInfo } = useNetworkStore()

--- a/frontend/components/dashboard/chart/DashboardChartSummaryChartFilter.vue
+++ b/frontend/components/dashboard/chart/DashboardChartSummaryChartFilter.vue
@@ -3,7 +3,7 @@ import { orderBy } from 'lodash-es'
 import { type AggregationTimeframe, AggregationTimeframes, type EfficiencyType, EfficiencyTypes, SUMMARY_CHART_GROUP_NETWORK_AVERAGE, SUMMARY_CHART_GROUP_TOTAL, type SummaryChartFilter } from '~/types/dashboard/summary'
 import { getGroupLabel } from '~/utils/dashboard/group'
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const { overview } = useValidatorDashboardOverviewStore()
 

--- a/frontend/components/dashboard/chart/RewardsChart.vue
+++ b/frontend/components/dashboard/chart/RewardsChart.vue
@@ -63,7 +63,7 @@ await useAsyncData('validator_dashboard_rewards_chart', async () => {
 
 const { groups } = useValidatorDashboardGroups()
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const colorMode = useColorMode()
 
 const { converter } = useValue()

--- a/frontend/components/dashboard/chart/SummaryChart.vue
+++ b/frontend/components/dashboard/chart/SummaryChart.vue
@@ -37,7 +37,7 @@ interface Props {
 const props = defineProps<Props>()
 const chart = ref<ECharts | undefined>()
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const colorMode = useColorMode()
 const { fetch } = useCustomFetch()
 const { tsToEpoch, slotToTs, secondsPerEpoch } = useNetworkStore()

--- a/frontend/components/dashboard/creation/DashboardCreationNetworkMask.vue
+++ b/frontend/components/dashboard/creation/DashboardCreationNetworkMask.vue
@@ -4,7 +4,7 @@ import { ChainInfo, type ChainIDs, isL1 } from '~/types/network'
 import { useNetworkStore } from '~/stores/useNetworkStore'
 
 const { currentNetwork, availableNetworks, isNetworkDisabled } = useNetworkStore()
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const emit = defineEmits<{(e: 'next' | 'back'): void }>()
 const network = defineModel<ChainIDs>('network', { required: true })

--- a/frontend/components/dashboard/creation/DashboardCreationTypeMask.vue
+++ b/frontend/components/dashboard/creation/DashboardCreationTypeMask.vue
@@ -2,7 +2,7 @@
 import { type DashboardType } from '~/types/dashboard'
 import { IconAccount, IconValidator } from '#components'
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { isLoggedIn } = useUserStore()
 
 interface Props {

--- a/frontend/components/dashboard/group/GroupLabel.vue
+++ b/frontend/components/dashboard/group/GroupLabel.vue
@@ -8,7 +8,7 @@ interface Props {
 
 const props = defineProps<Props>()
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const name = computed(() => {
   if (props.group.id === DAHSHBOARDS_ALL_GROUPS_ID) {

--- a/frontend/components/dashboard/group/GroupSelectionDialog.vue
+++ b/frontend/components/dashboard/group/GroupSelectionDialog.vue
@@ -7,7 +7,7 @@ interface Props {
   totalValidators?: number
 }
 const { props, setHeader, dialogRef } = useBcDialog<Props>()
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const selectedGroupId = ref<number>()
 

--- a/frontend/components/dashboard/table/DashboardTableBlocks.vue
+++ b/frontend/components/dashboard/table/DashboardTableBlocks.vue
@@ -10,7 +10,7 @@ const { dashboardKey, isPublic } = useDashboardKey()
 
 const cursor = ref<Cursor>()
 const pageSize = ref<number>(10)
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const { blocks, query: lastQuery, isLoading, getBlocks } = useValidatorDashboardBlocksStore()
 const { value: query, temp: tempQuery, bounce: setQuery } = useDebounceValue<TableQueryParams | undefined>(undefined, 500)

--- a/frontend/components/dashboard/table/DashboardTableClDeposits.vue
+++ b/frontend/components/dashboard/table/DashboardTableClDeposits.vue
@@ -11,7 +11,7 @@ const { dashboardKey } = useDashboardKey()
 
 const cursor = ref<Cursor>()
 const pageSize = ref<number>(5)
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const { slotToEpoch } = useNetworkStore()
 

--- a/frontend/components/dashboard/table/DashboardTableElDeposits.vue
+++ b/frontend/components/dashboard/table/DashboardTableElDeposits.vue
@@ -10,7 +10,7 @@ const { dashboardKey } = useDashboardKey()
 
 const cursor = ref<Cursor>()
 const pageSize = ref<number>(5)
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const { deposits, query: lastQuery, getDeposits, getTotalAmount, totalAmount, isLoadingDeposits, isLoadingTotal } = useValidatorDashboardElDepositsStore()
 const { value: query, bounce: setQuery } = useDebounceValue<TableQueryParams | undefined>(undefined, 500)

--- a/frontend/components/dashboard/table/DashboardTableRewards.vue
+++ b/frontend/components/dashboard/table/DashboardTableRewards.vue
@@ -13,7 +13,7 @@ const { dashboardKey, isPublic } = useDashboardKey()
 
 const cursor = ref<Cursor>()
 const pageSize = ref<number>(10)
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const showInDevelopment = Boolean(useRuntimeConfig().public.showInDevelopment)
 
 const { rewards, query: lastQuery, isLoading, getRewards } = useValidatorDashboardRewardsStore()

--- a/frontend/components/dashboard/table/DashboardTableRewardsDetails.vue
+++ b/frontend/components/dashboard/table/DashboardTableRewardsDetails.vue
@@ -14,7 +14,7 @@ const props = defineProps<Props>()
 
 const { dashboardKey } = useDashboardKey()
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { details } = useValidatorDashboardRewardsDetailsStore(dashboardKey.value, props.row.group_id, props.row.epoch)
 
 const dialog = useDialog()

--- a/frontend/components/dashboard/table/DashboardTableSummary.vue
+++ b/frontend/components/dashboard/table/DashboardTableSummary.vue
@@ -15,7 +15,7 @@ const { dashboardKey, isPublic } = useDashboardKey()
 
 const cursor = ref<Cursor>()
 const pageSize = ref<number>(10)
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const chartFilter = ref<SummaryChartFilter>({ aggregation: 'hourly', efficiency: 'all', groupIds: [] })
 
 const { summary, query: lastQuery, isLoading, getSummary } = useValidatorDashboardSummaryStore()

--- a/frontend/components/dashboard/table/DashboardTableValidators.vue
+++ b/frontend/components/dashboard/table/DashboardTableValidators.vue
@@ -21,7 +21,7 @@ interface Props {
 }
 const props = defineProps<Props>()
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { groups } = useValidatorDashboardGroups()
 
 const dialog = useDialog()

--- a/frontend/components/dashboard/table/DashboardTableWithdrawals.vue
+++ b/frontend/components/dashboard/table/DashboardTableWithdrawals.vue
@@ -15,7 +15,7 @@ const { dashboardKey } = useDashboardKey()
 
 const cursor = ref<Cursor>()
 const pageSize = ref<number>(10)
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const { latestState } = useLatestStateStore()
 const { slotToEpoch } = useNetworkStore()

--- a/frontend/components/dashboard/table/SummaryDetails.vue
+++ b/frontend/components/dashboard/table/SummaryDetails.vue
@@ -12,7 +12,7 @@ const props = defineProps<Props>()
 
 const { dashboardKey } = useDashboardKey()
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { details: summary, getDetails } = useValidatorDashboardSummaryDetailsStore(dashboardKey.value, props.row.group_id)
 
 watch(() => props.timeFrame, () => {

--- a/frontend/components/dashboard/table/SummaryStatus.vue
+++ b/frontend/components/dashboard/table/SummaryStatus.vue
@@ -7,7 +7,7 @@ interface Props {
 }
 const props = defineProps<Props>()
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const mapped = computed(() => {
   const mapCount = (count: number, key: string, icon: SlotVizIcons) => {

--- a/frontend/components/dashboard/table/SummaryValidators.vue
+++ b/frontend/components/dashboard/table/SummaryValidators.vue
@@ -21,7 +21,7 @@ interface Props {
 }
 const props = defineProps<Props>()
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { groups } = useValidatorDashboardGroups()
 
 const dialog = useDialog()

--- a/frontend/components/dashboard/table/SummaryValue.vue
+++ b/frontend/components/dashboard/table/SummaryValue.vue
@@ -32,7 +32,7 @@ interface Props {
 }
 const props = defineProps<Props>()
 
-const { tm: $tm, t: $t } = useI18n()
+const { tm: $tm, t: $t } = useTranslation()
 const { dashboardKey } = useDashboardKey()
 const dialog = useDialog()
 const { groups } = useValidatorDashboardGroups()

--- a/frontend/components/dashboard/validator/subset/ValidatorSubsetList.vue
+++ b/frontend/components/dashboard/validator/subset/ValidatorSubsetList.vue
@@ -15,7 +15,7 @@ interface Props {
 }
 const props = defineProps<Props>()
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const paging = ref<Paging | null>(null)
 const cursor = ref<Cursor>(undefined)

--- a/frontend/components/dashboard/validator/subset/ValidatorSubsetListHeader.vue
+++ b/frontend/components/dashboard/validator/subset/ValidatorSubsetListHeader.vue
@@ -20,7 +20,7 @@ interface Props {
 }
 const props = defineProps<Props>()
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const icon = computed(() => {
   let icon: IconDefinition | undefined

--- a/frontend/components/dashboard/validator/subset/ValidatorSubsetModal.vue
+++ b/frontend/components/dashboard/validator/subset/ValidatorSubsetModal.vue
@@ -11,7 +11,7 @@ import { sortSummaryValidators } from '~/utils/dashboard/validator'
 import { API_PATH } from '~/types/customFetch'
 import { type InternalGetValidatorDashboardSummaryValidatorsResponse, type VDBGroupSummaryData, type VDBSummaryTableRow, type VDBSummaryValidator, type VDBSummaryValidatorsData } from '~/types/api/validator_dashboard'
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { fetch } = useCustomFetch()
 
 interface Props {

--- a/frontend/components/notifications/DashboardsTable.vue
+++ b/frontend/components/notifications/DashboardsTable.vue
@@ -12,7 +12,7 @@ defineEmits<{(e: 'openDialog'): void }>()
 
 const cursor = ref<Cursor>()
 const pageSize = ref<number>(10)
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const { onSort, setCursor, setPageSize, setSearch, notificationsDashboards, query, isLoading } = useNotificationsDashboardStore()
 

--- a/frontend/components/notifications/DashboardsTableEmpty.vue
+++ b/frontend/components/notifications/DashboardsTableEmpty.vue
@@ -2,7 +2,7 @@
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { faCirclePlus, faRightFromBracket } from '@fortawesome/pro-regular-svg-icons'
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const emit = defineEmits<{(e: 'openDialog'): void }>()
 

--- a/frontend/components/notifications/management/NotificationsManagementDashboards.vue
+++ b/frontend/components/notifications/management/NotificationsManagementDashboards.vue
@@ -44,7 +44,7 @@ const MinimumTimeBetweenAPIcalls = 700 // ms. Any change ends-up saved anyway, s
 
 const { fetch } = useCustomFetch()
 const toast = useBcToast()
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const dialog = useDialog()
 const { dashboardGroups, query, cursor, pageSize, isLoading, onSort, setCursor, setPageSize, setSearch } = useNotificationsManagementDashboards()
 const { getDashboardLabel } = useUserDashboardStore()

--- a/frontend/components/notifications/management/NotificationsManagementGeneralTab.vue
+++ b/frontend/components/notifications/management/NotificationsManagementGeneralTab.vue
@@ -9,7 +9,7 @@ import { API_PATH } from '~/types/customFetch'
 import { useNotificationsManagementSettings } from '~/composables/notifications/useNotificationsManagementSettings'
 import { Target } from '~/types/links'
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { fetch } = useCustomFetch()
 const toast = useBcToast()
 

--- a/frontend/components/notifications/management/NotificationsManagementModal.vue
+++ b/frontend/components/notifications/management/NotificationsManagementModal.vue
@@ -8,7 +8,7 @@ import {
 } from '@fortawesome/pro-solid-svg-icons'
 import { useUseNotificationsManagementSettingsProvider } from '~/composables/notifications/useNotificationsManagementSettingsProvider'
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const visible = defineModel<boolean>()
 

--- a/frontend/components/notifications/management/NotificationsManagementPairedDeviceModalContent.vue
+++ b/frontend/components/notifications/management/NotificationsManagementPairedDeviceModalContent.vue
@@ -3,7 +3,7 @@ import { faTrash } from '@fortawesome/pro-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { type NotificationPairedDevice } from '~/types/api/notifications'
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 interface Props {
   device: NotificationPairedDevice

--- a/frontend/components/notifications/management/NotificationsManagementPairedDevicesModal.vue
+++ b/frontend/components/notifications/management/NotificationsManagementPairedDevicesModal.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { useNotificationsManagementSettings } from '~/composables/notifications/useNotificationsManagementSettings'
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const visible = defineModel<boolean>()
 const { pairedDevices } = useNotificationsManagementSettings()

--- a/frontend/components/notifications/management/SubscriptionDialog.vue
+++ b/frontend/components/notifications/management/SubscriptionDialog.vue
@@ -45,7 +45,7 @@ const RowsThatExpectAPercentage: Array<keyof AllOptions> =
 type ModifiableOptions = Record<keyof AllOptions, InternalEntry>
 
 const { props, dialogRef } = useBcDialog<Props>({ showHeader: false })
-const { t } = useI18n()
+const { t } = useTranslation()
 const { networkInfo } = useNetworkStore()
 const { user } = useUserStore()
 

--- a/frontend/components/notifications/management/SubscriptionRow.vue
+++ b/frontend/components/notifications/management/SubscriptionRow.vue
@@ -11,7 +11,7 @@ const props = defineProps<{
 
 const emitEvent = defineEmits<{(e: 'checkboxClick', checked: boolean) : void}>()
 
-const { t } = useI18n()
+const { t } = useTranslation()
 
 const parentVmodel = defineModel<InternalEntry>({ required: true })
 

--- a/frontend/components/pricing/PremiumAddonBox.vue
+++ b/frontend/components/pricing/PremiumAddonBox.vue
@@ -6,7 +6,7 @@ import { type ExtraDashboardValidatorsPremiumAddon, ProductCategoryPremiumAddon 
 import { formatPremiumProductPrice } from '~/utils/format'
 import { Target } from '~/types/links'
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { user, isLoggedIn } = useUserStore()
 const { stripeCustomerPortal, stripePurchase, isStripeDisabled } = useStripe()
 

--- a/frontend/components/pricing/PremiumAddons.vue
+++ b/frontend/components/pricing/PremiumAddons.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { products } = useProductsStore()
 
 interface Props {

--- a/frontend/components/pricing/PremiumCompare.vue
+++ b/frontend/components/pricing/PremiumCompare.vue
@@ -6,7 +6,7 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import type { PremiumPerks } from '~/types/api/user'
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { products } = useProductsStore()
 const showInDevelopment = Boolean(useRuntimeConfig().public.showInDevelopment)
 

--- a/frontend/components/pricing/PremiumProductBox.vue
+++ b/frontend/components/pricing/PremiumProductBox.vue
@@ -10,7 +10,7 @@ import type { Feature } from '~/types/pricing'
 
 const { products, bestPremiumProduct, currentPremiumSubscription, isPremiumSubscribedViaApp } = useProductsStore()
 const { isLoggedIn } = useUserStore()
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { stripeCustomerPortal, stripePurchase, isStripeDisabled } = useStripe()
 
 interface Props {

--- a/frontend/components/pricing/PremiumProducts.vue
+++ b/frontend/components/pricing/PremiumProducts.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { products } = useProductsStore()
 
 interface Props {

--- a/frontend/components/pricing/PremiumViaAppBanner.vue
+++ b/frontend/components/pricing/PremiumViaAppBanner.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { isPremiumSubscribedViaApp } = useProductsStore()
 </script>
 

--- a/frontend/components/slot/viz/SlotVizTooltip.vue
+++ b/frontend/components/slot/viz/SlotVizTooltip.vue
@@ -9,7 +9,7 @@ interface Props {
   currentSlotId?: number
 }
 const props = defineProps<Props>()
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const data = computed(() => {
   const slot = props.data

--- a/frontend/components/slot/viz/SlotVizViewer.vue
+++ b/frontend/components/slot/viz/SlotVizViewer.vue
@@ -22,7 +22,7 @@ interface Props {
 const props = defineProps<Props>()
 
 const { tsToSlot } = useNetworkStore()
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const selectedCategories = useCookie<SlotVizCategories[]>(COOKIE_KEY.SLOT_VIZ_SELECTED_CATEGORIES, { default: () => ['attestation', 'proposal', 'slashing', 'sync', 'visible', 'initial'] })
 

--- a/frontend/components/user/settings/UserSettingsDeleteAccount.vue
+++ b/frontend/components/user/settings/UserSettingsDeleteAccount.vue
@@ -3,7 +3,7 @@ import { BcDialogConfirm } from '#components'
 import { API_PATH } from '~/types/customFetch'
 
 const dialog = useDialog()
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { fetch } = useCustomFetch()
 const { user } = useUserStore()
 

--- a/frontend/components/user/settings/UserSettingsEmail.vue
+++ b/frontend/components/user/settings/UserSettingsEmail.vue
@@ -3,7 +3,7 @@ import { object as yupObject } from 'yup'
 import { useForm } from 'vee-validate'
 import { API_PATH } from '~/types/customFetch'
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { fetch } = useCustomFetch()
 const toast = useBcToast()
 

--- a/frontend/components/user/settings/UserSettingsPassword.vue
+++ b/frontend/components/user/settings/UserSettingsPassword.vue
@@ -3,7 +3,7 @@ import { object as yupObject } from 'yup'
 import { useForm } from 'vee-validate'
 import { API_PATH } from '~/types/customFetch'
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { fetch } = useCustomFetch()
 const toast = useBcToast()
 

--- a/frontend/components/user/settings/UserSettingsSubscriptions.vue
+++ b/frontend/components/user/settings/UserSettingsSubscriptions.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { currentPremiumSubscription } = useProductsStore()
 const { stripeCustomerPortal, isStripeDisabled } = useStripe()
 

--- a/frontend/components/validator/table/ValidatorTableDutyRewards.vue
+++ b/frontend/components/validator/table/ValidatorTableDutyRewards.vue
@@ -8,7 +8,7 @@ interface Props {
 }
 const props = defineProps<Props>()
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 const mapped = computed(() => {
   const total = totalDutyRewards(props.data)

--- a/frontend/components/validator/table/ValidatorTableDutyStatus.vue
+++ b/frontend/components/validator/table/ValidatorTableDutyStatus.vue
@@ -8,7 +8,7 @@ interface Props {
 }
 const props = defineProps<Props>()
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { networkInfo } = useNetworkStore()
 
 const mapped = computed(() => {

--- a/frontend/composables/useBcSeo.ts
+++ b/frontend/composables/useBcSeo.ts
@@ -1,5 +1,5 @@
 export function useBcSeo (pageTitle?: string | Ref<string | number | undefined> | ComputedRef<string | number | undefined>, removeDynamicUrlValue = false) {
-  const { t: $t } = useI18n()
+  const { t: $t } = useTranslation()
   const route = useRoute()
   const { networkInfo } = useNetworkStore()
 

--- a/frontend/composables/useBcToastProvider.ts
+++ b/frontend/composables/useBcToastProvider.ts
@@ -5,7 +5,7 @@ const TOAST_TIME = 3000
 
 export function useBcToastProvider () {
   const toast = useToast()
-  const { t: $t } = useI18n()
+  const { t: $t } = useTranslation()
 
   const { bounce, instant, temp, value } = useDebounceValue<ToastData[]>([], TOAST_TIME)
 

--- a/frontend/composables/useCurrency.ts
+++ b/frontend/composables/useCurrency.ts
@@ -6,7 +6,7 @@ import { type Currency } from '~/types/currencies'
 export function useCurrency () {
   const { latestState } = useLatestStateStore()
   const { networkInfo } = useNetworkStore()
-  const { t: $t } = useI18n()
+  const { t: $t } = useTranslation()
   const showInDevelopment = Boolean(useRuntimeConfig().public.showInDevelopment)
   const available = ref<Currency[]>([])
   const withLabel = ref<{currency: Currency, label: string}[]>([])

--- a/frontend/composables/useCustomFetch.ts
+++ b/frontend/composables/useCustomFetch.ts
@@ -14,7 +14,7 @@ export function useCustomFetch () {
   const xRealIp = useRequestHeader('x-real-ip')
   const { csrfHeader, setCsrfHeader } = useCsrfStore()
   const { showError } = useBcToast()
-  const { t: $t } = useI18n()
+  const { t: $t } = useTranslation()
   const { $bcLogger } = useNuxtApp()
   const uuid = inject<{value: string}>('app-uuid')
 

--- a/frontend/composables/useTranslation.ts
+++ b/frontend/composables/useTranslation.ts
@@ -4,8 +4,8 @@ export function useTranslation() {
   // enables autocompletion
   // https://vue-i18n.intlify.dev/guide/advanced/typescript.html#resource-keys-completion-supporting
   return {
-    t: useI18n<{ message: MessageSchema }>({
+    ...useI18n<{ message: MessageSchema }>({
       useScope: "global",
-    }).t,
+    })
   };
 }

--- a/frontend/composables/useValidatorDashboardGroups.ts
+++ b/frontend/composables/useValidatorDashboardGroups.ts
@@ -2,7 +2,7 @@ import type { VDBOverviewGroup } from '~/types/api/validator_dashboard'
 
 export function useValidatorDashboardGroups () {
   const { overview } = useValidatorDashboardOverviewStore()
-  const { t: $t } = useI18n()
+  const { t: $t } = useTranslation()
 
   const groups = computed<VDBOverviewGroup[]>(() => {
     if (!overview.value?.groups) {

--- a/frontend/pages/login.vue
+++ b/frontend/pages/login.vue
@@ -4,7 +4,7 @@ import { useForm } from 'vee-validate'
 import { useUserStore } from '~/stores/useUserStore'
 import { Target } from '~/types/links'
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { doLogin } = useUserStore()
 const toast = useBcToast()
 

--- a/frontend/pages/notifications.vue
+++ b/frontend/pages/notifications.vue
@@ -12,7 +12,7 @@ useDashboardKeyProvider('notifications')
 const { refreshDashboards } = useUserDashboardStore()
 const { isLoggedIn } = useUserStore()
 const dialog = useDialog()
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 await useAsyncData('user_dashboards', () => refreshDashboards(), { watch: [isLoggedIn] })
 

--- a/frontend/pages/pricing.vue
+++ b/frontend/pages/pricing.vue
@@ -2,7 +2,7 @@
 import { faArrowDown } from '@fortawesome/pro-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 
 useBcSeo('pricing.seo_title')
 const { stripeInit } = useStripeProvider()

--- a/frontend/pages/register.vue
+++ b/frontend/pages/register.vue
@@ -5,7 +5,7 @@ import { Target } from '~/types/links'
 import { tOf } from '~/utils/translation'
 import { API_PATH } from '~/types/customFetch'
 
-const { t: $t } = useI18n()
+const { t: $t } = useTranslation()
 const { fetch } = useCustomFetch()
 const toast = useBcToast()
 

--- a/frontend/stores/dashboard/useUserDashboardStore.ts
+++ b/frontend/stores/dashboard/useUserDashboardStore.ts
@@ -15,7 +15,7 @@ const userDashboardStore = defineStore('user_dashboards_store', () => {
 
 export function useUserDashboardStore () {
   const { fetch } = useCustomFetch()
-  const { t: $t } = useI18n()
+  const { t: $t } = useTranslation()
   const { data } = storeToRefs(userDashboardStore())
   const { isLoggedIn } = useUserStore()
   const dashboardCookie = useCookie(COOKIE_KEY.USER_DASHBOARDS)


### PR DESCRIPTION
This will enable `autocomplete` for `translations` to improve `dx`. And wraps `third party` code for better `maintainability`.

See: BEDS-97 (personal Ticket)