### PR TITLE
fix(NotificationsManagementNetwork): `currentNetworkId` by using `environment variable`

### DIFF
--- a/frontend/components/notifications/management/NotificationsManagementNetwork.vue
+++ b/frontend/components/notifications/management/NotificationsManagementNetwork.vue
@@ -3,8 +3,13 @@ const { t: $t } = useTranslation()
 
 const notificationsManagementStore = useNotificationsManagementStore()
 
+const { chainIdByDefault } = useRuntimeConfig().public
+
 const networks = computed(() => notificationsManagementStore.settings.networks ?? [])
-const currentNetworkId = computed(() => notificationsManagementStore.settings.networks[0]?.chain_id ?? 0)
+const currentNetworkId = computed(
+  () => notificationsManagementStore.settings.networks
+    .find(network => network.chain_id === Number(chainIdByDefault)) ?? 1,
+)
 
 const currentNetwork = computed(
   () => (networks.value.find(network => network.chain_id === currentNetworkId.value)),


### PR DESCRIPTION
As the `multichain feature` is not implemented yet, we are using `environment variables` to identify the current network

See: BEDS-898