### PR TITLE
fix(pricing): fix broken css vars import

### DIFF
--- a/frontend/pages/pricing.vue
+++ b/frontend/pages/pricing.vue
@@ -74,6 +74,12 @@ const scrollToAddons = () => {
   </BcPageWrapper>
 </template>
 
+<style lang="scss">
+// we need this one to have the pricing css variables on the whole page available
+@import "~/assets/css/pricing.scss";
+</style>
+
+
 <style lang="scss" scoped>
 @use "~/assets/css/pricing.scss";
 

--- a/frontend/pages/pricing.vue
+++ b/frontend/pages/pricing.vue
@@ -79,7 +79,6 @@ const scrollToAddons = () => {
 @import "~/assets/css/pricing.scss";
 </style>
 
-
 <style lang="scss" scoped>
 @use "~/assets/css/pricing.scss";
 


### PR DESCRIPTION
This PR:
- adds the import of the pricing page css vars that were removed by accident in a prev. PR