### PR TITLE
fix(dashboard): remove fixed button width, revers manage button order

### DIFF
--- a/frontend/components/dashboard/DashboardControls.vue
+++ b/frontend/components/dashboard/DashboardControls.vue
@@ -90,7 +90,7 @@ const manageButtons = computed<MenuBarEntry[] | undefined>(() => {
     return [ {
       dropdown: true,
       highlight: true,
-      items: buttons,
+      items: buttons.reverse(), // In the dropdown we want the button sorting to be reversed
       label: $t('dashboard.header.manage'),
     } ]
   }

--- a/frontend/components/dashboard/DashboardHeader.vue
+++ b/frontend/components/dashboard/DashboardHeader.vue
@@ -153,13 +153,6 @@ const items = computed<MenuBarEntry[]>(() => {
     overflow: hidden;
   }
 
-  :deep(.p-menubar-root-list > .p-menuitem) {
-    width: 145px;
-    .button-content {
-      gap: unset;
-    }
-  }
-
   :deep(.p-menubar-root-list .p-menuitem .p-submenu-list) {
     position: fixed;
   }


### PR DESCRIPTION
This PR:
- adapts the validator dashboard header
  - removes the fixed button width for buttons
  - reverses the sort of the manage buttons on mobile screen (when they are in a dropdown)

BEDS-285