### PR TITLE
fix(dashboard): `guest dashboards` not available

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -37,6 +37,7 @@
     "color-mode",
     "csrf",
     "customFetch",
+    "dashboard",
     "deps",
     "dialog",
     "eslint",

--- a/frontend/pages/dashboard/[[id]]/index.vue
+++ b/frontend/pages/dashboard/[[id]]/index.vue
@@ -95,6 +95,13 @@ const { error: validatorOverviewError } = await useAsyncData(
   () => refreshOverview(dashboardKey.value),
   { watch: [ dashboardKey ] },
 )
+// when we run into an error loading a dashboard keep it here to prevent an infinity loop
+const errorDashboardKeys: string[] = []
+const setDashboardKeyIfNoError = (key: string) => {
+  if (!errorDashboardKeys.includes(key)) {
+    setDashboardKey(key)
+  }
+}
 watch(
   validatorOverviewError,
   (error) => {
@@ -126,13 +133,6 @@ function showDashboardCreationDialog() {
   dashboardCreationControllerModal.value?.show()
 }
 
-// when we run into an error loading a dashboard keep it here to prevent an infinity loop
-const errorDashboardKeys: string[] = []
-const setDashboardKeyIfNoError = (key: string) => {
-  if (!errorDashboardKeys.includes(key)) {
-    setDashboardKey(key)
-  }
-}
 watch(
   [
     dashboardKey,


### PR DESCRIPTION
Due to an update it was not possible anymore to have a `watch`
function be dependend on `variables` that are not yet `initialized`.