### PR TITLE
fix(NotificationsManagementGeneralTab): reset `mute state` after `mute timestamp` had passed

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -22,6 +22,7 @@
     "NotificationsDashboardDialogEntity",
     "NotificationsDashboardTable",
     "NotificationsManagementDashboards",
+    "NotificationsManagementGeneralTab",
     "NotificationsManagementModalDashboardsDelete",
     "NotificationsManagementModalWebhook",
     "NotificationsManagementNetwork",

--- a/frontend/utils/time.ts
+++ b/frontend/utils/time.ts
@@ -1,3 +1,5 @@
+export const currentTimestampInSeconds = () => Math.round(Date.now() / 1000)
+
 export const getFutureTimestampInSeconds = (
   {
     seconds = 0,


### PR DESCRIPTION
See: BEDS-952