### PR TITLE
(BEDS-313) don't pass VDBId struct in archiving middleware

### DIFF
--- a/backend/pkg/api/data_access/dummy.go
+++ b/backend/pkg/api/data_access/dummy.go
@@ -193,19 +193,19 @@ func (d *DummyService) GetFreeTierPerks(ctx context.Context) (*t.PremiumPerks, e
 	return &r, err
 }
 
-func (d *DummyService) GetValidatorDashboardInfo(ctx context.Context, dashboardId t.VDBIdPrimary) (*t.DashboardInfo, error) {
-	r := t.DashboardInfo{}
+func (d *DummyService) GetValidatorDashboardUser(ctx context.Context, dashboardId t.VDBIdPrimary) (*t.DashboardUser, error) {
+	r := t.DashboardUser{}
 	err := commonFakeData(&r)
 	return &r, err
 }
 
-func (d *DummyService) GetValidatorDashboardInfoByPublicId(ctx context.Context, publicDashboardId t.VDBIdPublic) (*t.DashboardInfo, error) {
-	r := t.DashboardInfo{}
+func (d *DummyService) GetValidatorDashboardIdByPublicId(ctx context.Context, publicDashboardId t.VDBIdPublic) (*t.VDBIdPrimary, error) {
+	var r t.VDBIdPrimary
 	err := commonFakeData(&r)
 	return &r, err
 }
 
-func (d *DummyService) GetValidatorDashboard(ctx context.Context, dashboardId t.VDBId) (*t.ValidatorDashboard, error) {
+func (d *DummyService) GetValidatorDashboardInfo(ctx context.Context, dashboardId t.VDBIdPrimary) (*t.ValidatorDashboard, error) {
 	r := t.ValidatorDashboard{}
 	// return semi-valid data to not break staging
 	//nolint:errcheck

--- a/backend/pkg/api/data_access/vdb.go
+++ b/backend/pkg/api/data_access/vdb.go
@@ -9,9 +9,9 @@ import (
 )
 
 type ValidatorDashboardRepository interface {
-	GetValidatorDashboardInfo(ctx context.Context, dashboardId t.VDBIdPrimary) (*t.DashboardInfo, error)
-	GetValidatorDashboardInfoByPublicId(ctx context.Context, publicDashboardId t.VDBIdPublic) (*t.DashboardInfo, error)
-	GetValidatorDashboard(ctx context.Context, dashboardId t.VDBId) (*t.ValidatorDashboard, error)
+	GetValidatorDashboardUser(ctx context.Context, dashboardId t.VDBIdPrimary) (*t.DashboardUser, error)
+	GetValidatorDashboardIdByPublicId(ctx context.Context, publicDashboardId t.VDBIdPublic) (*t.VDBIdPrimary, error)
+	GetValidatorDashboardInfo(ctx context.Context, dashboardId t.VDBIdPrimary) (*t.ValidatorDashboard, error)
 	GetValidatorDashboardName(ctx context.Context, dashboardId t.VDBIdPrimary) (string, error)
 	CreateValidatorDashboard(ctx context.Context, userId uint64, name string, network uint64) (*t.VDBPostReturnData, error)
 	RemoveValidatorDashboard(ctx context.Context, dashboardId t.VDBIdPrimary) error

--- a/backend/pkg/api/data_access/vdb_management.go
+++ b/backend/pkg/api/data_access/vdb_management.go
@@ -26,8 +26,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func (d *DataAccessService) GetValidatorDashboardInfo(ctx context.Context, dashboardId t.VDBIdPrimary) (*t.DashboardInfo, error) {
-	result := &t.DashboardInfo{}
+func (d *DataAccessService) GetValidatorDashboardUser(ctx context.Context, dashboardId t.VDBIdPrimary) (*t.DashboardUser, error) {
+	result := &t.DashboardUser{}
 
 	err := d.alloyReader.GetContext(ctx, result, `
 		SELECT
@@ -42,13 +42,12 @@ func (d *DataAccessService) GetValidatorDashboardInfo(ctx context.Context, dashb
 	return result, err
 }
 
-func (d *DataAccessService) GetValidatorDashboardInfoByPublicId(ctx context.Context, publicDashboardId t.VDBIdPublic) (*t.DashboardInfo, error) {
-	result := &t.DashboardInfo{}
+func (d *DataAccessService) GetValidatorDashboardIdByPublicId(ctx context.Context, publicDashboardId t.VDBIdPublic) (*t.VDBIdPrimary, error) {
+	var result *t.VDBIdPrimary
 
 	err := d.alloyReader.GetContext(ctx, result, `
 		SELECT
-			uvd.id,
-			uvd.user_id
+			uvd.id
 		FROM users_val_dashboards_sharing uvds
 		LEFT JOIN users_val_dashboards uvd ON uvd.id = uvds.dashboard_id
 		WHERE uvds.public_id = $1
@@ -59,7 +58,7 @@ func (d *DataAccessService) GetValidatorDashboardInfoByPublicId(ctx context.Cont
 	return result, err
 }
 
-func (d *DataAccessService) GetValidatorDashboard(ctx context.Context, dashboardId t.VDBId) (*t.ValidatorDashboard, error) {
+func (d *DataAccessService) GetValidatorDashboardInfo(ctx context.Context, dashboardId t.VDBIdPrimary) (*t.ValidatorDashboard, error) {
 	result := &t.ValidatorDashboard{}
 
 	wg := errgroup.Group{}
@@ -84,7 +83,7 @@ func (d *DataAccessService) GetValidatorDashboard(ctx context.Context, dashboard
 		FROM users_val_dashboards uvd
 		LEFT JOIN users_val_dashboards_sharing uvds ON uvd.id = uvds.dashboard_id
 		WHERE uvd.id = $1
-	`, dashboardId.Id)
+	`, dashboardId)
 		if err != nil {
 			return err
 		}
@@ -94,7 +93,7 @@ func (d *DataAccessService) GetValidatorDashboard(ctx context.Context, dashboard
 		}
 
 		mutex.Lock()
-		result.Id = uint64(dashboardId.Id)
+		result.Id = uint64(dashboardId)
 		result.Name = dbReturn[0].Name
 		result.IsArchived = dbReturn[0].IsArchived.Valid
 		result.ArchivedReason = dbReturn[0].IsArchived.String
@@ -131,7 +130,7 @@ func (d *DataAccessService) GetValidatorDashboard(ctx context.Context, dashboard
 			FROM 
 			    dashboards_groups,
 			    dashboards_validators
-		`, dashboardId.Id)
+		`, dashboardId)
 		if err != nil {
 			return err
 		}

--- a/backend/pkg/api/data_access/vdb_management.go
+++ b/backend/pkg/api/data_access/vdb_management.go
@@ -43,9 +43,9 @@ func (d *DataAccessService) GetValidatorDashboardUser(ctx context.Context, dashb
 }
 
 func (d *DataAccessService) GetValidatorDashboardIdByPublicId(ctx context.Context, publicDashboardId t.VDBIdPublic) (*t.VDBIdPrimary, error) {
-	var result *t.VDBIdPrimary
+	var result t.VDBIdPrimary
 
-	err := d.alloyReader.GetContext(ctx, result, `
+	err := d.alloyReader.GetContext(ctx, &result, `
 		SELECT
 			uvd.id
 		FROM users_val_dashboards_sharing uvds
@@ -55,7 +55,7 @@ func (d *DataAccessService) GetValidatorDashboardIdByPublicId(ctx context.Contex
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("%w: public id %v not found", ErrNotFound, publicDashboardId)
 	}
-	return result, err
+	return &result, err
 }
 
 func (d *DataAccessService) GetValidatorDashboardInfo(ctx context.Context, dashboardId t.VDBIdPrimary) (*t.ValidatorDashboard, error) {

--- a/backend/pkg/api/handlers/auth.go
+++ b/backend/pkg/api/handlers/auth.go
@@ -884,13 +884,13 @@ func (h *HandlerService) VDBAuthMiddleware(next http.Handler) http.Handler {
 		ctx = context.WithValue(ctx, ctxUserIdKey, userId)
 		r = r.WithContext(ctx)
 
-		dashboard, err := h.dai.GetValidatorDashboardInfo(r.Context(), types.VDBIdPrimary(dashboardId))
+		dashboardUser, err := h.dai.GetValidatorDashboardUser(r.Context(), types.VDBIdPrimary(dashboardId))
 		if err != nil {
 			handleErr(w, err)
 			return
 		}
 
-		if dashboard.UserId != userId {
+		if dashboardUser.UserId != userId {
 			// user does not have access to dashboard
 			// the proper error would be 403 Forbidden, but we don't want to leak information so we return 404 Not Found
 			handleErr(w, newNotFoundErr("dashboard with id %v not found", dashboardId))
@@ -932,13 +932,11 @@ func (h *HandlerService) VDBArchivedCheckMiddleware(next http.Handler) http.Hand
 			handleErr(w, err)
 			return
 		}
-
 		if len(dashboardId.Validators) > 0 {
 			next.ServeHTTP(w, r)
 			return
 		}
-
-		dashboard, err := h.dai.GetValidatorDashboard(r.Context(), *dashboardId)
+		dashboard, err := h.dai.GetValidatorDashboardInfo(r.Context(), dashboardId.Id)
 		if err != nil {
 			handleErr(w, err)
 			return

--- a/backend/pkg/api/handlers/common.go
+++ b/backend/pkg/api/handlers/common.go
@@ -385,11 +385,11 @@ func (h *HandlerService) getDashboardPremiumPerks(ctx context.Context, id types.
 		return perk, nil
 	}
 	// could be made into a single query if needed
-	dashboardInfo, err := h.dai.GetValidatorDashboardInfo(ctx, id.Id)
+	dashboardUser, err := h.dai.GetValidatorDashboardUser(ctx, id.Id)
 	if err != nil {
 		return nil, err
 	}
-	userInfo, err := h.dai.GetUserInfo(ctx, dashboardInfo.UserId)
+	userInfo, err := h.dai.GetUserInfo(ctx, dashboardUser.UserId)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/api/handlers/internal.go
+++ b/backend/pkg/api/handlers/internal.go
@@ -462,7 +462,7 @@ func (h *HandlerService) InternalPutValidatorDashboardArchiving(w http.ResponseW
 	}
 
 	// check conditions for changing archival status
-	dashboardInfo, err := h.dai.GetValidatorDashboard(r.Context(), types.VDBId{Id: dashboardId})
+	dashboardInfo, err := h.dai.GetValidatorDashboardInfo(r.Context(), dashboardId)
 	if err != nil {
 		handleErr(w, err)
 		return
@@ -905,12 +905,12 @@ func (h *HandlerService) InternalPutValidatorDashboardPublicId(w http.ResponseWr
 		handleErr(w, v)
 		return
 	}
-	dashboardInfo, err := h.dai.GetValidatorDashboardInfoByPublicId(r.Context(), publicDashboardId)
+	fetchedId, err := h.dai.GetValidatorDashboardIdByPublicId(r.Context(), publicDashboardId)
 	if err != nil {
 		handleErr(w, err)
 		return
 	}
-	if dashboardInfo.Id != dashboardId {
+	if *fetchedId != dashboardId {
 		handleErr(w, newNotFoundErr("public id %v not found", publicDashboardId))
 	}
 
@@ -935,12 +935,12 @@ func (h *HandlerService) InternalDeleteValidatorDashboardPublicId(w http.Respons
 		handleErr(w, v)
 		return
 	}
-	dashboardInfo, err := h.dai.GetValidatorDashboardInfoByPublicId(r.Context(), publicDashboardId)
+	fetchedId, err := h.dai.GetValidatorDashboardIdByPublicId(r.Context(), publicDashboardId)
 	if err != nil {
 		handleErr(w, err)
 		return
 	}
-	if dashboardInfo.Id != dashboardId {
+	if *fetchedId != dashboardId {
 		handleErr(w, newNotFoundErr("public id %v not found", publicDashboardId))
 	}
 

--- a/backend/pkg/api/handlers/internal.go
+++ b/backend/pkg/api/handlers/internal.go
@@ -890,7 +890,7 @@ func (h *HandlerService) InternalPutValidatorDashboardPublicId(w http.ResponseWr
 	vars := mux.Vars(r)
 	dashboardId := v.checkPrimaryDashboardId(mux.Vars(r)["dashboard_id"])
 	req := struct {
-		Name          string `json:"name"`
+		Name          string `json:"name,omitempty"`
 		ShareSettings struct {
 			ShareGroups bool `json:"share_groups"`
 		} `json:"share_settings"`
@@ -899,7 +899,7 @@ func (h *HandlerService) InternalPutValidatorDashboardPublicId(w http.ResponseWr
 		handleErr(w, err)
 		return
 	}
-	name := v.checkNameNotEmpty(req.Name)
+	name := v.checkName(req.Name, 0)
 	publicDashboardId := v.checkValidatorDashboardPublicId(vars["public_id"])
 	if v.hasErrors() {
 		handleErr(w, v)

--- a/backend/pkg/api/types/data_access.go
+++ b/backend/pkg/api/types/data_access.go
@@ -33,7 +33,7 @@ type VDBId struct {
 // could replace if we want the import in all files
 type VDBValidator = types.ValidatorIndex
 
-type DashboardInfo struct {
+type DashboardUser struct {
 	Id     VDBIdPrimary `db:"id"` // this must be the bigint id
 	UserId uint64       `db:"user_id"`
 }


### PR DESCRIPTION
This PR changes the parameter of a data access function, so that it can never take a validator set / guest dashboard as an argument. also renames some stuff for clarity.