### PR TITLE
(BEDS-274) fix auth

### DIFF
--- a/backend/pkg/api/data_access/user.go
+++ b/backend/pkg/api/data_access/user.go
@@ -155,10 +155,16 @@ func (d *DataAccessService) GetUserInfo(ctx context.Context, userId uint64) (*t.
 		return nil, fmt.Errorf("error getting productSummary: %w", err)
 	}
 
-	err = d.userReader.GetContext(ctx, &userInfo.Email, `SELECT email FROM users WHERE id = $1`, userId)
+	result := struct {
+		Email     string `db:"email"`
+		UserGroup string `db:"user_group"`
+	}{}
+	err = d.userReader.GetContext(ctx, &result, `SELECT email, user_group FROM users WHERE id = $1`, userId)
 	if err != nil {
 		return nil, fmt.Errorf("error getting userEmail: %w", err)
 	}
+	userInfo.Email = result.Email
+	userInfo.UserGroup = result.UserGroup
 
 	userInfo.Email = utils.CensorEmail(userInfo.Email)
 

--- a/backend/pkg/api/handlers/auth.go
+++ b/backend/pkg/api/handlers/auth.go
@@ -101,15 +101,13 @@ Best regards,
 
 func (h *HandlerService) GetUserIdBySession(r *http.Request) (uint64, error) {
 	user, err := h.getUserBySession(r)
-	if err != nil {
-		return 0, err
-	}
-	return user.Id, nil
+	return user.Id, err
 }
 
 const authHeaderPrefix = "Bearer "
 
 func (h *HandlerService) GetUserIdByApiKey(r *http.Request) (uint64, error) {
+	// TODO: store user id in context during ratelimting and use it here
 	var apiKey string
 	authHeader := r.Header.Get("Authorization")
 	if strings.HasPrefix(authHeader, authHeaderPrefix) {
@@ -127,10 +125,11 @@ func (h *HandlerService) GetUserIdByApiKey(r *http.Request) (uint64, error) {
 	return userId, err
 }
 
+// if this is used, user ID should've been stored in context (by GetUserIdStoreMiddleware)
 func GetUserIdByContext(r *http.Request) (uint64, error) {
 	userId, ok := r.Context().Value(ctxUserIdKey).(uint64)
 	if !ok {
-		return 0, errors.New("error getting user id from context, not a uint64")
+		return 0, newUnauthorizedErr("user not authenticated")
 	}
 	return userId, nil
 }
@@ -696,16 +695,21 @@ func (h *HandlerService) InternalPutUserPassword(w http.ResponseWriter, r *http.
 }
 
 // Middlewares
+
 // returns a middleware that stores user id in context, using the provided function
 func GetUserIdStoreMiddleware(userIdFunc func(r *http.Request) (uint64, error)) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			userId, err := userIdFunc(r)
 			if err != nil {
-				handleErr(w, err)
+				if errors.Is(err, errUnauthorized) {
+					// if next handler requires authentication, it should return 'unauthorized' itself
+					next.ServeHTTP(w, r)
+				} else {
+					handleErr(w, err)
+				}
 				return
 			}
-			// store user id in context
 			ctx := r.Context()
 			ctx = context.WithValue(ctx, ctxUserIdKey, userId)
 			r = r.WithContext(ctx)
@@ -715,45 +719,42 @@ func GetUserIdStoreMiddleware(userIdFunc func(r *http.Request) (uint64, error)) 
 }
 
 // returns a middleware that checks if user has access to dashboard when a primary id is used
-// expects a userIdFunc to return user id, probably GetUserIdBySession or GetUserIdByApiKey
-func (h *HandlerService) GetVDBAuthMiddleware(userIdFunc func(r *http.Request) (uint64, error)) func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			var err error
-			dashboardId, err := strconv.ParseUint(mux.Vars(r)["dashboard_id"], 10, 64)
-			if err != nil {
-				// if primary id is not used, no need to check access
-				next.ServeHTTP(w, r)
-				return
-			}
-			// primary id is used -> user needs to have access to dashboard
-
-			userId, err := userIdFunc(r)
-			if err != nil {
-				handleErr(w, err)
-				return
-			}
-			// store user id in context
-			ctx := r.Context()
-			ctx = context.WithValue(ctx, ctxUserIdKey, userId)
-			r = r.WithContext(ctx)
-
-			dashboard, err := h.dai.GetValidatorDashboardInfo(r.Context(), types.VDBIdPrimary(dashboardId))
-			if err != nil {
-				handleErr(w, err)
-				return
-			}
-
-			if dashboard.UserId != userId {
-				// user does not have access to dashboard
-				// the proper error would be 403 Forbidden, but we don't want to leak information so we return 404 Not Found
-				handleErr(w, newNotFoundErr("dashboard with id %v not found", dashboardId))
-				return
-			}
-
+func (h *HandlerService) VDBAuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		dashboardId, err := strconv.ParseUint(mux.Vars(r)["dashboard_id"], 10, 64)
+		if err != nil {
+			// if primary id is not used, no need to check access
 			next.ServeHTTP(w, r)
-		})
-	}
+			return
+		}
+		// primary id is used -> user needs to have access to dashboard
+
+		userId, err := GetUserIdByContext(r)
+		if err != nil {
+			handleErr(w, err)
+			return
+		}
+		// store user id in context
+		ctx := r.Context()
+		ctx = context.WithValue(ctx, ctxUserIdKey, userId)
+		r = r.WithContext(ctx)
+
+		dashboard, err := h.dai.GetValidatorDashboardInfo(r.Context(), types.VDBIdPrimary(dashboardId))
+		if err != nil {
+			handleErr(w, err)
+			return
+		}
+
+		if dashboard.UserId != userId {
+			// user does not have access to dashboard
+			// the proper error would be 403 Forbidden, but we don't want to leak information so we return 404 Not Found
+			handleErr(w, newNotFoundErr("dashboard with id %v not found", dashboardId))
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
 }
 
 // returns a middleware that checks if user has premium perk to use public validator dashboard api

