### PR TITLE
fix: tootlip sizing and and border in validator list modal

### DIFF
--- a/frontend/assets/css/prime.scss
+++ b/frontend/assets/css/prime.scss
@@ -586,6 +586,7 @@ div.p-accordion {
       display: flex;
       align-items: center;
       gap: var(--padding);
+      border: none;
       .p-accordionheader-toggle-icon {
         display: none;
       }

--- a/frontend/components/bc/BcTooltip.vue
+++ b/frontend/components/bc/BcTooltip.vue
@@ -359,6 +359,7 @@ onUnmounted(() => {
   @include fonts.tooltip_text;
   pointer-events: none;
   max-width: 300px;
+  box-sizing: content-box;
 
   &.special {
     --tt-bg-color: var(--light-grey-5);


### PR DESCRIPTION
This Pr:
- fixes the tooltip sizing
- borders around the groups in the validator dialog