### PR TITLE
fix(table): make sure empty message is only used as default

### DIFF
--- a/frontend/components/bc/table/BcTable.vue
+++ b/frontend/components/bc/table/BcTable.vue
@@ -164,8 +164,9 @@ const sort = computed(() => {
       <slot
         v-if="!loading"
         name="empty"
-      />
-      <DashboardTableEmpty />
+      >
+        <DashboardTableEmpty />
+      </slot>
     </template>
 
     <template #expansion="slotProps">


### PR DESCRIPTION
This PR:
- makes sure that the empty message is only shown in the table if no empty component is defined by the content component.