### PR TITLE
BEDS-333: change Dolhpin Weekly Aggregated Chart Summary History

### DIFF
--- a/backend/pkg/commons/db/user.go
+++ b/backend/pkg/commons/db/user.go
@@ -380,7 +380,7 @@ func GetProductSummary(ctx context.Context) (*t.ProductSummary, error) { // TODO
 						Epoch:  5 * day,
 						Hourly: month,
 						Daily:  2 * month,
-						Weekly: 8 * week,
+						Weekly: 6 * month,
 					},
 					EmailNotificationsPerDay:                       20,
 					ConfigureNotificationsViaApi:                   false,


### PR DESCRIPTION
Adapt the API response to return 6 months instead of 56 days for the Dolphin plan