### PR TITLE
fix: cap do not disturb timestamp if greater than maxInt32

### DIFF
--- a/backend/pkg/api/handlers/public.go
+++ b/backend/pkg/api/handlers/public.go
@@ -2215,6 +2215,7 @@ func (h *HandlerService) PublicPutUserNotificationSettingsGeneral(w http.Respons
 		handleErr(w, r, v)
 		return
 	}
+	req.DoNotDisturbTimestamp = min(req.DoNotDisturbTimestamp, math.MaxInt32)
 
 	// check premium perks
 	userInfo, err := h.getDataAccessor(r).GetUserInfo(r.Context(), userId)


### PR DESCRIPTION
See: BEDS-856
