### PR TITLE
chore(ci): move typecheck to ci pipeline for better dev server performance

### DIFF
--- a/.github/workflows/frontend-format-lint-typecheck.yml
+++ b/.github/workflows/frontend-format-lint-typecheck.yml
@@ -1,4 +1,4 @@
-name: Frontend Linter
+name: Frontend Check
 
 on:
   push:
@@ -18,8 +18,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  frontend-lint:
-    name: lint
+  frontend-check:
+    name: lint and typecheck
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
@@ -27,7 +27,7 @@ jobs:
     - name: Setup Node Environment
       uses: actions/setup-node@v4
       with:
-        node-version: 21
+        node-version-file: 'frontend/.nvmrc'
         cache: 'npm'
         cache-dependency-path: frontend/package-lock.json
     - name: Install Dependencies
@@ -38,3 +38,6 @@ jobs:
     - name: Lint Files
       working-directory: frontend
       run: npm run lint
+    - name: Typecheck Files
+      working-directory: frontend
+      run: npm run typecheck

--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -4,7 +4,8 @@
     "vscode",
     "eslint",
     "mainHeader",
-    "checkout"
+    "checkout",
+    "ci"
   ],
 "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "always"

--- a/frontend/app.vue
+++ b/frontend/app.vue
@@ -21,6 +21,7 @@ useDateProvider()
 <template>
   <div class="min-h-full">
     <BcDataWrapper>
+      <NuxtLoadingIndicator color="var(--primary-color)" />
       <NuxtPage />
       <DynamicDialog />
       <Toast />

--- a/frontend/components/bc/searchbar/MiddleEllipsis.vue
+++ b/frontend/components/bc/searchbar/MiddleEllipsis.vue
@@ -76,7 +76,7 @@ const innerElements = {
 }
 const frameSpan = ref<HTMLSpanElement>(null as unknown as HTMLSpanElement)
 let frameStyle: CSSStyleDeclaration
-let frameText = props.text || '' // After mounting, this variable will always mirror the text in the frame. Before mounting, it contains the full text so that <template> can display it during isServer.
+let frameText = props.text || '' // After mounting, this variable will always mirror the text in the frame. Before mounting, it contains the full text so that <template> can display it during isServerSide.
 
 let mediaqueryWidthListener: MediaQueryList
 let delayedForcedUpdateIncoming = false
