### PR TITLE
fix(dashboard): center disabled header buttons, use plural for Valida…

### DIFF
--- a/frontend/assets/css/prime_menubar.scss
+++ b/frontend/assets/css/prime_menubar.scss
@@ -67,6 +67,9 @@
     white-space: nowrap;
     text-align: center;
     gap: var(--padding);
+    @media (max-width: 519px) {
+      gap: var(--padding-small);
+    }
 
     &:has(.icon):has(.text){
       justify-content: flex-start;

--- a/frontend/components/bc/menu/BcMenuBar.vue
+++ b/frontend/components/bc/menu/BcMenuBar.vue
@@ -28,7 +28,7 @@ defineProps<Props>()
         class="button-content"
         @click.stop.prevent="() => undefined"
       >
-        <span class="text-disabled">{{ item.label }}</span>
+        <span class="text-disabled text">{{ item.label }}</span>
       </BcTooltip>
       <BcLink
         v-else-if="item.route && !item.command"

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -140,9 +140,9 @@
       }
     },
     "header": {
-      "account": "Account",
+      "account": "Accounts",
       "manage": "Manage",
-      "validator": "Validator"
+      "validator": "Validators"
     },
     "public_account_dashboard": "Dashboard",
     "public_validator_dashboard": "Dashboard",


### PR DESCRIPTION
This PR:
- fixes some minor issues in the Dashboard Header Buttons
  - use Plural for the Validators / Accounts button
    - adjust the gap in the button on mobile so that the plural text is not truncated
  - fix the padding of disabled buttons 