### PR TITLE
feat(dashboard): add basic integration tests

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -32,3 +32,5 @@ pnpm-lock.yaml
 
 server.crt
 server.key
+
+test-results/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,9 +29,11 @@
       },
       "devDependencies": {
         "@nuxt/eslint": "^0.3.13",
+        "@nuxt/test-utils": "^3.14.1",
         "@nuxtjs/color-mode": "^3.3.2",
         "@nuxtjs/i18n": "^8.0.0",
         "@nuxtjs/style-resources": "^1.2.2",
+        "@playwright/test": "^1.47.0",
         "@primevue/nuxt-module": "4.0.4",
         "@rollup/plugin-babel": "^6.0.4",
         "@types/lodash-es": "^4.17.12",
@@ -2323,6 +2325,150 @@
         "nuxt-telemetry": "bin/nuxt-telemetry.mjs"
       }
     },
+    "node_modules/@nuxt/test-utils": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/test-utils/-/test-utils-3.14.1.tgz",
+      "integrity": "sha512-D8F18hnOHQSarKnzsLORRXzFPlI9Y5fcQFRKwJgGhnejlIRX6sFvVnyl2SDgCvoV+F2x2czQsdGkwg51iWAshA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nuxt/kit": "^3.12.4",
+        "@nuxt/schema": "^3.12.4",
+        "c12": "^1.11.1",
+        "consola": "^3.2.3",
+        "defu": "^6.1.4",
+        "destr": "^2.0.3",
+        "estree-walker": "^3.0.3",
+        "execa": "^8.0.1",
+        "fake-indexeddb": "^6.0.0",
+        "get-port-please": "^3.1.2",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.11",
+        "node-fetch-native": "^1.6.4",
+        "ofetch": "^1.3.4",
+        "pathe": "^1.1.2",
+        "perfect-debounce": "^1.0.0",
+        "radix3": "^1.1.2",
+        "scule": "^1.3.0",
+        "std-env": "^3.7.0",
+        "ufo": "^1.5.4",
+        "unenv": "^1.10.0",
+        "unplugin": "^1.12.1",
+        "vitest-environment-nuxt": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18.20.4"
+      },
+      "peerDependencies": {
+        "@cucumber/cucumber": "^10.3.1",
+        "@jest/globals": "^29.5.0",
+        "@playwright/test": "^1.43.1",
+        "@testing-library/vue": "^7.0.0 || ^8.0.1",
+        "@vitest/ui": "^0.34.6 || ^1.0.0 || ^2.0.0",
+        "@vue/test-utils": "^2.4.2",
+        "h3": "*",
+        "happy-dom": "^9.10.9 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0",
+        "jsdom": "^22.0.0 || ^23.0.0 || ^24.0.0",
+        "nitropack": "*",
+        "playwright-core": "^1.43.1",
+        "vite": "*",
+        "vitest": "^0.34.6 || ^1.0.0 || ^2.0.0",
+        "vue": "^3.3.4",
+        "vue-router": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@cucumber/cucumber": {
+          "optional": true
+        },
+        "@jest/globals": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "@testing-library/vue": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "@vue/test-utils": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "playwright-core": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nuxt/test-utils/node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@nuxt/test-utils/node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@nuxt/test-utils/node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/@nuxt/test-utils/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@nuxt/vite-builder": {
       "version": "3.12.4",
       "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-3.12.4.tgz",
@@ -3243,6 +3389,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.0.tgz",
+      "integrity": "sha512-SgAdlSwYVpToI4e/IH19IHHWvoijAYH5hu2MWSXptRypLSnzj51PcGD+rsOXFayde4P9ZLi+loXVwArg6IUkCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.47.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -7959,6 +8121,16 @@
         "ufo": "^1.1.2"
       }
     },
+    "node_modules/fake-indexeddb": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.0.0.tgz",
+      "integrity": "sha512-YEboHE5VfopUclOck7LncgIqskAqnv4q0EWbYCaxKKjAvO93c+TJIaBuGy8CBFdbg9nKdpN3AuPRwVBJ4k7NrQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -11678,6 +11850,53 @@
         "pathe": "^1.1.2"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.0.tgz",
