### PR TITLE
refactor(DashboardTableSummaryDetails): remove `missed rewards`

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -9,6 +9,7 @@
     "BcToggle",
     "DashboardChartSummaryChartFilter",
     "DashboardGroupManagementModal",
+    "DashboardTableSummaryDetails",
     "DashboardTableValidators",
     "DashboardValidatorManagmentModal",
     "NotificationMachinesTable",

--- a/frontend/components/dashboard/table/DashboardTableSummaryDetails.vue
+++ b/frontend/components/dashboard/table/DashboardTableSummaryDetails.vue
@@ -68,10 +68,9 @@ const data = computed<SummaryRow[][]>(() => {
     props.forEach(p => addToList(index, p))
   }
 
-  const rewardCols: CombinedPropOrUndefined[] = [
-    (!props.tableVisibility.reward ? 'reward' : undefined),
-    'missed_rewards',
-  ]
+  const rewardCols: CombinedPropOrUndefined[]
+  = [ (!props.tableVisibility.reward ? 'reward' : undefined) ]
+
   let addCols: CombinedPropOrUndefined[] = props.tableVisibility
     .attestations
     ? []


### PR DESCRIPTION
This is a `quick-fix`, temporarily remove `missed rewards` per request.

See: BEDS-923