### PR TITLE
BEDS-609/fix-text-attestation-missed

### DIFF
--- a/frontend/components/notifications/management/NotificationsManagementSubscriptionDialog.vue
+++ b/frontend/components/notifications/management/NotificationsManagementSubscriptionDialog.vue
@@ -94,7 +94,7 @@ watch(hasAllEvents, () => {
         <BcSettingsRow
           v-model:checkbox="checkboxes.is_attestations_missed_subscribed"
           :label="$t('notifications.subscriptions.validators.attestation_missed.label')"
-          :info="$t('notifications.subscriptions.validators.attestation_missed.info', { count: formatSecondsTo(secondsPerEpoch, { minimumFractionDigits: 1 }).minutes })"
+          :info="$t('notifications.subscriptions.validators.attestation_missed.info', { count: Number(formatSecondsTo(secondsPerEpoch, { minimumFractionDigits: 1 }).minutes) })"
         />
         <BcSettingsRow
           v-model:checkbox="checkboxes.is_block_proposal_subscribed"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,7 +53,7 @@
   "scripts": {
     "build": "nuxt build",
     "dev": "NODE_TLS_REJECT_UNAUTHORIZED=0 nuxt dev",
-    "dev:mock:api": "NUXT_IS_API_MOCKED=true npm run dev",
+    "dev:mock:api": "NUXT_PUBLIC_IS_API_MOCKED=true npm run dev",
     "dev:mock:production": "NUXT_DEPLOYMENT_TYPE=production npm run dev",
     "dev:mock:staging": "NUXT_DEPLOYMENT_TYPE=staging npm run dev",
     "generate": "nuxt generate",


### PR DESCRIPTION
Pluralization rule needs type `number` instead of `string`

See: BEDS-609