### PR TITLE
refactor(DashboardTableBlocks): remove sortable attribute from rewards

### DIFF
--- a/frontend/components/dashboard/table/DashboardTableBlocks.vue
+++ b/frontend/components/dashboard/table/DashboardTableBlocks.vue
@@ -280,7 +280,6 @@ const isRowExpandable = (row: VDBBlocksTableRow) => {
             <Column
               v-if="colsVisible.rewards"
               field="reward"
-              :sortable="true"
               body-class="reward"
               header-class="reward"
               :header="$t('dashboard.validator.col.proposer_rewards')"


### PR DESCRIPTION
Removes sort from proposer rewards in validator dashboard blocks table.

Before PR:
![image](https://github.com/user-attachments/assets/9466e25e-daa7-4357-9bf2-1bbdbdb4486c)

After PR:
![image](https://github.com/user-attachments/assets/d3a04917-3727-44da-b743-f6d54aa34732)
