### PR TITLE
fix(NotificationsManagementModalDashboardsDelete): remove `notificati…

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -21,6 +21,7 @@
     "NotificationsDashboardDialogEntity",
     "NotificationsDashboardTable",
     "NotificationsManagementDashboards",
+    "NotificationsManagementModalDashboardsDelete",
     "NotificationsManagementModalWebhook",
     "NotificationsManagementNetwork",
     "NotificationsManagementSubscriptionDialog",

--- a/frontend/components/notifications/management/modal/NotificationsManagementModalDashboardsDelete.vue
+++ b/frontend/components/notifications/management/modal/NotificationsManagementModalDashboardsDelete.vue
@@ -31,7 +31,10 @@ const emit = defineEmits<{
   ): void,
 }>()
 const handleDelete = () => {
-  if (props.value?.dashboard_id && props.value?.group_id) {
+  if (
+    typeof props.value?.dashboard_id === 'number'
+    && typeof props.value?.group_id === 'number'
+  ) {
     emit('delete', {
       dashboard_id: props.value.dashboard_id,
       group_id: props.value.group_id,


### PR DESCRIPTION
…ons for default group`

Before it was checked for truthy `groupIds` before `emitting` but the `default Group Id` is `0`

See: BEDS-1024