### PR TITLE
chore(checkout): using `nuxt`s `ssl handling`

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -3,7 +3,8 @@
     "i18n",
     "vscode",
     "eslint",
-    "mainHeader"
+    "mainHeader",
+    "checkout"
   ],
 "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "always"

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -43,14 +43,6 @@ Set the following mapping in your `/etc/hosts` file:
 127.0.0.1 local.beaconcha.in
 ```
 
-Create server certificates for locally running on https, by runing these comands in the console (the last two with `sudo`)
-
-```bash
-openssl genrsa 2048 > server.key
-chmod 400 server.key
-openssl req -new -x509 -nodes -sha256 -days 365 -key server.key -out server.crt
-```
-
 Navigate to folder `beaconchain/frontend` and run
 
 ```bash

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -46,10 +46,8 @@ export default defineNuxtConfig({
     '@fortawesome/fontawesome-svg-core/styles.css',
   ],
   devServer: {
-    https: {
-      cert: 'server.crt',
-      key: 'server.key',
-    },
+    host: 'local.beaconcha.in',
+    https: true,
   },
   devtools: { enabled: true },
   eslint: { config: { stylistic: true } },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,7 +50,7 @@
   "private": true,
   "scripts": {
     "build": "nuxt build",
-    "dev": "NODE_TLS_REJECT_UNAUTHORIZED=0 nuxt dev --host=local.beaconcha.in",
+    "dev": "NODE_TLS_REJECT_UNAUTHORIZED=0 nuxt dev",
     "generate": "nuxt generate",
     "lint": "eslint . --report-unused-disable-directives",
     "lint:fix": "npm run lint -- --fix",


### PR DESCRIPTION
Nuxt can create `selfsinged certificates` on its own. This is especially heplful when checking out the repo or when using `git worktree`s feature, as there a fewer steps to get the dev server running.

See: BEDS-97