### PR TITLE
feat(DashboardTableEfficiency): update `UI` for relative values in th…

### DIFF
--- a/frontend/components/base/BaseFormatPercent.vue
+++ b/frontend/components/base/BaseFormatPercent.vue
@@ -19,18 +19,24 @@ const ratio = computed(() => {
   assertIsNotZero(base)
   return (Number(value) / Number(base))
 })
+
+const result = computed(() => {
+  return formatPercent(ratio.value, {
+    maximumFractionDigits,
+    minimumFractionDigits,
+  })
+})
 </script>
 
 <template>
-  <BcColor :color>
-    <slot :value>
-      {{ formatPercent(ratio, {
-        maximumFractionDigits,
-        minimumFractionDigits,
-      }) }}
+  <span>
+    <slot
+      :result
+      :ratio
+    >
+      <BcColor :color>
+        {{ result }}
+      </BcColor>
     </slot>
-  </BcColor>
+  </span>
 </template>
-
-<style scoped lang="scss">
-</style>

--- a/frontend/components/dashboard/table/DashboardTableEfficiency.vue
+++ b/frontend/components/dashboard/table/DashboardTableEfficiency.vue
@@ -49,13 +49,20 @@ const data = computed(() => {
       />
     </span>
 
-    <BcFormatPercent
-      v-else
-      class="percent"
+    <BaseFormatPercent
+      v-else-if="props.success"
+      v-slot="{ result, ratio }"
       :base="data.sum"
       :value="props.success"
-      :color-break-point="80"
-      :full-on-empty-base="true"
-    />
+    >
+      <BcColor
+        :color="ratio >= 0.8 ? 'green' : 'red'"
+      >
+        {{ result }}
+      </BcColor>
+    </BaseFormatPercent>
+    <span v-else>
+      -
+    </span>
   </BcTooltip>
 </template>


### PR DESCRIPTION
…e `validator summary`

Display `-` when relative values are equal to `0`.

See: BEDS-844