### PR TITLE
fix(dashboard): label the time range overlay as date

### DIFF
--- a/frontend/components/dashboard/chart/RewardsChart.vue
+++ b/frontend/components/dashboard/chart/RewardsChart.vue
@@ -256,6 +256,9 @@ const option = computed<ECBasicOption | undefined>(() => {
         lineStyle: { color: colors.value.label },
       },
       end: 100,
+      labelFormatter: (_value: number, valueStr: string) => {
+        return formatEpochToDate(parseInt(valueStr), $t('locales.date'))
+      },
       start: 60,
       type: 'slider',
     },


### PR DESCRIPTION
This PR:
- labels the reward chart overlay as a date instead of the epoch

![image](https://github.com/user-attachments/assets/7cfc4a5e-d795-4d07-ab83-3c41419918b0)

BEDS-309