### PR TITLE
fix(table): make sure spinner is not to far down at big tables

### DIFF
--- a/frontend/assets/css/prime_datatable.scss
+++ b/frontend/assets/css/prime_datatable.scss
@@ -11,6 +11,11 @@
 .p-datatable {
   --table-background-color: var(--background-color);
 
+  .p-datatable-loading-overlay {
+    height: min(100%, 300px);
+    pointer-events: none;
+  }
+
   &.no-header {
     .p-datatable-thead {
       display: none;


### PR DESCRIPTION
This PR:
- adapts the loading spinner in the BcTable 
  - makes sure that the loading spinner is not to far down in big tables
  - makes sure that the table is still interactive while loading data. 