### PR TITLE
empty state for `notification tables` when there are `settings`

### DIFF
--- a/frontend/components/notifications/NotificationsTableEmpty.vue
+++ b/frontend/components/notifications/NotificationsTableEmpty.vue
@@ -9,6 +9,9 @@ const { t: $t } = useTranslation()
 
 const emit = defineEmits<{ (e: 'openDialog'): void }>()
 
+const { isLoggedIn } = useUserStore()
+const { overview } = useNotificationsDashboardOverviewStore()
+
 const handleClick = () => {
   if (!isLoggedIn.value) {
     return navigateTo('/login')
@@ -18,7 +21,6 @@ const handleClick = () => {
   }
   emit('openDialog')
 }
-const { isLoggedIn } = useUserStore()
 const {
   dashboards,
   refreshDashboards,
@@ -33,6 +35,12 @@ const hasDashboards = computed(() => {
     || dashboards.value?.validator_dashboards?.length
   )
 })
+const hasSubscriptions = computed(() => {
+  return (
+    overview.value?.vdb_subscriptions_count
+    || overview.value?.adb_subscriptions_count
+  )
+})
 
 const text = computed(() => {
   if (!isLoggedIn.value) {
@@ -41,7 +49,10 @@ const text = computed(() => {
   if (!hasDashboards.value) {
     return $t('notifications.dashboards.empty.no_dashboards')
   }
-  return $t('notifications.dashboards.empty.with_dashboards')
+  if (!hasSubscriptions.value) {
+    return $t('notifications.dashboards.empty.no_subscriptions')
+  }
+  return $t('notifications.dashboards.empty.no_notifications')
 })
 </script>
 
@@ -50,7 +61,8 @@ const text = computed(() => {
     class="empty delayed-fadein-animation"
     @click="handleClick"
   >
-    <span class="big_text">{{ text }}</span>
+    <span class="big_text">
+      {{ text }}</span>
     <FontAwesomeIcon
       v-if="isLoggedIn"
       :icon="faCirclePlus"

--- a/frontend/components/notifications/NotificationsTableEmpty.vue
+++ b/frontend/components/notifications/NotificationsTableEmpty.vue
@@ -62,7 +62,8 @@ const text = computed(() => {
     @click="handleClick"
   >
     <span class="big_text">
-      {{ text }}</span>
+      {{ text }}
+    </span>
     <FontAwesomeIcon
       v-if="isLoggedIn"
       :icon="faCirclePlus"

--- a/frontend/components/notifications/management/NotificationsManagementDashboards.vue
+++ b/frontend/components/notifications/management/NotificationsManagementDashboards.vue
@@ -28,6 +28,7 @@ interface WrappedRow extends NotificationSettingsDashboardsTableRow {
 const toast = useBcToast()
 const { t: $t } = useTranslation()
 const dialog = useDialog()
+const { refreshOverview } = useNotificationsDashboardOverviewStore()
 const {
   cursor,
   dashboards,
@@ -216,7 +217,7 @@ function getTypeIcon(type: DashboardType) {
   return faUser
 }
 const handleDelete = (payload: Parameters<typeof deleteDashboardNotifications>[0]) => {
-  deleteDashboardNotifications(payload)
+  deleteDashboardNotifications(payload).then(() => refreshOverview())
 }
 </script>
 

--- a/frontend/composables/notifications/useNotificationsManagementDashboards.ts
+++ b/frontend/composables/notifications/useNotificationsManagementDashboards.ts
@@ -11,7 +11,7 @@ import type {
 
 export function useNotificationsManagementDashboards() {
   const { fetch } = useCustomFetch()
-
+  const { refreshOverview } = useNotificationsDashboardOverviewStore()
   const data = ref<InternalGetUserNotificationSettingsDashboardsResponse>()
   const {
     cursor,
@@ -191,7 +191,7 @@ export function useNotificationsManagementDashboards() {
         group_id,
         settings,
       })
-    })
+    }).then(() => refreshOverview())
   }
 
   return {

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -644,7 +644,8 @@
       "empty": {
         "login": "Login to set notifications",
         "no_dashboards": "Create a dashboard to set notifications",
-        "with_dashboards": "Click here to set notifications"
+        "no_notifications": "No notifications received",
+        "no_subscriptions": "Click here to set notifications"
       },
       "entity": {
         "accounts": "account | accounts",

--- a/frontend/stores/notifications/useNotificationsManagementStore.ts
+++ b/frontend/stores/notifications/useNotificationsManagementStore.ts
@@ -10,6 +10,7 @@ import { API_PATH } from '~/types/customFetch'
 
 export const useNotificationsManagementStore = defineStore('notifications-management-store', () => {
   const { fetch } = useCustomFetch()
+  const { refreshOverview } = useNotificationsDashboardOverviewStore()
   const settings = ref<NotificationSettings>(
     {
       clients: [],
@@ -55,7 +56,7 @@ export const useNotificationsManagementStore = defineStore('notifications-manage
       // using optimistic ui here to avoid calling the api after delete
       settings.value.paired_devices
       = [ ...settings.value.paired_devices.filter(device => device.id !== id) ]
-    })
+    }).then(() => refreshOverview())
   }
   const setNotificationForPairedDevice = async ({
     id,
@@ -75,7 +76,7 @@ export const useNotificationsManagementStore = defineStore('notifications-manage
       {
         paired_device_id: id,
       },
-    )
+    ).then(() => refreshOverview())
   }
   const setNotificationForNetwork = async ({
     chain_id,
@@ -95,7 +96,9 @@ export const useNotificationsManagementStore = defineStore('notifications-manage
         network: chain_id,
       },
     )
+      .then(() => refreshOverview())
   }
+
   const setNotificationForClient = async ({
     client_id,
     is_subscribed,
@@ -113,7 +116,7 @@ export const useNotificationsManagementStore = defineStore('notifications-manage
       {
         client_id,
       },
-    )
+    ).then(() => refreshOverview())
   }
 
   return {


### PR DESCRIPTION
Remove `Click here to set notifications` text for `empty tables`, when there are already `notification settings` for the specifc table