### PR TITLE
chore: add `self signed` ssl certificates

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -43,6 +43,14 @@ Set the following mapping in your `/etc/hosts` file:
 127.0.0.1 local.beaconcha.in
 ```
 
+Create server certificates for locally running on https, by runing these comands in the console
+
+```bash
+openssl genrsa 2048 > server.key
+sudo chmod 400 server.key
+sudo openssl req -new -x509 -nodes -sha256 -days 365 -key server.key -out server.crt
+```
+
 Navigate to folder `beaconchain/frontend` and run
 
 ```bash

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -47,7 +47,10 @@ export default defineNuxtConfig({
   ],
   devServer: {
     host: 'local.beaconcha.in',
-    https: true,
+    https: {
+      cert: 'server.crt',
+      key: 'server.key',
+    },
   },
   devtools: { enabled: true },
   eslint: { config: { stylistic: true } },


### PR DESCRIPTION
When we create our own `certs`, which have a `validity` of one year. We do not have to `click proceed` everytime we restart the `dev server`