### PR TITLE
chore: add `flag` to disable `unauthorized tls certs` to `dev script`

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -51,14 +51,6 @@ chmod 400 server.key
 openssl req -new -x509 -nodes -sha256 -days 365 -key server.key -out server.crt
 ```
 
-Add the following env variable (on Ubuntu: in your `~/.profile`) needed to load local mock data:
-
-```bash
-export NODE_TLS_REJECT_UNAUTHORIZED=0
-```
-
-Restart.
-
 Navigate to folder `beaconchain/frontend` and run
 
 ```bash

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "nuxt build",
-    "dev": "nuxt dev --host=local.beaconcha.in",
+    "dev": "NODE_TLS_REJECT_UNAUTHORIZED=0 nuxt dev --host=local.beaconcha.in",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",


### PR DESCRIPTION
In order to run `dev server` with `https` we have to create a `certificate`. But this certificate is not `authorized` by a known and trusted `authority`. This is why we have to `disable` the rejection of that `certificate`

See: BEDS-97