### PR TITLE
(BEDS-306) api: add basic healthz endpoint

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -111,9 +111,6 @@ linters-settings:
         msg: Use log.Infof instead
       - p: ^fmt\.Printf.*$
         msg: Use log.Infof instead
-      # ban usage of db.ClickHouseWriter
-      - p: ^db\.ClickHouseWriter.*$
-        msg: Use db.ClickHouseNativeWriter instead
   gocognit:
     min-complexity: 65
   depguard:

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gobitfly/beaconchain/pkg/api"
 	dataaccess "github.com/gobitfly/beaconchain/pkg/api/data_access"
+	"github.com/gobitfly/beaconchain/pkg/monitoring"
 
 	"github.com/gobitfly/beaconchain/pkg/commons/log"
 	"github.com/gobitfly/beaconchain/pkg/commons/metrics"
@@ -57,6 +58,12 @@ func Run() {
 
 	router := api.NewApiRouter(dataAccessor, cfg)
 	router.Use(api.GetCorsMiddleware(cfg.CorsAllowedHosts))
+	if !cfg.Frontend.Debug {
+		// enable light-weight db connection monitoring
+		monitoring.Init(false)
+		monitoring.Start()
+		defer monitoring.Stop()
+	}
 
 	if utils.Config.Metrics.Enabled {
 		router.Use(metrics.HttpMiddleware)

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gobitfly/beaconchain/cmd/ethstore_exporter"
 	"github.com/gobitfly/beaconchain/cmd/exporter"
 	"github.com/gobitfly/beaconchain/cmd/misc"
+	"github.com/gobitfly/beaconchain/cmd/monitoring"
 	"github.com/gobitfly/beaconchain/cmd/node_jobs_processor"
 	"github.com/gobitfly/beaconchain/cmd/notification_collector"
 	"github.com/gobitfly/beaconchain/cmd/notification_sender"
@@ -57,6 +58,8 @@ func main() {
 		typescript_converter.Run()
 	case "user-service":
 		user_service.Run()
+	case "monitoring":
+		monitoring.Run()
 	default:
 		log.Fatal(nil, fmt.Sprintf("unknown target: %s", target), 0)
 	}

--- a/backend/cmd/misc/main.go
+++ b/backend/cmd/misc/main.go
@@ -181,7 +181,6 @@ func Run() {
 	defer db.FrontendWriterDB.Close()
 
 	// clickhouse
-	//nolint:forbidigo
 	db.ClickHouseWriter, db.ClickHouseReader = db.MustInitDB(&types.DatabaseConfig{
 		Username:     cfg.ClickHouse.WriterDatabase.Username,
 		Password:     cfg.ClickHouse.WriterDatabase.Password,
@@ -202,7 +201,7 @@ func Run() {
 		MaxIdleConns: cfg.ClickHouse.ReaderDatabase.MaxIdleConns,
 	}, "clickhouse", "clickhouse")
 	defer db.ClickHouseReader.Close()
-	defer db.ClickHouseWriter.Close() //nolint:forbidigo
+	defer db.ClickHouseWriter.Close()
 
 	// Initialize the persistent redis client
 	rdc := redis.NewClient(&redis.Options{

--- a/backend/cmd/monitoring/main.go
+++ b/backend/cmd/monitoring/main.go
@@ -1,4 +1,4 @@
-package main
+package monitoring
 
 import (
 	"flag"
@@ -12,7 +12,7 @@ import (
 	"github.com/gobitfly/beaconchain/pkg/monitoring"
 )
 
-func main() {
+func Run() {
 	configPath := flag.String("config", "", "Path to the config file, if empty string defaults will be used")
 	versionFlag := flag.Bool("version", false, "Show version and exit")
 	flag.Parse()

--- a/backend/cmd/monitoring/main.go
+++ b/backend/cmd/monitoring/main.go
@@ -18,8 +18,8 @@ func main() {
 	flag.Parse()
 
 	if *versionFlag {
-		log.Infof(version.Version)
-		log.Infof(version.GoVersion)
+		log.Infof("%s", version.Version)
+		log.Infof("%s", version.GoVersion)
 		return
 	}
 

--- a/backend/cmd/monitoring/main.go
+++ b/backend/cmd/monitoring/main.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"flag"
+	"time"
+
+	"github.com/gobitfly/beaconchain/pkg/commons/db"
+	"github.com/gobitfly/beaconchain/pkg/commons/log"
+	"github.com/gobitfly/beaconchain/pkg/commons/types"
+	"github.com/gobitfly/beaconchain/pkg/commons/utils"
+	"github.com/gobitfly/beaconchain/pkg/commons/version"
+	"github.com/gobitfly/beaconchain/pkg/monitoring"
+)
+
+func main() {
+	configPath := flag.String("config", "", "Path to the config file, if empty string defaults will be used")
+	versionFlag := flag.Bool("version", false, "Show version and exit")
+	flag.Parse()
+
+	if *versionFlag {
+		log.Infof(version.Version)
+		log.Infof(version.GoVersion)
+		return
+	}
+
+	cfg := &types.Config{}
+	err := utils.ReadConfig(cfg, *configPath)
+	if err != nil {
+		log.Fatal(err, "error reading config file", 0)
+	}
+	utils.Config = cfg
+
+	db.ClickHouseWriter, db.ClickHouseReader = db.MustInitDB(&types.DatabaseConfig{
+		Username:     cfg.ClickHouse.WriterDatabase.Username,
+		Password:     cfg.ClickHouse.WriterDatabase.Password,
+		Name:         cfg.ClickHouse.WriterDatabase.Name,
+		Host:         cfg.ClickHouse.WriterDatabase.Host,
+		Port:         cfg.ClickHouse.WriterDatabase.Port,
+		MaxOpenConns: cfg.ClickHouse.WriterDatabase.MaxOpenConns,
+		SSL:          true,
+		MaxIdleConns: cfg.ClickHouse.WriterDatabase.MaxIdleConns,
+	}, &types.DatabaseConfig{
+		Username:     cfg.ClickHouse.ReaderDatabase.Username,
+		Password:     cfg.ClickHouse.ReaderDatabase.Password,
+		Name:         cfg.ClickHouse.ReaderDatabase.Name,
+		Host:         cfg.ClickHouse.ReaderDatabase.Host,
+		Port:         cfg.ClickHouse.ReaderDatabase.Port,
+		MaxOpenConns: cfg.ClickHouse.ReaderDatabase.MaxOpenConns,
+		SSL:          true,
+		MaxIdleConns: cfg.ClickHouse.ReaderDatabase.MaxIdleConns,
+	}, "clickhouse", "clickhouse")
+	defer db.ClickHouseReader.Close()
+	defer db.ClickHouseWriter.Close()
+
+	monitoring.Init(true)
+	monitoring.Start()
+	defer monitoring.Stop()
+
+	// gotta wait forever
+	for {
+		time.Sleep(1 * time.Second)
+	}
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -69,9 +69,9 @@ require (
 	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a
 	golang.org/x/sync v0.6.0
 	golang.org/x/text v0.14.0
+	golang.org/x/time v0.5.0
 	golang.org/x/tools v0.18.0
 	google.golang.org/api v0.164.0
-	google.golang.org/appengine v1.6.8
 	google.golang.org/protobuf v1.32.0
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -233,8 +233,8 @@ require (
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/oauth2 v0.17.0 // indirect
 	golang.org/x/sys v0.17.0 // indirect
-	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
+	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto v0.0.0-20240125205218-1f4bbc51befe // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240125205218-1f4bbc51befe // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240205150955-31a09d347014 // indirect

--- a/backend/pkg/api/handlers/public.go
+++ b/backend/pkg/api/handlers/public.go
@@ -126,7 +126,9 @@ func (h *HandlerService) PublicGetHealthz(w http.ResponseWriter, r *http.Request
 			}
 		}
 	}
-	response.TotalOkPercentage = 1 - float64(failures)/float64(len(results))
+	if len(results) > 0 {
+		response.TotalOkPercentage = 1 - float64(failures)/float64(len(results))
+	}
 
 	if !r.URL.Query().Has("show_all") {
 		// we will filter out all reports that arent failure

--- a/backend/pkg/api/handlers/public.go
+++ b/backend/pkg/api/handlers/public.go
@@ -6,143 +6,144 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"slices"
 	"time"
 
 	"github.com/gobitfly/beaconchain/pkg/api/types"
 	"github.com/gobitfly/beaconchain/pkg/commons/db"
 	"github.com/gorilla/mux"
-	"golang.org/x/sync/errgroup"
 )
-
-type StatusReports struct {
-	StatusReports []StatusReport `json:"status_reports"`
-	IsOk          bool           `json:"is_ok"`
-}
-
-type StatusReport struct {
-	IsOk        bool     `json:"is_ok"`
-	Tags        []string `json:"tags"`
-	Id          string   `json:"id"`
-	Description string   `json:"description"`
-}
 
 // All handler function names must include the HTTP method and the path they handle
 // Public handlers may only be authenticated by an API key
 // Public handlers must never call internal handlers
 
 func (h *HandlerService) PublicGetHealthz(w http.ResponseWriter, r *http.Request) {
-	s := StatusReports{
-		IsOk: true,
-	}
-	// errgroup
-	ch := make(chan StatusReport, 100)
 	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 	defer cancel()
-	g, ctx := errgroup.WithContext(ctx)
 
-	g.Go(func() error {
-		sr := StatusReport{
-			Tags: []string{"clickhouse", "database"},
-			Id:   "ch_connection",
-		}
-		var version string
-		err := db.ClickHouseReader.GetContext(ctx, &version, "SELECT version()")
-		if err != nil {
-			sr.IsOk = false
-			sr.Description = "clickhouse is not healthy"
-			ch <- sr
-			return nil
-		}
-		sr.IsOk = true
-		sr.Description = "clickhouse is healthy, version: " + version
-		ch <- sr
-		return nil
-	})
-
-	g.Go(func() error {
-		sr := StatusReport{
-			Tags: []string{"clickhouse", "exporter", "validator_dashboard"},
-			Id:   "ch_latest_epoch",
-		}
-		var t time.Time
-		err := db.ClickHouseReader.GetContext(ctx, &t, "SELECT MAX(epoch_timestamp) FROM validator_dashboard_data_epoch")
-		if err != nil {
-			sr.IsOk = false
-			sr.Description = "failed to get latest epoch from clickhouse: " + err.Error()
-			ch <- sr
-			return nil
-		}
-		if time.Since(t) > 1*time.Hour {
-			sr.IsOk = false
-			sr.Description = fmt.Sprintf("latest exported epoch is older than 1 hour: %s", time.Since(t))
-			ch <- sr
-			return nil
-		}
-		sr.IsOk = true
-		sr.Description = fmt.Sprintf("latest exported epoch is %s old", time.Since(t))
-		ch <- sr
-		return nil
-	})
-
-	target_rollings := []string{"1h", "24h", "7d", "30d", "90d", "total"}
-	for _, target_rolling := range target_rollings {
-		target_rolling := target_rolling
-		g.Go(func() error {
-			sr := StatusReport{
-				Tags: []string{"clickhouse", "exporter", "validator_dashboard", target_rolling},
-				Id:   "ch_rolling_rolling_" + target_rolling,
-			}
-			var delta int
-			err := db.ClickHouseReader.GetContext(ctx, &delta, fmt.Sprintf(`
+	query := `
+		WITH sub AS
+			(
 				SELECT
-				    coalesce((
-				        SELECT
-				            max(epoch)
-				        FROM holesky.validator_dashboard_data_epoch
-				        WHERE
-				            epoch_timestamp = (
-				                SELECT
-				                    max(epoch_timestamp)
-				                FROM holesky.validator_dashboard_data_epoch)) - MAX(epoch_end), 255) AS delta
-				FROM
-				    holesky.validator_dashboard_data_rolling_%s
-				WHERE
-				    validator_index = 0`, target_rolling))
-			if err != nil {
-				sr.IsOk = false
-				sr.Description = fmt.Sprintf("failed to get epoch delta from clickhouse for rolling %s: %s", target_rolling, err.Error())
-				ch <- sr
-				return nil
-			}
-			threshold := 2
-			if delta > threshold {
-				sr.IsOk = false
-				sr.Description = fmt.Sprintf("epoch delta for rolling %s is %d, threshold is %d", target_rolling, delta, threshold)
-				ch <- sr
-				return nil
-			}
-			sr.IsOk = true
-			sr.Description = fmt.Sprintf("epoch delta for rolling %s is %d", target_rolling, delta)
-			ch <- sr
-			return nil
-		})
+					emitter,
+					event_id,
+					max(inserted_at) AS inserted_at,
+					max(expires_at) AS expires_at,
+					any(status) AS status,
+					any(mapSort(metadata)) AS metadata
+				FROM status_reports AS s
+				WHERE s.expires_at > now()
+				GROUP BY
+					1,
+					2,
+					s.status
+				ORDER BY
+					inserted_at DESC,
+					1 ASC,
+					2 ASC
+			)
+		SELECT
+			event_id,
+			status,
+			groupArray(
+				map(
+					'emitter',
+					CAST(emitter, 'String'),
+					'inserted_at',
+					CAST(inserted_at, 'String'),
+					'expires_at',
+					CAST(expires_at, 'String'),
+					'metadata',
+					CAST(metadata, 'String')
+				)
+			) AS result
+		FROM sub
+		GROUP BY
+			event_id,
+			status
+		ORDER BY event_id, max(inserted_at) DESC
+	`
+
+	type Result struct {
+		EventId string              `db:"event_id" json:"-"`
+		Status  string              `db:"status" json:"status"`
+		Result  []map[string]string `db:"result" json:"reports"`
+	}
+	var results []Result
+	var response struct {
+		TotalOkPercentage float64             `json:"total_ok_percentage"`
+		Reports           map[string][]Result `json:"status_reports"`
+	}
+	response.Reports = make(map[string][]Result)
+	err := db.ClickHouseReader.SelectContext(ctx, &results, query)
+	if err != nil {
+		response.Reports["response_error"] = []Result{
+			{
+				EventId: "response_error",
+				Status:  "failure",
+				Result:  []map[string]string{{"error": "failed to fetch status reports"}},
+			},
+		}
+
+		writeResponse(w, http.StatusInternalServerError, response)
+		return
 	}
 
-	if err := g.Wait(); err != nil {
-		returnInternalServerError(w, err)
+	mustExist := []string{
+		"ch_rolling_1h",
+		"ch_rolling_24h",
+		"ch_rolling_7d",
+		"ch_rolling_30d",
+		"ch_rolling_90d",
+		"ch_rolling_total",
+		"ch_dashboard_epoch",
+		"api_service_avg_efficiency",
+		"api_service_validator_mapping",
+		"api_service_slot_viz",
 	}
-	close(ch)
-
-	for report := range ch {
-		s.StatusReports = append(s.StatusReports, report)
-		if !report.IsOk && s.IsOk {
-			s.IsOk = false
+	for _, result := range results {
+		response.Reports[result.EventId] = append(response.Reports[result.EventId], result)
+	}
+	for _, id := range mustExist {
+		if _, ok := response.Reports[id]; !ok {
+			response.Reports[id] = []Result{
+				{
+					EventId: id,
+					Status:  "failure",
+					Result: []map[string]string{
+						{"error": "no status report found"},
+					},
+				},
+			}
 		}
 	}
-	if s.IsOk {
-		returnOk(w, s)
+	failures := 0
+	for _, r := range response.Reports {
+		for _, report := range r {
+			if report.Status == "failure" {
+				failures++
+			}
+		}
+	}
+	response.TotalOkPercentage = 1 - float64(failures)/float64(len(results))
+
+	if !r.URL.Query().Has("show_all") {
+		// we will filter out all reports that arent failure
+		for id, result := range response.Reports {
+			response.Reports[id] = slices.DeleteFunc(result, func(r Result) bool {
+				return r.Status != "failure"
+			})
+			if len(response.Reports[id]) == 0 {
+				delete(response.Reports, id)
+			}
+		}
+	}
+
+	if response.TotalOkPercentage == 1 {
+		returnOk(w, response)
 	} else {
-		writeResponse(w, http.StatusInternalServerError, s)
+		writeResponse(w, http.StatusInternalServerError, response)
 	}
 }
 

--- a/backend/pkg/api/services/service_average_network_efficiency.go
+++ b/backend/pkg/api/services/service_average_network_efficiency.go
@@ -30,7 +30,7 @@ func (s *Services) startEfficiencyDataService() {
 		go services.ReportStatus(context.Background(), "api_service_avg_efficiency", err, nil, map[string]string{"status": "running"})
 		if err != nil {
 			log.Error(err, "error updating average network efficiency data", 0)
-			go services.ReportStatus(context.Background(), "api_service_avg_efficiency", err, &delay, nil)
+			go services.ReportStatus(context.Background(), "api_service_avg_efficiency", err, nil, nil)
 			delay = 10 * time.Second
 		} else {
 			log.Infof("=== average network efficiency data updated in %s", time.Since(startTime))

--- a/backend/pkg/api/services/service_validator_mapping.go
+++ b/backend/pkg/api/services/service_validator_mapping.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gobitfly/beaconchain/pkg/commons/types"
 	"github.com/gobitfly/beaconchain/pkg/commons/utils"
 	constypes "github.com/gobitfly/beaconchain/pkg/consapi/types"
+	"github.com/gobitfly/beaconchain/pkg/monitoring/services"
 	"github.com/klauspost/pgzip"
 	"github.com/pkg/errors"
 )
@@ -37,12 +38,14 @@ func (s *Services) startIndexMappingService() {
 	for {
 		startTime := time.Now()
 		delay := time.Duration(utils.Config.Chain.ClConfig.SecondsPerSlot) * time.Second
-
+		expectedDelay := time.Duration(float64(utils.Config.Chain.ClConfig.SlotsPerEpoch)*1.25) * delay // 25% buffer
+		go services.ReportStatus(context.Background(), "api_service_validator_mapping", nil, &expectedDelay, map[string]string{"status": "running"})
 		latestEpoch := cache.LatestEpoch.Get()
 		if currentValidatorMapping == nil || latestEpoch != lastEpochUpdate {
 			err := s.updateValidatorMapping()
 			if err != nil {
 				log.Error(err, "error updating validator mapping", 0)
+				go services.ReportStatus(context.Background(), "api_service_validator_mapping", err, &expectedDelay, map[string]string{"took": time.Since(startTime).String()})
 				delay = 10 * time.Second
 			} else {
 				log.Infof("=== validator mapping updated in %s", time.Since(startTime))
@@ -50,6 +53,7 @@ func (s *Services) startIndexMappingService() {
 
 			lastEpochUpdate = latestEpoch
 		}
+		go services.ReportStatus(context.Background(), "api_service_validator_mapping", nil, nil, map[string]string{"status": "done", "took": time.Since(startTime).String(), "latest_epoch": fmt.Sprintf("%d", lastEpochUpdate)})
 		utils.ConstantTimeDelay(startTime, delay)
 	}
 }

--- a/backend/pkg/api/services/service_validator_mapping.go
+++ b/backend/pkg/api/services/service_validator_mapping.go
@@ -38,14 +38,13 @@ func (s *Services) startIndexMappingService() {
 	for {
 		startTime := time.Now()
 		delay := time.Duration(utils.Config.Chain.ClConfig.SecondsPerSlot) * time.Second
-		expectedDelay := time.Duration(float64(utils.Config.Chain.ClConfig.SlotsPerEpoch)*1.25) * delay // 25% buffer
-		go services.ReportStatus(context.Background(), "api_service_validator_mapping", nil, &expectedDelay, map[string]string{"status": "running"})
+		go services.ReportStatus(context.Background(), "api_service_validator_mapping", nil, nil, map[string]string{"status": "running"})
 		latestEpoch := cache.LatestEpoch.Get()
 		if currentValidatorMapping == nil || latestEpoch != lastEpochUpdate {
 			err := s.updateValidatorMapping()
 			if err != nil {
 				log.Error(err, "error updating validator mapping", 0)
-				go services.ReportStatus(context.Background(), "api_service_validator_mapping", err, &expectedDelay, map[string]string{"took": time.Since(startTime).String()})
+				go services.ReportStatus(context.Background(), "api_service_validator_mapping", err, nil, map[string]string{"took": time.Since(startTime).String()})
 				delay = 10 * time.Second
 			} else {
 				log.Infof("=== validator mapping updated in %s", time.Since(startTime))

--- a/backend/pkg/commons/cache/tiered_cache.go
+++ b/backend/pkg/commons/cache/tiered_cache.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Tiered cache is a cache implementation combining a
-type tieredCache struct {
+type TieredCacheBase struct {
 	localGoCache *freecache.Cache
 	remoteCache  RemoteCache
 }
@@ -30,7 +30,7 @@ type RemoteCache interface {
 	GetBool(ctx context.Context, key string) (bool, error)
 }
 
-var TieredCache *tieredCache
+var TieredCache *TieredCacheBase
 
 func MustInitTieredCache(redisAddress string) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
@@ -41,13 +41,13 @@ func MustInitTieredCache(redisAddress string) {
 		log.Fatal(err, "error initializing remote redis cache", 0, map[string]interface{}{"address": redisAddress})
 	}
 
-	TieredCache = &tieredCache{
+	TieredCache = &TieredCacheBase{
 		remoteCache:  remoteCache,
 		localGoCache: freecache.NewCache(100 * 1024 * 1024), // 100 MB
 	}
 }
 
-func (cache *tieredCache) SetString(key, value string, expiration time.Duration) error {
+func (cache *TieredCacheBase) SetString(key, value string, expiration time.Duration) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 
@@ -58,7 +58,7 @@ func (cache *tieredCache) SetString(key, value string, expiration time.Duration)
 	return cache.remoteCache.SetString(ctx, key, value, expiration)
 }
 
-func (cache *tieredCache) GetStringWithLocalTimeout(key string, localExpiration time.Duration) (string, error) {
+func (cache *TieredCacheBase) GetStringWithLocalTimeout(key string, localExpiration time.Duration) (string, error) {
 	// try to retrieve the key from the local cache
 	wanted, err := cache.localGoCache.Get([]byte(key))
 	if err == nil {
@@ -81,7 +81,7 @@ func (cache *tieredCache) GetStringWithLocalTimeout(key string, localExpiration 
 	return value, nil
 }
 
-func (cache *tieredCache) SetUint64(key string, value uint64, expiration time.Duration) error {
+func (cache *TieredCacheBase) SetUint64(key string, value uint64, expiration time.Duration) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 
@@ -92,7 +92,7 @@ func (cache *tieredCache) SetUint64(key string, value uint64, expiration time.Du
 	return cache.remoteCache.SetUint64(ctx, key, value, expiration)
 }
 
-func (cache *tieredCache) GetUint64WithLocalTimeout(key string, localExpiration time.Duration) (uint64, error) {
+func (cache *TieredCacheBase) GetUint64WithLocalTimeout(key string, localExpiration time.Duration) (uint64, error) {
 	// try to retrieve the key from the local cache
 	wanted, err := cache.localGoCache.Get([]byte(key))
 	if err == nil {
@@ -119,7 +119,7 @@ func (cache *tieredCache) GetUint64WithLocalTimeout(key string, localExpiration 
 	return value, nil
 }
 
-func (cache *tieredCache) SetBool(key string, value bool, expiration time.Duration) error {
+func (cache *TieredCacheBase) SetBool(key string, value bool, expiration time.Duration) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 
@@ -130,7 +130,7 @@ func (cache *tieredCache) SetBool(key string, value bool, expiration time.Durati
 	return cache.remoteCache.SetBool(ctx, key, value, expiration)
 }
 
-func (cache *tieredCache) GetBoolWithLocalTimeout(key string, localExpiration time.Duration) (bool, error) {
+func (cache *TieredCacheBase) GetBoolWithLocalTimeout(key string, localExpiration time.Duration) (bool, error) {
 	// try to retrieve the key from the local cache
 	wanted, err := cache.localGoCache.Get([]byte(key))
 	if err == nil {
@@ -157,7 +157,7 @@ func (cache *tieredCache) GetBoolWithLocalTimeout(key string, localExpiration ti
 	return value, nil
 }
 
-func (cache *tieredCache) Set(key string, value interface{}, expiration time.Duration) error {
+func (cache *TieredCacheBase) Set(key string, value interface{}, expiration time.Duration) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 
@@ -172,7 +172,7 @@ func (cache *tieredCache) Set(key string, value interface{}, expiration time.Dur
 	return cache.remoteCache.Set(ctx, key, value, expiration)
 }
 
-func (cache *tieredCache) GetWithLocalTimeout(key string, localExpiration time.Duration, returnValue interface{}) (interface{}, error) {
+func (cache *TieredCacheBase) GetWithLocalTimeout(key string, localExpiration time.Duration, returnValue interface{}) (interface{}, error) {
 	// try to retrieve the key from the local cache
 	wanted, err := cache.localGoCache.Get([]byte(key))
 	if err == nil {

--- a/backend/pkg/commons/db/clickhouse.go
+++ b/backend/pkg/commons/db/clickhouse.go
@@ -51,13 +51,13 @@ func MustInitClickhouseNative(writer *types.DatabaseConfig) ch.Conn {
 		log.Fatal(err, "Error connecting to clickhouse native writer", 0)
 	}
 	// verify connection
-	ClickHouseTestConnection(&dbWriter, writer.Name)
+	ClickHouseTestConnection(dbWriter, writer.Name)
 
 	return dbWriter
 }
 
-func ClickHouseTestConnection(db *ch.Conn, dataBaseName string) {
-	v, err := (*db).ServerVersion()
+func ClickHouseTestConnection(db ch.Conn, dataBaseName string) {
+	v, err := db.ServerVersion()
 	if err != nil {
 		log.Fatal(fmt.Errorf("failed to ping clickhouse database %s: %w", dataBaseName, err), "", 0)
 	}

--- a/backend/pkg/commons/db/migrations/clickhouse/20240821140310_status_reports.sql
+++ b/backend/pkg/commons/db/migrations/clickhouse/20240821140310_status_reports.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE status_reports
+(
+    `inserted_at` DateTime64(3) Default now(), -- miliseconds precision
+    `expires_at` DateTime Default now() + INTERVAL 1 MINUTE,
+    `event_id` LowCardinality(String),
+    `emitter` String,
+    `status` LowCardinality(String) MATERIALIZED if(has(metadata, 'status'), metadata['status'], 'not_set'),
+    `metadata` Map(LowCardinality(String), String),
+)
+ENGINE = MergeTree()
+ORDER BY (inserted_at, event_id, emitter)
+TTL toDateTime(inserted_at + toIntervalWeek(1))
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE status_reports IF EXISTS
+-- +goose StatementEnd

--- a/backend/pkg/commons/metrics/metrics.go
+++ b/backend/pkg/commons/metrics/metrics.go
@@ -20,6 +20,10 @@ var (
 		Name: "version",
 		Help: "Gauge with version-string in label",
 	}, []string{"version"})
+	UUID = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "uuid",
+		Help: "Gauge with uuid-string in label",
+	}, []string{"uuid"})
 	HttpRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "http_requests_total",
 		Help: "Total number of requests by path, method and status_code.",

--- a/backend/pkg/commons/utils/uuid.go
+++ b/backend/pkg/commons/utils/uuid.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"sync/atomic"
+
+	"github.com/gobitfly/beaconchain/pkg/commons/log"
+	"github.com/google/uuid"
+)
+
+// uuid that you can get  - gets set to a random value on startup/first read
+var _uuid atomic.Value
+
+// GetUUID returns the uuid
+func GetUUID() string {
+	if v := _uuid.Load(); v != nil {
+		return v.(string)
+	}
+
+	tmp_uuid := uuid.NewString()
+	if _uuid.CompareAndSwap(nil, tmp_uuid) {
+		log.Infof("uuid set to %s", tmp_uuid)
+	}
+	return _uuid.Load().(string)
+}

--- a/backend/pkg/monitoring/monitoring.go
+++ b/backend/pkg/monitoring/monitoring.go
@@ -1,0 +1,53 @@
+package monitoring
+
+import (
+	"github.com/gobitfly/beaconchain/pkg/commons/db"
+	"github.com/gobitfly/beaconchain/pkg/commons/metrics"
+	"github.com/gobitfly/beaconchain/pkg/commons/types"
+	"github.com/gobitfly/beaconchain/pkg/commons/utils"
+	"github.com/gobitfly/beaconchain/pkg/monitoring/services"
+)
+
+var monitoredServices []services.Service
+
+func Init(full bool) {
+	metrics.UUID.WithLabelValues(utils.GetUUID()).Set(1) // so we can find out where the uuid is set
+	if db.ClickHouseNativeWriter == nil {
+		db.ClickHouseNativeWriter = db.MustInitClickhouseNative(&types.DatabaseConfig{
+			Username:     utils.Config.ClickHouse.WriterDatabase.Username,
+			Password:     utils.Config.ClickHouse.WriterDatabase.Password,
+			Name:         utils.Config.ClickHouse.WriterDatabase.Name,
+			Host:         utils.Config.ClickHouse.WriterDatabase.Host,
+			Port:         utils.Config.ClickHouse.WriterDatabase.Port,
+			MaxOpenConns: utils.Config.ClickHouse.WriterDatabase.MaxOpenConns,
+			SSL:          true,
+			MaxIdleConns: utils.Config.ClickHouse.WriterDatabase.MaxIdleConns,
+		})
+
+	}
+	monitoredServices = []services.Service{
+		&services.ServerDbConnections{},
+	}
+	if full {
+		monitoredServices = append(monitoredServices,
+			&services.ServiceClickhouseRollings{},
+			&services.ServiceClickhouseEpoch{},
+		)
+	}
+
+	for _, service := range monitoredServices {
+		service.InitServices()
+	}
+}
+
+func Start() {
+	for _, service := range monitoredServices {
+		service.Start()
+	}
+}
+
+func Stop() {
+	for _, service := range monitoredServices {
+		service.Stop()
+	}
+}

--- a/backend/pkg/monitoring/monitoring.go
+++ b/backend/pkg/monitoring/monitoring.go
@@ -23,7 +23,6 @@ func Init(full bool) {
 			SSL:          true,
 			MaxIdleConns: utils.Config.ClickHouse.WriterDatabase.MaxIdleConns,
 		})
-
 	}
 	monitoredServices = []services.Service{
 		&services.ServerDbConnections{},

--- a/backend/pkg/monitoring/services/base.go
+++ b/backend/pkg/monitoring/services/base.go
@@ -1,0 +1,86 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gobitfly/beaconchain/pkg/commons/db"
+	"github.com/gobitfly/beaconchain/pkg/commons/log"
+	"github.com/gobitfly/beaconchain/pkg/commons/utils"
+	"github.com/gobitfly/beaconchain/pkg/commons/version"
+)
+
+// go interface for basic service
+
+type Service interface {
+	InitServices()
+	Start()
+	Stop()
+}
+
+type ServiceBase struct {
+	ctx     context.Context
+	cancel  context.CancelFunc
+	running atomic.Bool
+	wg      sync.WaitGroup
+}
+
+func (s *ServiceBase) InitServices() {
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+}
+
+func (s *ServiceBase) Stop() {
+	if !s.running.CompareAndSwap(true, false) {
+		return
+	}
+	s.cancel()
+	s.wg.Wait()
+}
+
+func ReportStatus(ctx context.Context, id string, err error, expires_in *time.Duration, metadata map[string]string) {
+	if metadata == nil {
+		metadata = make(map[string]string)
+	}
+	// if "status" is not set set it to "failure" if err is not nil or "heartbeat" if err is nil
+	if _, ok := metadata["status"]; !ok {
+		if err != nil {
+			metadata["status"] = "failure"
+		} else {
+			metadata["status"] = "heartbeat"
+		}
+	}
+	metadata["executable_version"] = fmt.Sprintf("%s (%s)", version.Version, version.GoVersion)
+
+	if err != nil {
+		metadata["error"] = err.Error()
+	}
+
+	// report status to monitoring
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	//log.Infof("new status report at %v", time.Now())
+	if db.ClickHouseNativeWriter == nil {
+		log.Error(nil, "clickhouse native writer is nil", 0)
+		return
+	}
+	expires_at := time.Now().Add(1 * time.Minute)
+	if expires_in != nil {
+		expires_at = time.Now().Add(*expires_in)
+	}
+	err = db.ClickHouseNativeWriter.AsyncInsert(
+		ctx,
+		"INSERT INTO status_reports (emitter, event_id, inserted_at, expires_at, metadata) VALUES (?, ?, ?, ?, ?)",
+		false,
+		utils.GetUUID(),
+		id,
+		time.Now().UnixMilli(),
+		expires_at,
+		metadata,
+	)
+	if err != nil {
+		log.Error(err, "error inserting status report", 0)
+	}
+}

--- a/backend/pkg/monitoring/services/clickhouse_epoch.go
+++ b/backend/pkg/monitoring/services/clickhouse_epoch.go
@@ -55,7 +55,7 @@ func (s *ServiceClickhouseEpoch) runChecks() {
 	}
 	// check if delta is out of bounds
 	threshold := 1 * time.Hour
-	md := map[string]string{"delta": fmt.Sprintf("%s", time.Since(t)), "threshold": threshold.String()}
+	md := map[string]string{"delta": time.Since(t).String(), "threshold": threshold.String()}
 	if time.Since(t) > threshold {
 		ReportStatus(s.ctx, id, fmt.Errorf("delta is over threshold %d", threshold), &expiry, md)
 		return

--- a/backend/pkg/monitoring/services/clickhouse_epoch.go
+++ b/backend/pkg/monitoring/services/clickhouse_epoch.go
@@ -1,0 +1,64 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gobitfly/beaconchain/pkg/commons/db"
+	"github.com/gobitfly/beaconchain/pkg/commons/log"
+)
+
+type ServiceClickhouseEpoch struct {
+	ServiceBase
+}
+
+func (s *ServiceClickhouseEpoch) Start() {
+	if !s.running.CompareAndSwap(false, true) {
+		// already running, return error
+		return
+	}
+	s.wg.Add(1)
+	go s.internalProcess()
+}
+
+func (s *ServiceClickhouseEpoch) internalProcess() {
+	defer s.wg.Done()
+	s.runChecks()
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-time.After(30 * time.Second):
+			s.runChecks()
+		}
+	}
+}
+
+func (s *ServiceClickhouseEpoch) runChecks() {
+	id := "ch_dashboard_epoch"
+	if db.ClickHouseReader == nil {
+		ReportStatus(s.ctx, id, fmt.Errorf("clickhouse reader is nil"), nil, nil)
+		// ignore
+		return
+	}
+	log.Debugf("checking clickhouse epoch")
+	// context with deadline
+	ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
+	defer cancel()
+	var t time.Time
+	expiry := 5 * time.Minute
+	err := db.ClickHouseReader.GetContext(ctx, &t, "SELECT MAX(epoch_timestamp) FROM validator_dashboard_data_epoch")
+	if err != nil {
+		ReportStatus(s.ctx, id, err, &expiry, nil)
+		return
+	}
+	// check if delta is out of bounds
+	threshold := 1 * time.Hour
+	md := map[string]string{"delta": fmt.Sprintf("%s", time.Since(t)), "threshold": threshold.String()}
+	if time.Since(t) > threshold {
+		ReportStatus(s.ctx, id, fmt.Errorf("delta is over threshold %d", threshold), &expiry, md)
+		return
+	}
+	ReportStatus(s.ctx, id, nil, &expiry, md)
+}

--- a/backend/pkg/monitoring/services/clickhouse_rollings.go
+++ b/backend/pkg/monitoring/services/clickhouse_rollings.go
@@ -1,0 +1,98 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/gobitfly/beaconchain/pkg/commons/db"
+	"github.com/gobitfly/beaconchain/pkg/commons/log"
+)
+
+// create db connection service that checks for the status of db connections
+
+type ServiceClickhouseRollings struct {
+	ServiceBase
+}
+
+func (s *ServiceClickhouseRollings) Start() {
+	if !s.running.CompareAndSwap(false, true) {
+		// already running, return error
+		return
+	}
+	s.wg.Add(1)
+	go s.internalProcess()
+}
+
+func (s *ServiceClickhouseRollings) internalProcess() {
+	defer s.wg.Done()
+	s.runChecks()
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-time.After(30 * time.Second):
+			s.runChecks()
+		}
+	}
+}
+
+func (s *ServiceClickhouseRollings) runChecks() {
+	rollings := []string{
+		"1h",
+		"24h",
+		"7d",
+		"30d",
+		"90d",
+		"total",
+	}
+	wg := sync.WaitGroup{}
+	expiry := 5 * time.Minute
+	for _, rolling := range rollings {
+		rolling := rolling
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			id := fmt.Sprintf("ch_rolling_%s", rolling)
+			if db.ClickHouseReader == nil {
+				ReportStatus(s.ctx, id, fmt.Errorf("clickhouse reader is nil"), &expiry, nil)
+				// ignore
+				return
+			}
+			log.Debugf("checking clickhouse rolling %s", rolling)
+			// context with deadline
+			ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
+			defer cancel()
+			var delta uint64
+			err := db.ClickHouseReader.GetContext(ctx, &delta, fmt.Sprintf(`
+					SELECT
+						coalesce((
+							SELECT
+								max(epoch)
+							FROM holesky.validator_dashboard_data_epoch
+							WHERE
+								epoch_timestamp = (
+									SELECT
+										max(epoch_timestamp)
+									FROM holesky.validator_dashboard_data_epoch)) - MAX(epoch_end), 255) AS delta
+					FROM
+						holesky.validator_dashboard_data_rolling_%s
+					WHERE
+						validator_index = 0`, rolling))
+			if err != nil {
+				ReportStatus(s.ctx, id, err, &expiry, nil)
+				return
+			}
+			// check if delta is out of bounds
+			threshold := 2
+			md := map[string]string{"delta": fmt.Sprintf("%d", delta), "threshold": fmt.Sprintf("%d", threshold)}
+			if delta > uint64(threshold) {
+				ReportStatus(s.ctx, id, fmt.Errorf("delta is over threshold %d", threshold), &expiry, md)
+				return
+			}
+			ReportStatus(s.ctx, id, nil, &expiry, md)
+		}()
+	}
+	wg.Wait()
+}

--- a/backend/pkg/monitoring/services/db_connections.go
+++ b/backend/pkg/monitoring/services/db_connections.go
@@ -1,0 +1,125 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+	"unsafe"
+
+	ch "github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/go-redis/redis/v8"
+
+	"github.com/gobitfly/beaconchain/pkg/commons/cache"
+	"github.com/gobitfly/beaconchain/pkg/commons/db"
+	"github.com/gobitfly/beaconchain/pkg/commons/log"
+	"github.com/jmoiron/sqlx"
+)
+
+// create db connection service that checks for the status of db connections
+
+type ServerDbConnections struct {
+	ServiceBase
+}
+
+func (s *ServerDbConnections) internalProcess() {
+	defer s.wg.Done()
+	s.checkDBConnections()
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-time.After(10 * time.Second):
+			s.checkDBConnections()
+		}
+	}
+}
+
+func (s *ServerDbConnections) Start() {
+	if !s.running.CompareAndSwap(false, true) {
+		return
+	}
+	s.wg.Add(1)
+	go s.internalProcess()
+}
+
+type Entry struct {
+	ID string
+	DB any
+}
+
+func n[T interface{}](id string, db T) *Entry {
+	// use reflect to check if db is nil. use reflect. do not simply compare to nil
+	if v := reflect.ValueOf(db); !v.IsValid() || v.IsNil() {
+		return nil
+	}
+
+	return &Entry{id, db}
+}
+
+func (s *ServerDbConnections) checkDBConnections() {
+	entries := []*Entry{
+		n("db_conn_reader_db", db.ReaderDb),
+		n("db_conn_writer_db", db.WriterDb),
+		n("db_conn_user_reader", db.UserReader),
+		n("db_conn_user_writer", db.UserWriter),
+		n("db_conn_alloy_reader", db.AlloyReader),
+		n("db_conn_alloy_writer", db.AlloyWriter),
+		n("db_conn_frontend_reader_db", db.FrontendReaderDB),
+		n("db_conn_frontend_writer_db", db.FrontendWriterDB),
+		n("db_conn_clickhouse_reader", db.ClickHouseReader),
+		n("db_conn_clickhouse_writer", db.ClickHouseWriter),
+		n("db_conn_clickhouse_native_writer", db.ClickHouseNativeWriter),
+		n("db_conn_persistent_redis_db_client", db.PersistentRedisDbClient),
+	}
+	if cache.TieredCache != nil {
+		entries = append(entries, n("db_conn_tiered_cache", cache.TieredCache))
+	}
+	wg := sync.WaitGroup{}
+	for _, entry := range entries {
+		if entry == nil {
+			// ignore
+			continue
+		}
+		wg.Add(1)
+		go func(entry *Entry) {
+			defer wg.Done()
+			log.Debugf("checking db connection for %s", entry.ID)
+			// context with deadline
+			ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
+			defer cancel()
+			switch edb := entry.DB.(type) {
+			case *sqlx.DB:
+				err := edb.PingContext(ctx)
+				ReportStatus(s.ctx, entry.ID, err, nil, nil)
+			case *redis.Client:
+				err := edb.Ping(ctx).Err()
+				ReportStatus(s.ctx, entry.ID, err, nil, nil)
+			case *cache.TieredCacheBase:
+				// have to use reflection cause nothing is public. this is a hack. but it works
+				val := reflect.ValueOf(edb).Elem().FieldByName("remoteCache")
+				if !val.IsValid() {
+					log.Error(fmt.Errorf("failed to get remoteCache"), "failed to get remoteCache", 0)
+					return
+				}
+				// its a pointer to a pointer that is cache.RemoteCache compliant. convert it so we can call Get() on it
+				rf := reflect.NewAt(val.Type(), unsafe.Pointer(val.UnsafeAddr())).Elem()
+				vals := rf.MethodByName("GetBool").Call([]reflect.Value{reflect.ValueOf(ctx), reflect.ValueOf("test")})
+				err := vals[1].Interface().(error)
+				// check if its redis nil, if yes ignore
+				if err != nil && errors.Is(err, redis.Nil) {
+					err = nil
+				}
+				ReportStatus(s.ctx, entry.ID, err, nil, nil)
+			case ch.Conn: // its an interface
+				err := edb.Ping(ctx)
+				ReportStatus(s.ctx, entry.ID, err, nil, nil)
+			default:
+				log.Error(fmt.Errorf("unknown db type"), "unknown db type", 0, map[string]interface{}{"entry": entry})
+			}
+		}(entry)
+	}
+	wg.Wait()
+}

--- a/backend/pkg/monitoring/services/flaky_test_service.go
+++ b/backend/pkg/monitoring/services/flaky_test_service.go
@@ -1,0 +1,32 @@
+package services
+
+import (
+	"fmt"
+	"time"
+)
+
+type FlakyTestService struct {
+	ServiceBase
+}
+
+func (s *FlakyTestService) Start() {
+	if !s.running.CompareAndSwap(false, true) {
+		// already running, return error
+		return
+	}
+	s.wg.Add(1)
+	go s.internalProcess()
+}
+
+func (s *FlakyTestService) internalProcess() {
+	defer s.wg.Done()
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-time.After(10 * time.Second):
+			err := fmt.Errorf("random error")
+			ReportStatus(s.ctx, "flaky_test", err, nil, nil)
+		}
+	}
+}


### PR DESCRIPTION
status can be checked by response code (500=bad, 200=good) or the root `is_ok` flag
breakdown of reports is in `status_reports`
`tags` would allow for dynamic routing of alerts (for example all clickhouse alerts go to person a while all alloy alerts go to person b)
![image](https://github.com/user-attachments/assets/0390fe27-b583-47b0-9ff8-bc7f608f5704)
