### PR TITLE
Beds 306/healthz v2

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -48,6 +48,13 @@ func Run() {
 
 	log.InfoWithFields(log.Fields{"config": *configPath, "version": version.Version, "commit": version.GitCommit, "chainName": utils.Config.Chain.ClConfig.ConfigName}, "starting")
 
+	if cfg.DeploymentType != "development" {
+		// enable light-weight db connection monitoring
+		monitoring.Init(false)
+		monitoring.Start()
+		defer monitoring.Stop()
+	}
+
 	var dataAccessor dataaccess.DataAccessor
 	if dummyApi {
 		dataAccessor = dataaccess.NewDummyService()
@@ -58,12 +65,6 @@ func Run() {
 
 	router := api.NewApiRouter(dataAccessor, cfg)
 	router.Use(api.GetCorsMiddleware(cfg.CorsAllowedHosts))
-	if !cfg.Frontend.Debug {
-		// enable light-weight db connection monitoring
-		monitoring.Init(false)
-		monitoring.Start()
-		defer monitoring.Stop()
-	}
 
 	if utils.Config.Metrics.Enabled {
 		router.Use(metrics.HttpMiddleware)

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.25.0
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.43
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.49.0
+	github.com/bwmarrin/snowflake v0.3.0
 	github.com/coocood/freecache v1.2.4
 	github.com/davecgh/go-spew v1.1.1
 	github.com/donovanhide/eventsource v0.0.0-20210830082556-c59027999da0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -115,6 +115,8 @@ github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOF
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+github.com/bwmarrin/snowflake v0.3.0 h1:xm67bEhkKh6ij1790JB83OujPR5CzNe8QuQqAgISZN0=
+github.com/bwmarrin/snowflake v0.3.0/go.mod h1:NdZxfVWX+oR6y2K0o6qAYv6gIOP9rjG0/E9WsDpxqwE=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=

--- a/backend/pkg/api/data_access/healthz.go
+++ b/backend/pkg/api/data_access/healthz.go
@@ -2,10 +2,15 @@ package dataaccess
 
 import (
 	"context"
+	"maps"
 	"slices"
+	"time"
 
 	"github.com/gobitfly/beaconchain/pkg/api/types"
 	"github.com/gobitfly/beaconchain/pkg/commons/db"
+	"github.com/gobitfly/beaconchain/pkg/commons/log"
+	"github.com/gobitfly/beaconchain/pkg/commons/utils"
+	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
 )
 
 type HealthzRepository interface {
@@ -16,50 +21,82 @@ func (d *DataAccessService) GetHealthz(ctx context.Context, showAll bool) types.
 	var results []types.HealthzResult
 	var response types.HealthzData
 	query := `
-		WITH sub AS
-			(
-				SELECT
-					emitter,
-					event_id,
-					max(inserted_at) AS inserted_at,
-					max(expires_at) AS expires_at,
-					any(status) AS status,
-					any(mapSort(metadata)) AS metadata
-				FROM status_reports AS s
-				WHERE s.expires_at > now()
-				GROUP BY
-					1,
-					2,
-					s.status
-				ORDER BY
-					inserted_at DESC,
-					1 ASC,
-					2 ASC
-			)
+		with active_reports as (
+			SELECT
+				event_id,
+				emitter,
+				run_id,
+				inserted_at,
+				insert_id,
+				expires_at,
+				timeouts_at,
+				status,
+				metadata
+			FROM status_reports2
+			WHERE expires_at > now() and deployment_type = ?
+			ORDER BY
+				event_id ASC,
+				emitter ASC,
+				run_id ASC,
+				insert_id DESC
+		), latest_report_per_run as (
+			SELECT
+				event_id,
+				emitter,
+				any(inserted_at) as inserted_at, 
+				any(insert_id) as insert_id, 
+				any(expires_at) as expires_at,
+				any(timeouts_at) as timeouts_at,
+				any(status) AS status,
+				any(metadata) AS metadata
+			FROM
+				active_reports
+			GROUP BY
+				event_id,
+				emitter,
+				run_id
+			order by insert_id desc
+		), latest_report_per_status as (
+			select 
+				event_id,
+				emitter,
+				status,
+				any(inserted_at) as inserted_at, 
+				any(expires_at) as expires_at,
+				any(timeouts_at) as timeouts_at,
+				any(metadata) AS metadata
+			from latest_report_per_run
+			group by event_id, emitter, status
+		)
 		SELECT
 			event_id,
 			status,
 			groupArray(
-				map(
-					'emitter',
-					CAST(emitter, 'String'),
-					'inserted_at',
-					CAST(inserted_at, 'String'),
-					'expires_at',
-					CAST(expires_at, 'String'),
-					'metadata',
-					CAST(metadata, 'String')
-				)
-			) AS result
-		FROM sub
+						map(
+							'emitter',
+							CAST(emitter, 'String'),
+							'inserted_at',
+							CAST(inserted_at, 'String'),
+							'expires_at',
+							CAST(expires_at, 'String'),
+							'timeouts_at',
+							CAST(timeouts_at, 'String'),
+							'metadata',
+							CAST(mapSort(metadata), 'String')
+						)
+					) as result
+		FROM
+			latest_report_per_status
 		GROUP BY
-			event_id,
+			event_id, 
 			status
-		ORDER BY event_id, max(inserted_at) DESC
+		ORDER BY event_id ASC, max(inserted_at) DESC
 	`
 
 	response.Reports = make(map[string][]types.HealthzResult)
-	err := db.ClickHouseReader.SelectContext(ctx, &results, query)
+	response.ReportingUUID = utils.GetUUID()
+	response.DeploymentType = utils.Config.DeploymentType
+	err := db.ClickHouseReader.SelectContext(ctx, &results, query, utils.Config.DeploymentType)
 	if err != nil {
 		response.Reports["response_error"] = []types.HealthzResult{
 			{
@@ -68,6 +105,7 @@ func (d *DataAccessService) GetHealthz(ctx context.Context, showAll bool) types.
 				Result:  []map[string]string{{"error": "failed to fetch status reports"}},
 			},
 		}
+		log.Error(err, "failed to fetch status reports", 0)
 
 		return response
 	}
@@ -91,8 +129,7 @@ func (d *DataAccessService) GetHealthz(ctx context.Context, showAll bool) types.
 		if _, ok := response.Reports[id]; !ok {
 			response.Reports[id] = []types.HealthzResult{
 				{
-					EventId: id,
-					Status:  "failure",
+					Status: constants.Failure,
 					Result: []map[string]string{
 						{"error": "no status report found"},
 					},
@@ -100,10 +137,48 @@ func (d *DataAccessService) GetHealthz(ctx context.Context, showAll bool) types.
 			}
 		}
 	}
+
+	// we check all running ones if they are older than their timeouts_at field. if yes add an entry to failures
+	// if failures is already a key in the response, we will append a new entry to it
+	for _, r := range response.Reports {
+		for _, report := range r {
+			if report.Status != constants.Running {
+				continue
+			}
+			for _, result := range report.Result {
+				if timeoutsAt, ok := result["timeouts_at"]; ok {
+					// 2024-08-23 13:36:10
+					t, err := time.Parse("2006-01-02 15:04:05", timeoutsAt)
+					newMap := maps.Clone(result)
+					newMap["emitter"] = utils.GetUUID()
+					if err != nil {
+						newMap["healthz_error"] = "failed to parse timeouts_at"
+					} else if time.Now().After(t) {
+						newMap["healthz_error"] = "timeout"
+					} else {
+						continue
+					}
+					index := slices.IndexFunc(response.Reports[report.EventId], func(r types.HealthzResult) bool {
+						return r.Status == constants.Failure
+					})
+					if index == -1 {
+						response.Reports[report.EventId] = append(response.Reports[report.EventId], types.HealthzResult{
+							Status: constants.Failure,
+							Result: []map[string]string{},
+						})
+						index = len(response.Reports[report.EventId]) - 1
+					}
+					// copy the original map
+					response.Reports[report.EventId][index].Result = append(response.Reports[report.EventId][index].Result, newMap)
+				}
+			}
+		}
+	}
+
 	failures := 0
 	for _, r := range response.Reports {
 		for _, report := range r {
-			if report.Status == "failure" {
+			if report.Status == constants.Failure {
 				failures++
 			}
 		}

--- a/backend/pkg/api/services/service_slot_viz.go
+++ b/backend/pkg/api/services/service_slot_viz.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gobitfly/beaconchain/pkg/commons/types"
 	"github.com/gobitfly/beaconchain/pkg/commons/utils"
 	constypes "github.com/gobitfly/beaconchain/pkg/consapi/types"
+	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
 	"github.com/gobitfly/beaconchain/pkg/monitoring/services"
 	"github.com/juliangruber/go-intersect"
 	"github.com/lib/pq"
@@ -31,14 +32,15 @@ func (s *Services) startSlotVizDataService() {
 	for {
 		startTime := time.Now()
 		delay := time.Duration(utils.Config.Chain.ClConfig.SecondsPerSlot) * time.Second
-		go services.ReportStatus(context.Background(), "api_service_slot_viz", nil, nil, map[string]string{"status": "running"})
+		r := services.NewStatusReport("api_service_slot_viz", constants.Default, delay)
+		go r(constants.Running, nil)
 		err := s.updateSlotVizData() // TODO: only update data if something has changed (new head slot or new head epoch)
 		if err != nil {
 			log.Error(err, "error updating slotviz data", 0)
-			go services.ReportStatus(context.Background(), "api_service_slot_viz", err, nil, nil)
+			go r(constants.Failure, map[string]string{"error": err.Error()})
 		}
 		log.Infof("=== slotviz data updated in %s", time.Since(startTime))
-		go services.ReportStatus(context.Background(), "api_service_slot_viz", nil, nil, map[string]string{"status": "done", "took": time.Since(startTime).String()})
+		go r(constants.Success, map[string]string{"took": time.Since(startTime).String()})
 		utils.ConstantTimeDelay(startTime, delay)
 	}
 }

--- a/backend/pkg/api/services/service_validator_mapping.go
+++ b/backend/pkg/api/services/service_validator_mapping.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gobitfly/beaconchain/pkg/commons/types"
 	"github.com/gobitfly/beaconchain/pkg/commons/utils"
 	constypes "github.com/gobitfly/beaconchain/pkg/consapi/types"
+	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
 	"github.com/gobitfly/beaconchain/pkg/monitoring/services"
 	"github.com/klauspost/pgzip"
 	"github.com/pkg/errors"
@@ -38,13 +39,14 @@ func (s *Services) startIndexMappingService() {
 	for {
 		startTime := time.Now()
 		delay := time.Duration(utils.Config.Chain.ClConfig.SecondsPerSlot) * time.Second
-		go services.ReportStatus(context.Background(), "api_service_validator_mapping", nil, nil, map[string]string{"status": "running"})
+		r := services.NewStatusReport("api_service_validator_mapping", constants.Default, delay)
+		go r(constants.Running, nil)
 		latestEpoch := cache.LatestEpoch.Get()
 		if currentValidatorMapping == nil || latestEpoch != lastEpochUpdate {
 			err := s.updateValidatorMapping()
 			if err != nil {
 				log.Error(err, "error updating validator mapping", 0)
-				go services.ReportStatus(context.Background(), "api_service_validator_mapping", err, nil, map[string]string{"took": time.Since(startTime).String()})
+				go r(constants.Failure, map[string]string{"error": err.Error()})
 				delay = 10 * time.Second
 			} else {
 				log.Infof("=== validator mapping updated in %s", time.Since(startTime))
@@ -52,7 +54,7 @@ func (s *Services) startIndexMappingService() {
 
 			lastEpochUpdate = latestEpoch
 		}
-		go services.ReportStatus(context.Background(), "api_service_validator_mapping", nil, nil, map[string]string{"status": "done", "took": time.Since(startTime).String(), "latest_epoch": fmt.Sprintf("%d", lastEpochUpdate)})
+		go r(constants.Success, map[string]string{"took": time.Since(startTime).String(), "latest_epoch": fmt.Sprintf("%d", lastEpochUpdate)})
 		utils.ConstantTimeDelay(startTime, delay)
 	}
 }

--- a/backend/pkg/api/types/data_access.go
+++ b/backend/pkg/api/types/data_access.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gobitfly/beaconchain/pkg/api/enums"
 	"github.com/gobitfly/beaconchain/pkg/consapi/types"
+	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
 	"github.com/shopspring/decimal"
 )
 
@@ -215,12 +216,14 @@ type VDBValidatorSummaryChartRow struct {
 // healthz structs
 
 type HealthzResult struct {
-	EventId string              `db:"event_id" json:"-"`
-	Status  string              `db:"status" json:"status"`
-	Result  []map[string]string `db:"result" json:"reports"`
+	EventId string               `db:"event_id" json:"-"`
+	Status  constants.StatusType `db:"status" json:"status"`
+	Result  []map[string]string  `db:"result" json:"reports"`
 }
 
 type HealthzData struct {
 	TotalOkPercentage float64                    `json:"total_ok_percentage"`
+	ReportingUUID     string                     `json:"reporting_uuid"`
+	DeploymentType    string                     `json:"deployment_type"`
 	Reports           map[string][]HealthzResult `json:"status_reports"`
 }

--- a/backend/pkg/commons/db/migrations/clickhouse/20240821140310_status_reports.sql
+++ b/backend/pkg/commons/db/migrations/clickhouse/20240821140310_status_reports.sql
@@ -1,19 +1,23 @@
 -- +goose Up
 -- +goose StatementBegin
-CREATE TABLE status_reports
+CREATE TABLE status_reports2
 (
-    `inserted_at` DateTime64(3) Default now(), -- miliseconds precision
-    `expires_at` DateTime Default now() + INTERVAL 1 MINUTE,
+    `insert_id` Int64 CODEC(Delta, ZSTD(1)),
+    `inserted_at` DateTime Materialized snowflakeToDateTime(insert_id), -- twitter snowflake epoch
+    `timeouts_at` DateTime Default inserted_at + INTERVAL 1 MINUTE,
+    `expires_at` DateTime Default timeouts_at + INTERVAL 1 MINUTE,
+    `deployment_type` LowCardinality(String),
     `event_id` LowCardinality(String),
-    `emitter` String,
+    `emitter` UUID,
+    `run_id` UUID Materialized if(has(metadata, 'run_id'), metadata['run_id'], null),
     `status` LowCardinality(String) MATERIALIZED if(has(metadata, 'status'), metadata['status'], 'not_set'),
     `metadata` Map(LowCardinality(String), String),
 )
 ENGINE = MergeTree()
 ORDER BY (inserted_at, event_id, emitter)
-TTL toDateTime(inserted_at + toIntervalWeek(1))
+TTL toDateTime(expires_at + toIntervalMonth(1))
 
--- +goose StatementEnd
+-- +goose StatementEnd  
 
 -- +goose Down
 -- +goose StatementBegin

--- a/backend/pkg/commons/metrics/metrics.go
+++ b/backend/pkg/commons/metrics/metrics.go
@@ -24,6 +24,10 @@ var (
 		Name: "uuid",
 		Help: "Gauge with uuid-string in label",
 	}, []string{"uuid"})
+	DeploymentType = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "deployment_type",
+		Help: "Gauge with deployment-type in label",
+	}, []string{"deployment_type"})
 	HttpRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "http_requests_total",
 		Help: "Total number of requests by path, method and status_code.",

--- a/backend/pkg/commons/types/config.go
+++ b/backend/pkg/commons/types/config.go
@@ -9,7 +9,8 @@ import (
 
 // Config is a struct to hold the configuration data
 type Config struct {
-	JustV2         bool `yaml:"justV2" envconfig:"JUST_V2"` // temp, remove at some point
+	JustV2         bool   `yaml:"justV2" envconfig:"JUST_V2"` // temp, remove at some point
+	DeploymentType string `yaml:"deploymentType" envconfig:"DEPLOYMENT_TYPE"`
 	ReaderDatabase struct {
 		Username     string `yaml:"user" envconfig:"READER_DB_USERNAME"`
 		Password     string `yaml:"password" envconfig:"READER_DB_PASSWORD"`

--- a/backend/pkg/commons/utils/config.go
+++ b/backend/pkg/commons/utils/config.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"net"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/params"
@@ -103,6 +104,16 @@ func ReadConfig(cfg *types.Config, path string) error {
 	}
 
 	cfg.Chain.Name = cfg.Chain.ClConfig.ConfigName
+
+	// match DeploymentType to development, staging, production. if its empty fallback to development
+	validTypes := []string{"development", "development_noisy", "staging", "production"}
+	if cfg.DeploymentType == "" {
+		log.Warn("DeploymentType not set, defaulting to development")
+		cfg.DeploymentType = validTypes[0]
+	}
+	if !slices.Contains(validTypes, cfg.DeploymentType) {
+		log.Fatal(fmt.Errorf("invalid DeploymentType: %v (valid types: %v)", cfg.DeploymentType, validTypes), "", 0)
+	}
 
 	if cfg.Chain.GenesisTimestamp == 0 {
 		switch cfg.Chain.Name {

--- a/backend/pkg/commons/utils/uuid.go
+++ b/backend/pkg/commons/utils/uuid.go
@@ -3,12 +3,14 @@ package utils
 import (
 	"sync/atomic"
 
+	"github.com/bwmarrin/snowflake"
 	"github.com/gobitfly/beaconchain/pkg/commons/log"
 	"github.com/google/uuid"
 )
 
 // uuid that you can get  - gets set to a random value on startup/first read
 var _uuid atomic.Value
+var _snowflakeGenerator atomic.Value
 
 // GetUUID returns the uuid
 func GetUUID() string {
@@ -21,4 +23,18 @@ func GetUUID() string {
 		log.Infof("uuid set to %s", tmp_uuid)
 	}
 	return _uuid.Load().(string)
+}
+
+func GetSnowflake() int64 {
+	if v := _snowflakeGenerator.Load(); v != nil {
+		return v.(*snowflake.Node).Generate().Int64()
+	}
+
+	node, err := snowflake.NewNode(1)
+	if err != nil {
+		log.Fatal(err, "snowflake generator failed to start", 0)
+		return 0
+	}
+	_snowflakeGenerator.CompareAndSwap(nil, node)
+	return _snowflakeGenerator.Load().(*snowflake.Node).Generate().Int64()
 }

--- a/backend/pkg/monitoring/constants/main.go
+++ b/backend/pkg/monitoring/constants/main.go
@@ -1,0 +1,13 @@
+package constants
+
+import "time"
+
+// status enum
+type StatusType string
+
+const (
+	Running StatusType    = "running"
+	Success StatusType    = "success"
+	Failure StatusType    = "failure"
+	Default time.Duration = -1 * time.Second
+)

--- a/backend/pkg/monitoring/monitoring.go
+++ b/backend/pkg/monitoring/monitoring.go
@@ -12,6 +12,7 @@ var monitoredServices []services.Service
 
 func Init(full bool) {
 	metrics.UUID.WithLabelValues(utils.GetUUID()).Set(1) // so we can find out where the uuid is set
+	metrics.DeploymentType.WithLabelValues(utils.Config.DeploymentType).Set(1)
 	if db.ClickHouseNativeWriter == nil {
 		db.ClickHouseNativeWriter = db.MustInitClickhouseNative(&types.DatabaseConfig{
 			Username:     utils.Config.ClickHouse.WriterDatabase.Username,

--- a/backend/pkg/monitoring/services/base.go
+++ b/backend/pkg/monitoring/services/base.go
@@ -11,6 +11,8 @@ import (
 	"github.com/gobitfly/beaconchain/pkg/commons/log"
 	"github.com/gobitfly/beaconchain/pkg/commons/utils"
 	"github.com/gobitfly/beaconchain/pkg/commons/version"
+	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
+	"github.com/google/uuid"
 )
 
 // go interface for basic service
@@ -40,47 +42,50 @@ func (s *ServiceBase) Stop() {
 	s.wg.Wait()
 }
 
-func ReportStatus(ctx context.Context, id string, err error, expires_in *time.Duration, metadata map[string]string) {
-	if metadata == nil {
-		metadata = make(map[string]string)
-	}
-	// if "status" is not set set it to "failure" if err is not nil or "heartbeat" if err is nil
-	if _, ok := metadata["status"]; !ok {
-		if err != nil {
-			metadata["status"] = "failure"
-		} else {
-			metadata["status"] = "heartbeat"
+func NewStatusReport(id string, timeout time.Duration, check_interval time.Duration) func(status constants.StatusType, metadata map[string]string) {
+	runId := uuid.New().String()
+	return func(status constants.StatusType, metadata map[string]string) {
+		// acquire snowflake
+		flake := utils.GetSnowflake()
+		if metadata == nil {
+			metadata = make(map[string]string)
 		}
-	}
-	metadata["executable_version"] = fmt.Sprintf("%s (%s)", version.Version, version.GoVersion)
 
-	if err != nil {
-		metadata["error"] = err.Error()
-	}
+		metadata["run_id"] = runId
+		metadata["status"] = string(status)
+		metadata["executable_version"] = fmt.Sprintf("%s (%s)", version.Version, version.GoVersion)
 
-	// report status to monitoring
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	//log.Infof("new status report at %v", time.Now())
-	if db.ClickHouseNativeWriter == nil {
-		log.Error(nil, "clickhouse native writer is nil", 0)
-		return
-	}
-	expires_at := time.Now().Add(1 * time.Minute)
-	if expires_in != nil {
-		expires_at = time.Now().Add(*expires_in)
-	}
-	err = db.ClickHouseNativeWriter.AsyncInsert(
-		ctx,
-		"INSERT INTO status_reports (emitter, event_id, inserted_at, expires_at, metadata) VALUES (?, ?, ?, ?, ?)",
-		false,
-		utils.GetUUID(),
-		id,
-		time.Now().UnixMilli(),
-		expires_at,
-		metadata,
-	)
-	if err != nil {
-		log.Error(err, "error inserting status report", 0)
+		// report status to monitoring
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		timeouts_at := time.Now().Add(1 * time.Minute)
+		if timeout != constants.Default {
+			timeouts_at = time.Now().Add(timeout)
+		}
+		expires_at := timeouts_at.Add(5 * time.Minute)
+		if check_interval != constants.Default {
+			expires_at = timeouts_at.Add(check_interval)
+		}
+		var err error
+		if db.ClickHouseNativeWriter != nil {
+			err = db.ClickHouseNativeWriter.AsyncInsert(
+				ctx,
+				"INSERT INTO status_reports2 (emitter, event_id, deployment_type, insert_id, expires_at, timeouts_at, metadata) VALUES (?, ?, ?, ?, ?, ?, ?)",
+				true,
+				utils.GetUUID(),
+				id,
+				utils.Config.DeploymentType,
+				flake,
+				expires_at,
+				timeouts_at,
+				metadata,
+			)
+		} else if utils.Config.DeploymentType != "development" {
+			log.Error(nil, "clickhouse native writer is nil", 0)
+		}
+		if err != nil && utils.Config.DeploymentType != "development" {
+			log.Error(err, "error inserting status report", 0)
+		}
 	}
 }

--- a/backend/pkg/monitoring/services/clickhouse_rollings.go
+++ b/backend/pkg/monitoring/services/clickhouse_rollings.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gobitfly/beaconchain/pkg/commons/db"
 	"github.com/gobitfly/beaconchain/pkg/commons/log"
+	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
 )
 
 // create db connection service that checks for the status of db connections
@@ -48,15 +49,16 @@ func (s *ServiceClickhouseRollings) runChecks() {
 		"total",
 	}
 	wg := sync.WaitGroup{}
-	expiry := 5 * time.Minute
 	for _, rolling := range rollings {
 		rolling := rolling
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			id := fmt.Sprintf("ch_rolling_%s", rolling)
+			r := NewStatusReport(id, constants.Default, 30*time.Second)
+			r(constants.Running, nil)
 			if db.ClickHouseReader == nil {
-				ReportStatus(s.ctx, id, fmt.Errorf("clickhouse reader is nil"), &expiry, nil)
+				r(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})
 				// ignore
 				return
 			}
@@ -81,17 +83,18 @@ func (s *ServiceClickhouseRollings) runChecks() {
 					WHERE
 						validator_index = 0`, rolling))
 			if err != nil {
-				ReportStatus(s.ctx, id, err, &expiry, nil)
+				r(constants.Failure, map[string]string{"error": err.Error()})
 				return
 			}
 			// check if delta is out of bounds
-			threshold := 2
+			threshold := 4
 			md := map[string]string{"delta": fmt.Sprintf("%d", delta), "threshold": fmt.Sprintf("%d", threshold)}
 			if delta > uint64(threshold) {
-				ReportStatus(s.ctx, id, fmt.Errorf("delta is over threshold %d", threshold), &expiry, md)
+				md["error"] = fmt.Sprintf("delta is over threshold %d", threshold)
+				r(constants.Failure, md)
 				return
 			}
-			ReportStatus(s.ctx, id, nil, &expiry, md)
+			r(constants.Success, md)
 		}()
 	}
 	wg.Wait()

--- a/backend/pkg/monitoring/services/flaky_test_service.go
+++ b/backend/pkg/monitoring/services/flaky_test_service.go
@@ -3,6 +3,8 @@ package services
 import (
 	"fmt"
 	"time"
+
+	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
 )
 
 type FlakyTestService struct {
@@ -26,7 +28,7 @@ func (s *FlakyTestService) internalProcess() {
 			return
 		case <-time.After(10 * time.Second):
 			err := fmt.Errorf("random error")
-			ReportStatus(s.ctx, "flaky_test", err, nil, nil)
+			NewStatusReport("flaky_test", constants.Default, constants.Default)(constants.Failure, map[string]string{"error": err.Error()})
 		}
 	}
 }


### PR DESCRIPTION
- adds deployment flags so staging/production can be cleanly seperated
- makes monitoring quite if in marked as development (the default if not manually set)
- adds run_id so healthz can catch incomplete excutions
- uses snowflakes during insertion to ensure order from single entity
- uses constants for statuses