### PR TITLE
fix(qrCode): use shorter url syntax for dashboards with many `valid… 

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -2,6 +2,7 @@
   "conventionalCommits.scopes": [
   "checkout",
   "ci",
+  "customFetch",
   "eslint",
   "git",
   "i18n",

--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -1,14 +1,15 @@
 {
   "conventionalCommits.scopes": [
-  "checkout",
-  "ci",
-  "customFetch",
-  "eslint",
-  "git",
-  "i18n",
-  "mainHeader",
-  "vscode"
-],
+    "checkout",
+    "ci",
+    "customFetch",
+    "eslint",
+    "git",
+    "i18n",
+    "mainHeader",
+    "vscode",
+    "qrCode"
+  ],
 "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "always"
 },

--- a/frontend/components/dashboard/DashboardShareCodeModal.vue
+++ b/frontend/components/dashboard/DashboardShareCodeModal.vue
@@ -34,7 +34,9 @@ const isShared = computed(() => isSharedKey(sharedKey.value))
 const path = computed(() => {
   const newRoute = router.resolve({
     name: 'dashboard-id',
-    params: { id: sharedKey.value },
+    query: {
+      validators: fromBase64Url(sharedKey.value ?? ''),
+    },
   })
   return url.origin + newRoute.fullPath
 })
@@ -78,6 +80,7 @@ const unpublish = async () => {
         class="qr-code"
         :value="path"
         :size="330"
+        level="L"
       />
       <label class="title">{{
         $t("dashboard.share_dialog.public_dashboard_url")

--- a/frontend/composables/useCustomFetch.ts
+++ b/frontend/composables/useCustomFetch.ts
@@ -45,7 +45,7 @@ export function useCustomFetch() {
 
     const url = useRequestURL()
     const runtimeConfig = useRuntimeConfig()
-    const showInDevelopment = Boolean(runtimeConfig.showInDevelopment)
+    const showInDevelopment = Boolean(runtimeConfig.public.showInDevelopment)
     const {
       private: pConfig,
       public: {


### PR DESCRIPTION
…ators`

`validator ids` get encoded in `base64`.
 Which triggerd the `data capacity limit` of the `qr library`.

 So we use the `unencoded url version` (?validators=<validatorID or validatorIndex>),
 as a workaround.

See: BEDS-350