### PR TITLE
fix(dashboard): move by 0 px to show top border on IOS

### DIFF
--- a/frontend/components/dashboard/ValidatorOverview.vue
+++ b/frontend/components/dashboard/ValidatorOverview.vue
@@ -126,6 +126,7 @@ const dataList = computed(() => {
   justify-content: space-between;
   overflow-x: auto;
   margin-top: var(--padding-large);
+  transform: translateY(0px); // Needed to show top border on IOS
   gap: 50px;
   height: 101px;
   padding-left: var(--padding-xl);

--- a/frontend/components/dashboard/ValidatorOverview.vue
+++ b/frontend/components/dashboard/ValidatorOverview.vue
@@ -126,7 +126,7 @@ const dataList = computed(() => {
   justify-content: space-between;
   overflow-x: auto;
   margin-top: var(--padding-large);
-  transform: translateY(0px); // Needed to show top border on IOS
+  transform: translateY(0px); // hack: on safari top-border is not shown
   gap: 50px;
   height: 101px;
   padding-left: var(--padding-xl);


### PR DESCRIPTION
This PR:
- moves the overview by 0 px to show the top border on IOS