### PR TITLE
fix(dashboard): have a min button size for the dashboard header butto…

### DIFF
--- a/frontend/components/dashboard/DashboardHeader.vue
+++ b/frontend/components/dashboard/DashboardHeader.vue
@@ -153,6 +153,15 @@ const items = computed<MenuBarEntry[]>(() => {
     overflow: hidden;
   }
 
+  :deep(.p-menubar-root-list >.p-menuitem ) {
+    min-width: 102px;
+    >.p-menuitem-content:not(:has(.toggle)) {
+      .button-content {
+        justify-content: center;
+      }
+    }
+  }
+
   :deep(.p-menubar-root-list .p-menuitem .p-submenu-list) {
     position: fixed;
   }


### PR DESCRIPTION
This PR:
- sets a min width for the dashboard header buttons 
- centers the content of the dashboard header buttons if they are not a dropdown

![image](https://github.com/user-attachments/assets/77621d18-2a4a-4257-831f-a732761776c3)