+      "integrity": "sha512-jOWiRq2pdNAX/mwLiwFYnPHpEZ4rM+fRSQpRHwEwZlP2PUANvL3+aJOF/bvISMhFD30rqMxUB4RJx9aQbfh4Ww==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.47.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.0.tgz",
+      "integrity": "sha512-1DyHT8OqkcfCkYUD9zzUTfg7EfTd+6a8MkD/NWOvjo0u/SCNd5YmY/lJwFvUZOxJbWNds+ei7ic2+R/cRz/PDg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -14780,6 +14999,16 @@
       },
       "peerDependencies": {
         "vite": "^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0"
+      }
+    },
+    "node_modules/vitest-environment-nuxt": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vitest-environment-nuxt/-/vitest-environment-nuxt-1.0.1.tgz",
+      "integrity": "sha512-eBCwtIQriXW5/M49FjqNKfnlJYlG2LWMSNFsRVKomc8CaMqmhQPBS5LZ9DlgYL9T8xIVsiA6RZn2lk7vxov3Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nuxt/test-utils": ">=3.13.1"
       }
     },
     "node_modules/vscode-jsonrpc": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,9 +22,11 @@
   },
   "devDependencies": {
     "@nuxt/eslint": "^0.3.13",
+    "@nuxt/test-utils": "^3.14.1",
     "@nuxtjs/color-mode": "^3.3.2",
     "@nuxtjs/i18n": "^8.0.0",
     "@nuxtjs/style-resources": "^1.2.2",
+    "@playwright/test": "^1.47.0",
     "@primevue/nuxt-module": "4.0.4",
     "@rollup/plugin-babel": "^6.0.4",
     "@types/lodash-es": "^4.17.12",
@@ -56,6 +58,7 @@
     "lint:fix": "npm run lint -- --fix",
     "postinstall": "nuxt prepare",
     "preview": "nuxt preview",
+    "test": "npx playwright test",
     "typecheck": "npx nuxi typecheck",
     "validate": "npm run lint:fix && npm run typecheck"
   },

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test'
+import type { ConfigOptions } from '@nuxt/test-utils/playwright'
+
+export default defineConfig<ConfigOptions>({
+  timeout: 30000,
+  use: {
+    nuxt: {
+      host: 'http://localhost:3000',
+    },
+  },
+})

--- a/frontend/tests/example.test.ts
+++ b/frontend/tests/example.test.ts
@@ -1,0 +1,45 @@
+import {
+  expect, test,
+} from '@nuxt/test-utils/playwright'
+
+test('test public dashboard', async ({
+  goto, page,
+}) => {
+  await goto('/', { waitUntil: 'hydration' })
+
+  // make sure the onboarding dialog is displyed
+  await expect(page.getByText('Add a new dashboard')).toBeVisible()
+
+  // navigate to the second page of the wizard
+  await page.getByText('Continue').click()
+  await expect(page.getByText('What network are your validators on?')).toBeVisible()
+
+  // navigate to the dashboard
+  await page.getByText('Continue').click()
+  await expect(page.getByText('Online Validators')).toBeVisible()
+
+  // now open the manage validator menu
+  await expect(page.getByText('Manage Validators')).toBeVisible()
+  await page.getByText('Manage Validators').click()
+
+  // and make sure the modal is displayed
+  await expect(page.getByText('Add or remove validators from your dashboard')).toBeVisible()
+
+  // search for validator number 5
+  await page.getByPlaceholder('Index, Public key, Deposit or Withdrawal address or ENS, Graffiti, ...').press('5')
+
+  // add the validator to the dashboard
+  await page.getByPlaceholder('Index, Public key, Deposit or Withdrawal address or ENS, Graffiti, ...').press('Enter')
+
+  // make sure the validator is added
+  await expect(page.getByText('0x9699')).toBeVisible()
+
+  // close the modal
+  await page.getByText('Done').click()
+
+  // make sure the default group is displayed
+  await expect(page.getByRole('cell', { name: 'Default' })).toBeVisible()
+
+  // save a screenshot at the end
+  await page.screenshot({ path: 'test-results/screenshot.png' })
+})


### PR DESCRIPTION
requires playwright to be installed and a local instance of the frontend to be running at port `3000`. tests can be run with `npm run test`.