### PR TITLE
fix(dashboard): place hover menubar on the correct element

### DIFF
--- a/frontend/assets/css/prime_menubar.scss
+++ b/frontend/assets/css/prime_menubar.scss
@@ -52,10 +52,10 @@
         }
       }
 
-      &:not(:has([highlight])):not(.p-disabled) > .p-menuitem-content:hover {
+      &:not(:has([highlight])):not(.p-disabled):hover {
         background: var(--list-hover-background);
       }
-      &:has([highlight]):not(.p-disabled) > .p-menuitem-content:hover {
+      &:has([highlight]):not(.p-disabled):hover {
         background: var(--button-color-hover);
       }
     }


### PR DESCRIPTION
This Pr:
- places the hover background on the correct element of the BcMenuBar elements