@@ -95,7 +95,7 @@ let lastMeasuredFrameWidth = 0
 let currentAdditionalWidthAvailable = 0
 let currentText = ''
 const canvasContextToCalculateTextWidths = (
-  isServer ? null : document.createElement('canvas').getContext('2d')
+  isServerSide ? null : document.createElement('canvas').getContext('2d')
 ) as CanvasRenderingContext2D
 const lastTextWidthCalculation: TextProperties = {
   text: '',
@@ -285,7 +285,7 @@ watch(
     The first resizing is approximate for some reason and triggers the resizeObserver.
     The second resizing is definitive and accurate but does not trigger the resizeObserver, so MiddleEllipsis stays with a wrong clipping.
   */
-    if (isServer || !navigator.userAgent.includes('Chrom')) {
+    if (isServerSide || !navigator.userAgent.includes('Chrom')) {
       return
     }
     if (mediaqueryWidthListener) {
@@ -323,7 +323,7 @@ function catchResizingCausedByMediaquery() {
 }
 
 let resizingObserver: ResizeObserver
-if (!isServer) {
+if (!isServerSide) {
   resizingObserver = new ResizeObserver(() => {
     // will react to changes of width
     if (!didTheResizingObserverFireSinceMount) {
@@ -1122,7 +1122,7 @@ const frameClassList = computed(
   >
     {{ frameText }}
     <!--
-      The text above is not reactive because its only purpose is to provide a content during isServer. During CSR,
+      The text above is not reactive because its only purpose is to provide a content during isServerSide. During CSR,
       MiddleEllipsis clips and overwrites the text
       of the frame with a direct assignment (frameSpan.value.textContent = ...), which has an immediate effect within
       one reflow unlike reactive properties.

--- a/frontend/components/bc/searchbar/SearchbarMain.vue
+++ b/frontend/components/bc/searchbar/SearchbarMain.vue
@@ -229,7 +229,7 @@ watch(() => props, reconfigureSearchbar, { immediate: true })
 watch(availableNetworks, reconfigureSearchbar)
 
 let resizingObserver: ResizeObserver
-if (isClient) {
+if (isClientSide) {
   resizingObserver = new ResizeObserver((entries) => {
     const newLayout: SearchbarDropdownLayout
       = entries[0].borderBoxSize[0].inlineSize < LayoutThreshold

--- a/frontend/composables/useCustomFetch.ts
+++ b/frontend/composables/useCustomFetch.ts
@@ -62,7 +62,7 @@ export function useCustomFetch() {
         : apiClient
     const ssrSecret = pConfig?.ssrSecret
 
-    if (isServer) {
+    if (isServerSide) {
       baseURL = map.mock
         ? `${domain || url.origin.replace('http:', 'https:')}/mock`
         : map.legacy
@@ -78,7 +78,7 @@ export function useCustomFetch() {
       options.headers.append('Authorization', `Bearer ${apiKey}`)
     }
 
-    if (isServer && ssrSecret) {
+    if (isServerSide && ssrSecret) {
       options.headers.append('x-ssr-secret', ssrSecret)
     }
 
@@ -89,7 +89,7 @@ export function useCustomFetch() {
     options.credentials = 'include'
     const method = options.method || map.method || 'GET'
 
-    if (isServer && logIp === 'LOG') {
+    if (isServerSide && logIp === 'LOG') {
       $bcLogger.warn(
         `${
           uuid?.value

--- a/frontend/composables/useDashboardKeyProvider.ts
+++ b/frontend/composables/useDashboardKeyProvider.ts
@@ -39,7 +39,7 @@ export function useDashboardKeyProvider(
       params: { id: key },
     })
     dashboardKey.value = key
-    if (isClient) {
+    if (isClientSide) {
       // we only want to change the url in the browser and don't want to trigger a page refresh
       history.replaceState({}, '', newRoute.fullPath)
     }

--- a/frontend/composables/useHashTabs.ts
+++ b/frontend/composables/useHashTabs.ts
@@ -37,7 +37,7 @@ export function useHashTabs(tabs: HashTabs) {
   })
 
   const updateHash = (index: number) => {
-    if (isServer) {
+    if (isServerSide) {
       return
     }
     window.location.hash = findHashForIndex(index)
@@ -46,7 +46,7 @@ export function useHashTabs(tabs: HashTabs) {
   watch(
     activeIndex,
     (index) => {
-      if (isServer && index < 0) {
+      if (isServerSide && index < 0) {
         return
       }
       updateHash(index)
@@ -55,7 +55,7 @@ export function useHashTabs(tabs: HashTabs) {
   )
 
   const setActiveIndex = (index: number) => {
-    if (isServer) {
+    if (isServerSide) {
       return
     }
     activeIndex.value = index

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -87,7 +87,6 @@ export default defineNuxtConfig({
     },
   },
   ssr: process.env.ENABLE_SSR !== 'FALSE',
-  typescript: { typeCheck: true },
   vite: {
     build: {
       minify: true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,7 +55,9 @@
     "lint": "eslint . --report-unused-disable-directives",
     "lint:fix": "npm run lint -- --fix",
     "postinstall": "nuxt prepare",
-    "preview": "nuxt preview"
+    "preview": "nuxt preview",
+    "typecheck": "npx nuxi typecheck",
+    "validate": "npm run lint:fix && npm run typecheck"
   },
   "type": "module"
 }

--- a/frontend/plugins/bcLogger.ts
+++ b/frontend/plugins/bcLogger.ts
@@ -9,7 +9,7 @@ export default defineNuxtPlugin((_nuxtApp) => {
       bcLogger: {
         warn: (msg: string, ...rest: any) => {
           const ts = new Date().toISOString()
-          if (isServer && logFile) {
+          if (isServerSide && logFile) {
             const filePath = path.resolve(logFile)
             fs.appendFileSync(
               filePath,

--- a/frontend/utils/environment.ts
+++ b/frontend/utils/environment.ts
@@ -1,2 +1,2 @@
-export const isServer = import.meta.server
-export const isClient = import.meta.client
+export const isServerSide = import.meta.server
+export const isClientSide = import.meta.client


### PR DESCRIPTION
Nuxt recommends not to run `linting` or `typechecking` on the `dev server`,
due to performacne reasons. As the `ide` should already catch `linting` or
`typeerrors`.

To improve DX for local `validation` before `pushing` you can run
`npm run validate` now (formatting, linting and typechecking)

See: https://nuxt.com/docs/guide/concepts/typescript#type-checking
See: BEDS-156