--- a/backend/pkg/api/handlers/auth.go
+++ b/backend/pkg/api/handlers/auth.go
@@ -762,9 +762,9 @@ func (h *HandlerService) VDBAuthMiddleware(next http.Handler) http.Handler {
 func (h *HandlerService) ManageViaApiCheckMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// get user id from context
-		userId, ok := r.Context().Value(ctxUserIdKey).(uint64)
-		if !ok {
-			handleErr(w, errors.New("error getting user id from context"))
+		userId, err := GetUserIdByContext(r)
+		if err != nil {
+			handleErr(w, err)
 			return
 		}
 		userInfo, err := h.dai.GetUserInfo(r.Context(), userId)

--- a/backend/pkg/api/handlers/common.go
+++ b/backend/pkg/api/handlers/common.go
@@ -690,6 +690,13 @@ func getMaxChartAge(aggregation enums.ChartAggregation, perkSeconds types.ChartH
 	}
 }
 
+func isUserAdmin(user *types.UserInfo) bool {
+	if user == nil {
+		return false
+	}
+	return user.UserGroup == types.UserGroupAdmin
+}
+
 // --------------------------------------
 //   Response handling
 

--- a/backend/pkg/api/handlers/public.go
+++ b/backend/pkg/api/handlers/public.go
@@ -23,7 +23,7 @@ func (h *HandlerService) PublicGetHealthzLoadbalancer(w http.ResponseWriter, r *
 }
 
 func (h *HandlerService) PublicGetUserDashboards(w http.ResponseWriter, r *http.Request) {
-	userId, err := h.GetUserIdByApiKey(r)
+	userId, err := GetUserIdByContext(r)
 	if err != nil {
 		handleErr(w, err)
 		return
@@ -168,9 +168,9 @@ func (h *HandlerService) PublicPostValidatorDashboardValidators(w http.ResponseW
 		returnNotFound(w, errors.New("group not found"))
 		return
 	}
-	userId, ok := ctx.Value(ctxUserIdKey).(uint64)
-	if !ok {
-		handleErr(w, errors.New("error getting user id from context"))
+	userId, err := GetUserIdByContext(r)
+	if err != nil {
+		handleErr(w, err)
 		return
 	}
 	userInfo, err := h.dai.GetUserInfo(ctx, userId)
@@ -179,7 +179,7 @@ func (h *HandlerService) PublicPostValidatorDashboardValidators(w http.ResponseW
 		return
 	}
 	limit := userInfo.PremiumPerks.ValidatorsPerDashboard
-	if req.Validators == nil && !userInfo.PremiumPerks.BulkAdding {
+	if req.Validators == nil && !userInfo.PremiumPerks.BulkAdding && !isUserAdmin(userInfo) {
 		returnConflict(w, errors.New("bulk adding not allowed with current subscription plan"))
 		return
 	}

--- a/backend/pkg/api/types/user.go
+++ b/backend/pkg/api/types/user.go
@@ -1,7 +1,10 @@
 package types
 
+const UserGroupAdmin = "ADMIN"
+
 type UserInfo struct {
 	Id            uint64             `json:"id"`
+	UserGroup     string             `json:"-"`
 	Email         string             `json:"email"`
 	ApiKeys       []string           `json:"api_keys"`
 	ApiPerks      ApiPerks           `json:"api_perks"`


### PR DESCRIPTION
This PR fixes the bug that prevents users from creating a dashboard, aswell as cleaning up the middlewares a bit. With these changes, the user ID (if available) is always loaded into the request context at the beginning. Further handlers should then only need to load user ID by context and throw unauthorized themselves, if they expect it to be in context.