### PR TITLE
refactor(dashboard): use better terminology for dashboard types

### DIFF
--- a/frontend/components/dashboard/DashboardControls.vue
+++ b/frontend/components/dashboard/DashboardControls.vue
@@ -37,15 +37,15 @@ const { isLoggedIn } = useUserStore()
 const {
   dashboardKey,
   dashboardType,
-  isPrivate,
-  isPublic,
-  isShared,
+  isGuestDashboard,
+  isPrivateDashboard,
+  isSharedDashboard,
   publicEntities,
   setDashboardKey,
 } = useDashboardKey()
 const { refreshOverview } = useValidatorDashboardOverviewStore()
 const {
-  dashboards, getDashboardLabel, refreshDashboards, updateHash,
+  dashboards, getDashboardLabel, refreshDashboards, updateGuestDashboardKey,
 }
   = useUserDashboardStore()
 
@@ -59,7 +59,7 @@ const manageGroupsModalVisisble = ref(false)
 const manageValidatorsModalVisisble = ref(false)
 
 const manageButtons = computed<MenuBarEntry[] | undefined>(() => {
-  if (isShared.value) {
+  if (isSharedDashboard.value) {
     return undefined
   }
 
@@ -108,7 +108,7 @@ const shareDashboard = computed(() => {
 })
 
 const shareButtonOptions = computed(() => {
-  const edit = isPrivate.value && !shareDashboard.value?.public_ids?.length
+  const edit = isPrivateDashboard.value && !shareDashboard.value?.public_ids?.length
 
   const label = isMobile.value
     ? ''
@@ -116,7 +116,7 @@ const shareButtonOptions = computed(() => {
         ? $t('dashboard.shared')
         : $t('dashboard.share')
   const icon = !edit ? faUsers : faShare
-  const disabled = isShared.value || !dashboardKey.value
+  const disabled = isSharedDashboard.value || !dashboardKey.value
   return {
     disabled,
     edit,
@@ -130,7 +130,7 @@ const editButtons = computed<MenuBarEntry[]>(() => {
 
   buttons.push({ component: RocketpoolToggle })
 
-  if (isPrivate.value) {
+  if (isPrivateDashboard.value) {
     buttons.push({
       command: editDashboard,
       faIcon: faEdit,
@@ -148,7 +148,7 @@ const editButtons = computed<MenuBarEntry[]>(() => {
     })
   }
 
-  if (!isShared.value && dashboardKey.value) {
+  if (!isSharedDashboard.value && dashboardKey.value) {
     buttons.push({
       command: onDelete,
       faIcon: faTrash,
@@ -172,7 +172,7 @@ const shareView = () => {
     },
     onClose: (options?: DynamicDialogCloseOptions) => {
       if (options?.data === 'DELETE') {
-        if (isShared.value && dashboardId) {
+        if (isSharedDashboard.value && dashboardId) {
           setDashboardKey(`${dashboardId}`)
         }
       }
@@ -202,12 +202,12 @@ const share = () => {
 }
 
 const deleteButtonOptions = computed(() => {
-  const visible = !isShared.value
+  const visible = !isSharedDashboard.value
 
-  const disabled = isPublic.value && publicEntities.value?.length === 0
+  const disabled = isGuestDashboard.value && publicEntities.value?.length === 0
 
-  // private dashboards always get deleted, public dashboards only get cleared
-  const deleteDashboard = isPrivate.value
+  // private dashboards always get deleted, guest dashboards only get cleared
+  const deleteDashboard = isPrivateDashboard.value
 
   // we can only forward if there is something to forward to after a potential deletion
   const privateDashboardsCount = isLoggedIn.value
@@ -281,8 +281,8 @@ const deleteAction = async (
     await refreshDashboards()
   }
   else if (!isLoggedIn.value) {
-    // simply clear the public dashboard by emptying the hash
-    updateHash(dashboardType.value, '')
+    // simply clear the guest dashboard by emptying the key
+    updateGuestDashboardKey(dashboardType.value, '')
     setDashboardKey('')
     return
   }

--- a/frontend/components/dashboard/DashboardHeader.vue
+++ b/frontend/components/dashboard/DashboardHeader.vue
@@ -4,7 +4,7 @@ import type {
 } from '~/types/menuBar'
 import { useUserDashboardStore } from '~/stores/dashboard/useUserDashboardStore'
 import {
-  COOKIE_DASHBOARD_ID, type CookieDashboard, type Dashboard, type DashboardKey, type DashboardType,
+  type Dashboard, type DashboardKey, type DashboardType, GUEST_DASHBOARD_ID, type GuestDashboard,
 } from '~/types/dashboard'
 
 const { t: $t } = useTranslation()
@@ -16,7 +16,7 @@ const { has } = useFeatureFlag()
 const { isLoggedIn } = useUserStore()
 const { dashboards } = useUserDashboardStore()
 const {
-  dashboardKey, dashboardType, isShared, setDashboardKey,
+  dashboardKey, dashboardType, isSharedDashboard, setDashboardKey,
 } = useDashboardKey()
 
 const emit = defineEmits<{ (e: 'showCreation'): void }>()
@@ -26,14 +26,14 @@ const getDashboardName = (db: Dashboard): string => {
     return db.name || `${$t('dashboard.title')} ${db.id}` // Just to be sure, we should not have dashboards without a name in prod
   }
   else {
-    return db.id === COOKIE_DASHBOARD_ID.ACCOUNT
+    return db.id === GUEST_DASHBOARD_ID.ACCOUNT
       ? $t('dashboard.account_dashboard')
       : $t('dashboard.validator_dashboard')
   }
 }
 
 const items = computed<MenuBarEntry[]>(() => {
-  if (dashboards.value === undefined || isShared.value) {
+  if (dashboards.value === undefined || isSharedDashboard.value) {
     return []
   }
 
@@ -87,13 +87,13 @@ const items = computed<MenuBarEntry[]>(() => {
     }
   }
   addToSortedItems($t('dashboard.header.validator'), dashboards.value?.validator_dashboards?.map((db) => {
-    const cd = db as CookieDashboard
-    return createMenuBarButton('validator', getDashboardName(cd), `${cd.hash !== undefined ? cd.hash : cd.id}`)
+    const gd = db as GuestDashboard
+    return createMenuBarButton('validator', getDashboardName(gd), `${gd.key !== undefined ? gd.key : gd.id}`)
   }))
   if (has('feature-account_dashboards')) {
     addToSortedItems($t('dashboard.header.account'), dashboards.value?.validator_dashboards?.slice(0, 1).map((db) => {
-      const cd = db as CookieDashboard
-      return createMenuBarButton('account', getDashboardName(cd), `${cd.hash ?? cd.id}`)
+      const gd = db as GuestDashboard
+      return createMenuBarButton('account', getDashboardName(gd), `${gd.key ?? gd.id}`)
     }))
   }
   const disabledTooltip = !has('feature-notifications') ? $t('common.coming_soon') : undefined
@@ -115,7 +115,7 @@ const items = computed<MenuBarEntry[]>(() => {
       :buttons="items"
     />
     <BcButton
-      v-if="!isShared"
+      v-if="!isSharedDashboard"
       variant="secondary"
       class="p-button-icon-only"
       @click="emit('showCreation')"

--- a/frontend/components/dashboard/DashboardShareCodeModal.vue
+++ b/frontend/components/dashboard/DashboardShareCodeModal.vue
@@ -2,10 +2,10 @@
 import { warn } from 'vue'
 import type { ValidatorDashboard } from '~/types/api/dashboard'
 import { API_PATH } from '~/types/customFetch'
-import { isSharedKey } from '~/utils/dashboard/key'
+import { isSharedDashboardKey } from '~/utils/dashboard/key'
 
 interface Props {
-  // Currently only validator dashboards are supported. For public dashboards this will be undefined
+  // Currently only validator dashboards are supported. For guest dashboards this will be undefined
   dashboard?: ValidatorDashboard,
   dashboardKey: string,
 }
@@ -29,7 +29,7 @@ const sharedKey = computed(() =>
     : props.value?.dashboardKey,
 )
 
-const isShared = computed(() => isSharedKey(sharedKey.value))
+const isShared = computed(() => isSharedDashboardKey(sharedKey.value))
 
 const path = computed(() => {
   const newRoute = router.resolve({
@@ -41,7 +41,7 @@ const path = computed(() => {
 
 const edit = () => {
   if (isReadonly.value) {
-    warn('cannot edit public dashboard share')
+    warn('cannot edit guest dashboard share')
     return
   }
   dialogRef?.value?.close('EDIT')
@@ -49,7 +49,7 @@ const edit = () => {
 
 const unpublish = async () => {
   if (isReadonly.value) {
-    warn('cannot delete public dashboard share')
+    warn('cannot delete guest dashboard share')
     return
   }
   if (isUpdating.value) {

--- a/frontend/components/dashboard/DashboardValidatorManagementModal.vue
+++ b/frontend/components/dashboard/DashboardValidatorManagementModal.vue
@@ -44,10 +44,9 @@ const selectedGroup = ref<number>(-1)
 const {
   addEntities,
   dashboardKey,
-  isPublic: isPublicDashboard,
+  isGuestDashboard,
   removeEntities,
-}
-  = useDashboardKey()
+} = useDashboardKey()
 const {
   user,
 } = useUserStore()
@@ -136,7 +135,7 @@ const removeValidators = async (validators?: NumberOrString[]) => {
     warn('no validators selected to change group')
     return
   }
-  if (isPublicDashboard.value) {
+  if (isGuestDashboard.value) {
     removeEntities(validators.map(v => v.toString()))
     return
   }
@@ -275,7 +274,7 @@ const removeRow = (row: VDBManageValidatorsTableRow) => {
 const totalValidators = computed(() => addUpValues(overview.value?.validators))
 
 const maxValidatorsPerDashboard = computed(() =>
-  isPublicDashboard.value || !user.value?.premium_perks?.validators_per_dashboard
+  isGuestDashboard.value || !user.value?.premium_perks?.validators_per_dashboard
     ? 20
     : user.value.premium_perks.validators_per_dashboard,
 )
@@ -312,7 +311,7 @@ const handleSubmit = (item: InternalPostSearchResponse['data'][number] | undefin
     handleInvalidSubmit()
     return
   }
-  if (isPublicDashboard.value) {
+  if (isGuestDashboard.value) {
     if (item.type === 'validator') {
       addEntities([ `${item.value.index}` ])
       resetInput()
@@ -360,7 +359,7 @@ const inputValidator = ref('')
     <BcTableControl
       :search-placeholder="
         $t(
-          isPublicDashboard
+          isGuestDashboard
             ? 'dashboard.validator.summary.search_placeholder_public'
             : 'dashboard.validator.summary.search_placeholder',
         )
@@ -390,7 +389,7 @@ const inputValidator = ref('')
             :has-premium-perk-bulk-adding
             :total-validators
             :max-validators-per-dashboard
-            :is-public-dashboard
+            :is-guest-dashboard
             @submit="handleSubmit"
           />
         </div>

--- a/frontend/components/dashboard/DashboardValidatorManagementModalSearch.vue
+++ b/frontend/components/dashboard/DashboardValidatorManagementModalSearch.vue
@@ -6,7 +6,7 @@ import { API_PATH } from '~/types/customFetch'
 
 const props = defineProps<{
   hasPremiumPerkBulkAdding: boolean,
-  isPublicDashboard: boolean,
+  isGuestDashboard: boolean,
   maxValidatorsPerDashboard: number,
   totalValidators: number,
 }>()
@@ -67,7 +67,7 @@ const isDisabled = (type: InternalPostSearchResponse['data'][number]['type'], va
     return true
   }
   if (
-    props.isPublicDashboard
+    props.isGuestDashboard
     && ((type !== 'validator' && type !== 'validator_list'))
   ) {
     return true

--- a/frontend/components/dashboard/GroupManagementModal.vue
+++ b/frontend/components/dashboard/GroupManagementModal.vue
@@ -22,7 +22,8 @@ const { fetch } = useCustomFetch()
 const dialog = useDialog()
 
 const {
-  dashboardKey, isPublic,
+  dashboardKey,
+  isGuestDashboard,
 } = useDashboardKey()
 
 const {
@@ -186,7 +187,7 @@ const dashboardName = computed(() => {
 })
 
 const maxGroupsPerDashboard = computed(() =>
-  isPublic.value || !user.value?.premium_perks?.validator_groups_per_dashboard
+  isGuestDashboard.value || !user.value?.premium_perks?.validator_groups_per_dashboard
     ? 1
     : user.value.premium_perks.validator_groups_per_dashboard,
 )
@@ -222,7 +223,7 @@ const isMobile = computed(() => {
       :search-placeholder="
         $t('dashboard.validator.group_management.search_placeholder')
       "
-      :disabled-filter="isPublic"
+      :disabled-filter="isGuestDashboard"
       @set-search="setSearch"
     >
       <template #header-left>
@@ -288,7 +289,7 @@ const isMobile = computed(() => {
                       : ''
                   "
                   :can-be-empty="slotProps.data.id === 0"
-                  :disabled="isPublic"
+                  :disabled="isGuestDashboard"
                   :pattern="REGEXP_VALID_NAME"
                   :trim-input="true"
                   :maxlength="20"

--- a/frontend/components/dashboard/SharedDashboardModal.vue
+++ b/frontend/components/dashboard/SharedDashboardModal.vue
@@ -7,7 +7,7 @@ const cookiePreference = useCookie<CookiesPreference>(
   COOKIE_KEY.COOKIES_PREFERENCE,
   { default: () => undefined },
 )
-const { isShared } = useDashboardKey()
+const { isSharedDashboard } = useDashboardKey()
 const { dashboards } = useUserDashboardStore()
 const { t: $t } = useTranslation()
 const route = useRoute()
@@ -15,7 +15,7 @@ const route = useRoute()
 const dismissed = ref(false)
 const visible = computed(
   () =>
-    isShared.value && !dismissed.value && cookiePreference.value !== undefined,
+    isSharedDashboard.value && !dismissed.value && cookiePreference.value !== undefined,
 )
 
 const text = computed(() => {

--- a/frontend/components/dashboard/chart/RewardsChart.vue
+++ b/frontend/components/dashboard/chart/RewardsChart.vue
@@ -59,7 +59,7 @@ use([
 const { fetch } = useCustomFetch()
 
 const {
-  dashboardKey, isPrivate: groupsEnabled,
+  dashboardKey, isPrivateDashboard: groupsEnabled,
 } = useDashboardKey()
 
 const data = ref<ChartData<number, string> | undefined>()

--- a/frontend/components/dashboard/creation/DashboardCreationController.vue
+++ b/frontend/components/dashboard/creation/DashboardCreationController.vue
@@ -123,7 +123,7 @@ async function createDashboard() {
     const response = await createAccountDashboard(name.value, publicKey)
 
     await navigateTo(
-      `/account-dashboard/${response?.hash ?? response?.id ?? 1}`,
+      `/account-dashboard/${response?.key ?? response?.id ?? 1}`,
     )
   }
   else if (type.value === 'validator') {
@@ -154,7 +154,7 @@ async function createDashboard() {
         { dashboardKey: response.id },
       )
     }
-    await navigateTo(`/dashboard/${response?.hash ?? response?.id ?? 1}`)
+    await navigateTo(`/dashboard/${response?.key ?? response?.id ?? 1}`)
   }
 }
 </script>

--- a/frontend/components/dashboard/table/DashboardTableBlocks.vue
+++ b/frontend/components/dashboard/table/DashboardTableBlocks.vue
@@ -9,7 +9,8 @@ import { BcFormatHash } from '#components'
 import { getGroupLabel } from '~/utils/dashboard/group'
 
 const {
-  dashboardKey, isPublic,
+  dashboardKey,
+  isGuestDashboard,
 } = useDashboardKey()
 
 const cursor = ref<Cursor>()
@@ -118,7 +119,7 @@ const isRowExpandable = (row: VDBBlocksTableRow) => {
       :title="$t('dashboard.validator.blocks.title')"
       :search-placeholder="
         $t(
-          isPublic
+          isGuestDashboard
             ? 'dashboard.validator.blocks.search_placeholder_public'
             : 'dashboard.validator.blocks.search_placeholder',
         )

--- a/frontend/components/dashboard/table/DashboardTableRewards.vue
+++ b/frontend/components/dashboard/table/DashboardTableRewards.vue
@@ -15,7 +15,8 @@ import { formatRewardValueOption } from '~/utils/dashboard/table'
 import { useValidatorDashboardOverviewStore } from '~/stores/dashboard/useValidatorDashboardOverviewStore'
 
 const {
-  dashboardKey, isPublic,
+  dashboardKey,
+  isGuestDashboard,
 } = useDashboardKey()
 
 const cursor = ref<Cursor>()
@@ -145,7 +146,7 @@ const findNextEpochDuties = (epoch: number) => {
       :title="$t('dashboard.validator.rewards.title')"
       :search-placeholder="
         $t(
-          isPublic
+          isGuestDashboard
             ? 'dashboard.validator.rewards.search_placeholder_public'
             : 'dashboard.validator.rewards.search_placeholder',
         )

--- a/frontend/components/dashboard/table/DashboardTableSummary.vue
+++ b/frontend/components/dashboard/table/DashboardTableSummary.vue
@@ -17,7 +17,8 @@ import {
 } from '~/types/dashboard/summary'
 
 const {
-  dashboardKey, isPublic,
+  dashboardKey,
+  isGuestDashboard,
 } = useDashboardKey()
 
 const cursor = ref<Cursor>()
@@ -146,7 +147,7 @@ const getRowClass = (row: VDBSummaryTableRow) => {
 
 const searchPlaceholder = computed(() =>
   $t(
-    isPublic.value && (groups.value?.length ?? 0) <= 1
+    isGuestDashboard.value && (groups.value?.length ?? 0) <= 1
       ? 'dashboard.validator.summary.search_placeholder_public'
       : 'dashboard.validator.summary.search_placeholder',
   ),

--- a/frontend/composables/useDashboardKey.ts
+++ b/frontend/composables/useDashboardKey.ts
@@ -12,10 +12,10 @@ export function useDashboardKey() {
   }
 
   const dashboardKey = computed(() => data.dashboardKey.value ?? '')
-  const isPublic = computed(() => !!data.isPublic.value)
-  const isShared = computed(() => !!data.isShared.value)
+  const isGuestDashboard = computed(() => !!data.isGuestDashboard.value)
+  const isSharedDashboard = computed(() => !!data.isSharedDashboard.value)
   const publicEntities = computed(() => data.publicEntities.value ?? [])
-  const isPrivate = computed(() => isLoggedIn.value && !isPublic.value)
+  const isPrivateDashboard = computed(() => isLoggedIn.value && !isGuestDashboard.value)
   const setDashboardKey = (key: string) => data.setDashboardKey(key)
   const dashboardType = computed(() => data.dashboardType.value)
 
@@ -23,9 +23,9 @@ export function useDashboardKey() {
     ...data,
     dashboardKey,
     dashboardType,
-    isPrivate,
-    isPublic,
-    isShared,
+    isGuestDashboard,
+    isPrivateDashboard,
+    isSharedDashboard,
     publicEntities,
     setDashboardKey,
   }

--- a/frontend/composables/useDashboardKeyProvider.ts
+++ b/frontend/composables/useDashboardKeyProvider.ts
@@ -11,7 +11,7 @@ import type {
   DashboardType,
 } from '~/types/dashboard'
 import {
-  isPublicDashboardKey, isSharedKey,
+  isGuestDashboardKey, isSharedDashboardKey,
 } from '~/utils/dashboard/key'
 
 export function useDashboardKeyProvider(
@@ -57,8 +57,8 @@ export function useDashboardKeyProvider(
       // only use the dashboard cookie key as default if you are not logged in and it's not private
       if (
         !isLoggedIn.value
-        && isPublicDashboardKey(dashboardKeyCookie.value)
-        && !isSharedKey(dashboardKeyCookie.value)
+        && isGuestDashboardKey(dashboardKeyCookie.value)
+        && !isSharedDashboardKey(dashboardKeyCookie.value)
       ) {
         setDashboardKey(`${dashboardKeyCookie.value}`)
       }
@@ -73,17 +73,17 @@ export function useDashboardKeyProvider(
   }
   initialCheck()
 
-  const isPublic = computed(() => {
-    return isPublicDashboardKey(dashboardKey.value)
+  const isGuestDashboard = computed(() => {
+    return isGuestDashboardKey(dashboardKey.value)
   })
 
-  const isShared = computed(() => {
-    return isSharedKey(dashboardKey.value)
+  const isSharedDashboard = computed(() => {
+    return isSharedDashboardKey(dashboardKey.value)
   })
 
   // validator id / publicKey for validator dashboard or account id or ens name for account dashboard
   const publicEntities = computed(() => {
-    if (!isPublic.value || !dashboardKey.value) {
+    if (!isGuestDashboard.value || !dashboardKey.value) {
       return []
     }
     return fromBase64Url(dashboardKey.value)?.split(',') ?? []
@@ -107,8 +107,8 @@ export function useDashboardKeyProvider(
     addEntities,
     dashboardKey,
     dashboardType,
-    isPublic,
-    isShared,
+    isGuestDashboard,
+    isSharedDashboard,
     publicEntities,
     removeEntities,
     setDashboardKey,

--- a/frontend/pages/dashboard/[[id]]/index.vue
+++ b/frontend/pages/dashboard/[[id]]/index.vue
@@ -12,9 +12,9 @@ import {
   DashboardCreationController, DashboardTableBlocks, DashboardTableEmpty, DashboardTableRewards, DashboardTableSummary,
   DashboardTableWithdrawals,
 } from '#components'
-import type { CookieDashboard } from '~/types/dashboard'
+import type { GuestDashboard } from '~/types/dashboard'
 import {
-  isPublicDashboardKey, isSharedKey,
+  isGuestDashboardKey, isSharedDashboardKey,
 } from '~/utils/dashboard/key'
 import type { HashTabs } from '~/types/hashTabs'
 
@@ -70,7 +70,7 @@ const {
   dashboards,
   getDashboardLabel,
   refreshDashboards,
-  updateHash,
+  updateGuestDashboardKey,
 } = useUserDashboardStore()
 // when we run into an error loading a dashboard keep it here to prevent an infinity loop
 const errorDashboardKeys: string[] = []
@@ -138,38 +138,38 @@ watch(
     newLoggedIn,
   ], [ oldKey ]) => {
     if (!newLoggedIn || !newKey) {
-      // Some checks if we need to update the dashboard key or the public dashboard
-      let cd = dashboards.value?.validator_dashboards?.[0] as CookieDashboard
-      const isPublic = isPublicDashboardKey(newKey)
-      const isShared = isSharedKey(newKey)
+      // Some checks if we need to update the dashboard key or the guest dashboard
+      let gd = dashboards.value?.validator_dashboards?.[0] as GuestDashboard
+      const isGuest = isGuestDashboardKey(newKey)
+      const isShared = isSharedDashboardKey(newKey)
       if (isShared) {
         return
       }
       if (newLoggedIn) {
         // if we are logged in and have no dashboard key we only want to switch
         //  to the first dashboard if it is a private one
-        if (cd && cd.hash === undefined) {
-          setDashboardKeyIfNoError(cd.id.toString())
+        if (gd && gd.key === undefined) {
+          setDashboardKeyIfNoError(gd.id.toString())
         }
       }
       else if (
         !newLoggedIn
-        && cd
-        && isPublic
-        && (!cd.hash || (cd.hash ?? '') === (oldKey ?? ''))
+        && gd
+        && isGuest
+        && (!gd.key || (gd.key ?? '') === (oldKey ?? ''))
       ) {
-        // we got a new public dashboard hash but the old hash matches the
+        // we got a new guest dashboard key but the old key matches the
         // stored dashboard - so we update the stored dashboard
         if (!errorDashboardKeys.includes(newKey)) {
-          updateHash('validator', newKey)
+          updateGuestDashboardKey('validator', newKey)
         }
         setDashboardKeyIfNoError(newKey ?? '')
       }
-      else if (!newKey || !isPublic) {
+      else if (!newKey || !isGuest) {
         // trying to view a private dashboad but not logged in
-        cd = cookieDashboards.value
-          ?.validator_dashboards?.[0] as CookieDashboard
-        setDashboardKeyIfNoError(cd?.hash ?? '')
+        gd = cookieDashboards.value
+          ?.validator_dashboards?.[0] as GuestDashboard
+        setDashboardKeyIfNoError(gd?.key ?? '')
       }
     }
   },

--- a/frontend/stores/dashboard/useValidatorSlotVizStore.ts
+++ b/frontend/stores/dashboard/useValidatorSlotVizStore.ts
@@ -32,7 +32,7 @@ export function useValidatorSlotVizStore() {
     )
 
     // We use this hacky solution as we don't have an api endpoint to load a slot viz without validators
-    // So we load it for a small public dashboard and then remove the validator informations from it.
+    // So we load it for a small guest dashboard and then remove the validator informations from it.
     if (!dashboardKey) {
       data.value = res.data.map(e => ({
         ...e,

--- a/frontend/types/dashboard/index.ts
+++ b/frontend/types/dashboard/index.ts
@@ -3,7 +3,7 @@ export type DashboardKey = string
 
 export type DashboardType = 'account' | 'notifications' | 'validator'
 
-export enum COOKIE_DASHBOARD_ID {
+export enum GUEST_DASHBOARD_ID {
   ACCOUNT = -3,
   VALIDATOR = -2,
 }
@@ -15,8 +15,8 @@ export type DashboardKeyData = {
   addEntities: (list: string[]) => void,
   dashboardKey: globalThis.Ref<string>,
   dashboardType: globalThis.Ref<DashboardType>,
-  isPublic: globalThis.Ref<boolean>,
-  isShared: globalThis.Ref<boolean>,
+  isGuestDashboard: globalThis.Ref<boolean>,
+  isSharedDashboard: globalThis.Ref<boolean>,
   publicEntities: globalThis.Ref<string[]>,
   removeEntities: (list: string[]) => void,
   setDashboardKey: (key: string) => void,
@@ -29,6 +29,6 @@ export interface Dashboard {
 }
 
 // For not logged in Users we store the Dashboard in Cookies
-export interface CookieDashboard extends Dashboard {
-  hash?: string,
+export interface GuestDashboard extends Dashboard {
+  key?: string,
 }

--- a/frontend/utils/dashboard/key.ts
+++ b/frontend/utils/dashboard/key.ts
@@ -1,4 +1,4 @@
-export function isPublicDashboardKey(value?: string): boolean {
+export function isGuestDashboardKey(value?: string): boolean {
   if (!value) {
     return true
   }
@@ -7,6 +7,6 @@ export function isPublicDashboardKey(value?: string): boolean {
   return isNaN(id)
 }
 
-export function isSharedKey(value?: string): boolean {
+export function isSharedDashboardKey(value?: string): boolean {
   return !!value?.startsWith('v-')
 }


### PR DESCRIPTION
- replaces all mentions of "public" dashboards with "guest" dashboards, as this is the correct internal terminology.
- replaces all mentions of "hash" regarding guest dashboards with "key", as guest dashboard keys are NOT hashes.
- unifies some misc. function and variable naming

no relevant BEDS
