### PR TITLE
fix(dashboard): summary details attestation props sorting

### DIFF
--- a/frontend/components/dashboard/table/SummaryDetails.vue
+++ b/frontend/components/dashboard/table/SummaryDetails.vue
@@ -34,7 +34,7 @@ const data = computed<SummaryRow[][]>(() => {
 
   const rewardCols: SummaryDetailsEfficiencyCombinedProp[] = ['reward', 'missed_rewards']
   let addCols: SummaryDetailsEfficiencyCombinedProp[] = props.tableVisibility.attestations ? [] : rewardCols
-  addPropsTolist(0, ['efficiency', ...addCols, 'attestations', 'attestations_head', 'attestations_source', 'attestations_target', 'attestation_efficiency', 'attestation_avg_incl_dist'])
+  addPropsTolist(0, ['efficiency', ...addCols, 'attestations', 'attestations_source', 'attestations_target', 'attestations_head', 'attestation_efficiency', 'attestation_avg_incl_dist'])
 
   addPropsTolist(1, ['sync', 'validators_sync', 'proposals', 'validators_proposal', 'slashings', 'validators_slashings'])
 


### PR DESCRIPTION
This PR:
- fixes the sorting of the attestation props in the validator dashboard summary details. 