### PR TITLE
Adds "RPL" to notifications

### DIFF
--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -768,7 +768,7 @@
       "event_type": {
         "gas_above": "Gas price maximum reached",
         "gas_below": "Gas price minimum reached",
-        "new_reward_round": "New reward round",
+        "new_reward_round": "New RPL reward round",
         "participation_rate": "Participation rate minimum reached"
       },
       "footer": {
@@ -778,7 +778,7 @@
         "alert_if_gas_above": "Alert if gas is above",
         "alert_if_gas_below": "Alert if gas is below",
         "alert_if_participation_rate_below": "Alert if participation rate is below",
-        "new_reward_round": "New reward round"
+        "new_reward_round": "New RPL reward round"
       },
       "title": "Networks"
     },
@@ -854,10 +854,10 @@
           "label": "Group efficiency below"
         },
         "max_collateral_reached": {
-          "label": "Max collateral reached"
+          "label": "Max RPL collateral reached"
         },
         "min_collateral_reached": {
-          "label": "Min collateral reached"
+          "label": "Min RPL collateral reached"
         },
         "sync_committee": {
           "label": "Sync committee"


### PR DESCRIPTION
Adds “RPL” to Rocket Pool-related notifications to avoid confusion for non-RPL users.