### PR TITLE
fix(dashboard): improve summary chart from handling

### DIFF
--- a/frontend/components/dashboard/chart/SummaryChart.vue
+++ b/frontend/components/dashboard/chart/SummaryChart.vue
@@ -403,7 +403,6 @@ const validateDataZoom = (instant?: boolean) => {
     from: fromTs,
     to: timestamps.toTs
   }
-  console.log('timestamps', timestamps.fromIndex, newTimeFrames.from)
   // when the timeframes of the slider change we bounce the new timeframe for the chart
   if (tempTimeFrames.value.to !== newTimeFrames.to || tempTimeFrames.value.from !== newTimeFrames.from) {
     if (instant) {


### PR DESCRIPTION
This PR:
- fixes the dashboard summary chart time handling
  - omits the from value if you place the slider on the far left to prevent us from going to far in the past and cause a ws error
  - refreshes the current slot that is based for the time frame range calculation when the user input changes
  - prevents the UI from being locked if we get a WS error (previously the error message was placed over the UI and prevented the user from interacting with the chart to change the settings. 

BEDS-164