### PR TITLE
fix(dashboard): chart tooltip position, line color, min pre selection…

### DIFF
--- a/frontend/components/dashboard/DashboardControls.vue
+++ b/frontend/components/dashboard/DashboardControls.vue
@@ -389,7 +389,6 @@ const editDashboard = () => {
   height: 30px;
   display: flex;
   gap: var(--padding);
-  margin-bottom: var(--padding-large);
   @media (max-width: 519px) {
     gap: var(--padding-small);
   }

--- a/frontend/components/dashboard/ValidatorOverview.vue
+++ b/frontend/components/dashboard/ValidatorOverview.vue
@@ -125,6 +125,7 @@ const dataList = computed(() => {
   align-items: center;
   justify-content: space-between;
   overflow-x: auto;
+  margin-top: var(--padding-large);
   gap: 50px;
   height: 101px;
   padding-left: var(--padding-xl);

--- a/frontend/components/dashboard/chart/SummaryChart.vue
+++ b/frontend/components/dashboard/chart/SummaryChart.vue
@@ -328,6 +328,7 @@ const option = computed(() => {
     },
     tooltip: {
       borderColor: colors.value.background,
+      confine: true,
       formatter(params: any): HTMLElement {
         const ts = parseInt(params[0].axisValue)
         let lastDif = 0
@@ -411,7 +412,11 @@ const option = computed(() => {
         ],
       },
       silent: true,
-      splitLine: { lineStyle: { color: colors.value.label } },
+      splitLine: {
+        lineStyle: {
+          color: colors.value.label, opacity: 0.3,
+        },
+      },
       type: 'value',
     },
   }
@@ -475,6 +480,8 @@ const validateDataZoom = (instant?: boolean, categoryChanged?: boolean) => {
         targetPoints = 8
         break
     }
+    // for dashboards with a large amount of time frames we show at least 3%
+    targetPoints = Math.max(targetPoints, Math.ceil(max * 0.03))
     timestamps.toIndex = firstTime ? max : Math.max(Math.ceil(max / 100 * timestamps.end), targetPoints)
     timestamps.fromIndex = timestamps.toIndex - targetPoints
   }

--- a/frontend/composables/useHashTabs.ts
+++ b/frontend/composables/useHashTabs.ts
@@ -1,10 +1,13 @@
 import type { HashTabs } from '~/types/hashTabs'
 
-export function useHashTabs(tabs: HashTabs) {
+export function useHashTabs(tabs: HashTabs, defaultTab: string) {
   const activeIndex = ref(-1)
   const { hash: initialHash } = useRoute()
 
   const findFirstValidIndex = () => {
+    if (tabs[defaultTab] && !tabs[defaultTab].disabled) {
+      return tabs[defaultTab].index
+    }
     const list = Object.values(tabs)
     for (let i = 0; i < list.length; i++) {
       const tab = list[i]

--- a/frontend/pages/dashboard/[[id]]/index.vue
+++ b/frontend/pages/dashboard/[[id]]/index.vue
@@ -32,7 +32,7 @@ const tabs: HashTabs = {
 
 const {
   activeIndex, setActiveIndex,
-} = useHashTabs(tabs)
+} = useHashTabs(tabs, 'summary')
 
 const {
   dashboardKey, setDashboardKey,

--- a/frontend/pages/notifications.vue
+++ b/frontend/pages/notifications.vue
@@ -42,7 +42,7 @@ const tabs: HashTabs = {
 
 const {
   activeIndex, setActiveIndex,
-} = useHashTabs(tabs)
+} = useHashTabs(tabs, 'dashboards')
 
 useBcSeo('notifications.title')
 
@@ -50,7 +50,7 @@ const openManageNotifications = () => {
   if (!isLoggedIn.value) {
     dialog.open(BcDialogConfirm, {
       data: { question: $t('notifications.login_question') },
-      onClose: async (response) => {
+      onClose: async (response: { data?: boolean }) => {
         if (response?.data) {
           await navigateTo('/login')
         }

--- a/frontend/pages/notifications.vue
+++ b/frontend/pages/notifications.vue
@@ -5,6 +5,7 @@ import {
   faMonitorWaveform,
   faNetworkWired,
 } from '@fortawesome/pro-solid-svg-icons'
+import type { DynamicDialogCloseOptions } from 'primevue/dynamicdialogoptions'
 import { BcDialogConfirm } from '#components'
 import type { HashTabs } from '~/types/hashTabs'
 
@@ -50,7 +51,7 @@ const openManageNotifications = () => {
   if (!isLoggedIn.value) {
     dialog.open(BcDialogConfirm, {
       data: { question: $t('notifications.login_question') },
-      onClose: async (response: { data?: boolean }) => {
+      onClose: async (response: DynamicDialogCloseOptions) => {
         if (response?.data) {
           await navigateTo('/login')
         }


### PR DESCRIPTION
This PR fixes:
- Tab pre selection
  - new default selection prop
  - use the correct default on validator and notifications dashboard
- summary chart
  - have an initial 3 % min range selection 
  - set an 0.3 opacity for the chart background lines 
  - keep the tooltip in the boundries of the chart
- try to fix the cut border top on the validator overview 