### PR TITLE
chore(notifications): remove `dashboard header`

### DIFF
--- a/frontend/pages/notifications.vue
+++ b/frontend/pages/notifications.vue
@@ -9,9 +9,6 @@ import type { DynamicDialogCloseOptions } from 'primevue/dynamicdialogoptions'
 import { BcDialogConfirm } from '#components'
 import type { HashTabs } from '~/types/hashTabs'
 
-// TODO: get rid of this provider logic -> necessary for `<DashboardHeader`
-useDashboardKeyProvider('notifications')
-
 const { isLoggedIn } = useUserStore()
 const dialog = useDialog()
 const { t: $t } = useTranslation()
@@ -77,7 +74,6 @@ const openManageNotifications = () => {
   <div>
     <BcPageWrapper>
       <template #top>
-        <DashboardHeader :dashboard-title="$t('notifications.title')" />
         <div class="overview">
           <NotificationsOverview
             @open-dialog="openManageNotifications"
@@ -135,6 +131,9 @@ const openManageNotifications = () => {
 
 <style lang="scss" scoped>
 .overview {
+  --dashboardHeader-height: 54px;
+  --dashboardHeader-padding-bottom: 15px;
+  margin-top: calc(var(--dashboardHeader-height) + var(--dashboardHeader-padding-bottom));
   margin-bottom: var(--padding-large);
 }
 


### PR DESCRIPTION
The `DashboardHeader component` did not work on
`/notifications`, due to the way it was designed.

As a quickfix it has been removed.

See: BEDS-568