### PR TITLE
fix(dashbaord): fix whitespace of validator status in management modal

### DIFF
--- a/frontend/components/validator/table/ValidatorTableStatus.vue
+++ b/frontend/components/validator/table/ValidatorTableStatus.vue
@@ -37,7 +37,7 @@ const iconColor = computed(() => {
 .wrapper {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: var(--padding-small);
   .status {
     text-transform: capitalize;


### PR DESCRIPTION
This PR: 
- fixes the whitespace for the validator status in the Manage Validator Dialog