### PR TITLE
Adjust style for displaying the accordion content.

### DIFF
--- a/frontend/assets/css/prime.scss
+++ b/frontend/assets/css/prime.scss
@@ -597,6 +597,7 @@ div.p-accordion {
       align-items: center;
       gap: var(--padding);
       border: none;
+      justify-content: flex-start;
       .p-accordionheader-toggle-icon {
         display: none;
       }


### PR DESCRIPTION
This PR is going to adjust styling to display the `accordion-header` correctly. 

 
![Screenshot from 2024-09-04 10-28-42](https://github.com/user-attachments/assets/325858cd-7288-4818-8c54-b57c7713312d)

BEDS-405