### PR TITLE
fix:  show `fraction digits` only for  `non-whole number percentages`

### DIFF
--- a/frontend/components/bc/format/BcFormatPercent.vue
+++ b/frontend/components/bc/format/BcFormatPercent.vue
@@ -60,7 +60,11 @@ const data = computed(() => {
   const localPercent = percent ?? calculatePercent(value, base)
   label = new Intl.NumberFormat('en', {
     maximumFractionDigits,
-    minimumFractionDigits,
+    // due to the default value of minimumFractionDigits: 2
+    // there will be an error when `minimumFractionDigits > maximumFractionDitigs`
+    minimumFractionDigits: minimumFractionDigits > maximumFractionDigits
+      ? maximumFractionDigits
+      : minimumFractionDigits,
     style: 'unit',
     trailingZeroDisplay,
     unit: 'percent',


### PR DESCRIPTION
See: 4e053b08c0766cd1a0b2cd29cc63254d59b6295b