### PR TITLE
refactor: convert `userDashboardStore` to proper store

### DIFF
--- a/frontend/components/dashboard/DashboardControls.vue
+++ b/frontend/components/dashboard/DashboardControls.vue
@@ -9,7 +9,6 @@ import {
   faUsers,
 } from '@fortawesome/pro-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-
 import type { DynamicDialogCloseOptions } from 'primevue/dynamicdialogoptions'
 import {
   BcDialogConfirm,
@@ -44,10 +43,12 @@ const {
   setDashboardKey,
 } = useDashboardKey()
 const { refreshOverview } = useValidatorDashboardOverviewStore()
+const userDashboardStore = useUserDashboardStore()
 const {
-  dashboards, getDashboardLabel, refreshDashboards, updateGuestDashboardKey,
-}
-  = useUserDashboardStore()
+  getDashboardLabel, refreshDashboards, updateGuestDashboardKey,
+} = userDashboardStore
+
+const { dashboards } = storeToRefs(userDashboardStore)
 
 const { t: $t } = useTranslation()
 const { width } = useWindowSize()

--- a/frontend/components/dashboard/DashboardHeader.vue
+++ b/frontend/components/dashboard/DashboardHeader.vue
@@ -2,7 +2,6 @@
 import type {
   MenuBarButton, MenuBarEntry,
 } from '~/types/menuBar'
-import { useUserDashboardStore } from '~/stores/dashboard/useUserDashboardStore'
 import {
   type Dashboard, type DashboardKey, type DashboardType, GUEST_DASHBOARD_ID, type GuestDashboard,
 } from '~/types/dashboard'
@@ -14,7 +13,7 @@ const router = useRouter()
 const { has } = useFeatureFlag()
 
 const { isLoggedIn } = useUserStore()
-const { dashboards } = useUserDashboardStore()
+const { dashboards } = storeToRefs(useUserDashboardStore())
 const {
   dashboardKey, dashboardType, isSharedDashboard, setDashboardKey,
 } = useDashboardKey()

--- a/frontend/components/dashboard/GroupManagementModal.vue
+++ b/frontend/components/dashboard/GroupManagementModal.vue
@@ -8,7 +8,6 @@ import type { DataTableSortEvent } from 'primevue/datatable'
 import {
   BcDialogConfirm, BcPremiumModal,
 } from '#components'
-import { useValidatorDashboardOverviewStore } from '~/stores/dashboard/useValidatorDashboardOverviewStore'
 import type { ApiPagingResponse } from '~/types/api/common'
 import type { VDBOverviewGroup } from '~/types/api/validator_dashboard'
 import type {
@@ -34,7 +33,7 @@ const visible = defineModel<boolean>()
 
 const { refreshOverview } = useValidatorDashboardOverviewStore()
 const { groups } = useValidatorDashboardGroups()
-const { dashboards } = useUserDashboardStore()
+const { dashboards } = storeToRefs(useUserDashboardStore())
 const { user } = useUserStore()
 
 const cursor = ref<Cursor>(0)

--- a/frontend/components/dashboard/SharedDashboardModal.vue
+++ b/frontend/components/dashboard/SharedDashboardModal.vue
@@ -8,7 +8,7 @@ const cookiePreference = useCookie<CookiesPreference>(
   { default: () => undefined },
 )
 const { isSharedDashboard } = useDashboardKey()
-const { dashboards } = useUserDashboardStore()
+const { dashboards } = storeToRefs(useUserDashboardStore())
 const { t: $t } = useTranslation()
 const route = useRoute()
 

--- a/frontend/components/dashboard/creation/DashboardCreationController.vue
+++ b/frontend/components/dashboard/creation/DashboardCreationController.vue
@@ -7,11 +7,16 @@ import {
 import { type ChainIDs } from '~/types/network'
 import { API_PATH } from '~/types/customFetch'
 
+const userDashboardStore = useUserDashboardStore()
 const {
-  createAccountDashboard, createValidatorDashboard,
-}
-  = useUserDashboardStore()
-const { dashboards } = useUserDashboardStore()
+  createAccountDashboard,
+  createValidatorDashboard,
+} = userDashboardStore
+
+const {
+  dashboards,
+} = storeToRefs(userDashboardStore)
+
 const {
   isLoggedIn, user,
 } = useUserStore()

--- a/frontend/components/notifications/NotificationsTableEmpty.vue
+++ b/frontend/components/notifications/NotificationsTableEmpty.vue
@@ -21,10 +21,15 @@ const handleClick = () => {
   }
   emit('openDialog')
 }
+
+const userDashboardStore = useUserDashboardStore()
+const {
+  refreshDashboards,
+} = userDashboardStore
+
 const {
   dashboards,
-  refreshDashboards,
-} = useUserDashboardStore()
+} = storeToRefs(userDashboardStore)
 
 if (!dashboards.value) {
   refreshDashboards()

--- a/frontend/pages/dashboard/[[id]]/index.vue
+++ b/frontend/pages/dashboard/[[id]]/index.vue
@@ -65,15 +65,19 @@ const tabs: HashTabs = [
 const {
   dashboardKey, setDashboardKey,
 } = useDashboardKeyProvider('validator')
+
+const userDashboardStore = useUserDashboardStore()
 const {
-  cookieDashboards,
-  dashboards,
   getDashboardLabel,
   refreshDashboards,
   updateGuestDashboardKey,
-} = useUserDashboardStore()
-// when we run into an error loading a dashboard keep it here to prevent an infinity loop
-const errorDashboardKeys: string[] = []
+} = userDashboardStore
+
+const {
+  cookieDashboards,
+  dashboards,
+} = storeToRefs(userDashboardStore)
+await useAsyncData('user_dashboards', () => refreshDashboards(), { watch: [ isLoggedIn ] })
 
 const seoTitle = computed(() => {
   return getDashboardLabel(dashboardKey.value, 'validator')
@@ -122,12 +126,13 @@ function showDashboardCreationDialog() {
   dashboardCreationControllerModal.value?.show()
 }
 
+// when we run into an error loading a dashboard keep it here to prevent an infinity loop
+const errorDashboardKeys: string[] = []
 const setDashboardKeyIfNoError = (key: string) => {
   if (!errorDashboardKeys.includes(key)) {
     setDashboardKey(key)
   }
 }
-
 watch(
   [
     dashboardKey,


### PR DESCRIPTION
- removes the composable wrapper from `useUserDashboardStore`
- makes sure that all refs from the store are properly converted with `storeToRefs`
