### PR TITLE
fix(customFetch): add `flag` to get `mocked data`

### DIFF
--- a/frontend/composables/useCustomFetch.ts
+++ b/frontend/composables/useCustomFetch.ts
@@ -85,7 +85,7 @@ export function useCustomFetch() {
     options.query = {
       ...options.query,
       ...query,
-      is_mocked: true,
+      is_mocked: useRuntimeConfig().public.isApiMocked ? true : undefined,
     }
     options.credentials = 'include'
     const method = options.method || map.method || 'GET'


### PR DESCRIPTION
Flag was not linked to `environment variable`

See: e7b05