### PR TITLE
fix(NotificationsManagementSubscriptionDialog): only show `premium ge…

### DIFF
--- a/frontend/components/notifications/management/NotificationsManagementSubscriptionDialog.vue
+++ b/frontend/components/notifications/management/NotificationsManagementSubscriptionDialog.vue
@@ -127,7 +127,7 @@ watch(hasAllEvents, () => {
           has-unit
           :info="$t('notifications.subscriptions.validators.group_efficiency.info', { percentage: thresholds.group_efficiency_below_threshold })"
           :label="$t('notifications.subscriptions.validators.group_efficiency.label')"
-          :has-premium-gem="hasPremiumPerkGroupEfficiency"
+          :has-premium-gem="!hasPremiumPerkGroupEfficiency"
         />
         <BcSettingsRow
           v-model:checkbox="checkboxes.is_min_collateral_subscribed"


### PR DESCRIPTION
…m` for users that do not have `group efficiency perk`