### PR TITLE
fix: timestamp for `sepolia network`

### DIFF
--- a/frontend/utils/mock.ts
+++ b/frontend/utils/mock.ts
@@ -87,5 +87,11 @@ export function simulateAPIresponseAboutNetworkList(): ApiDataResponse<
       )
     }
   }
+  result.data.push(
+    {
+      chain_id: 11155111,
+      name: 'sepolia',
+    },
+  )
   return result
 }


### PR DESCRIPTION
This is a `hotfix`, we have to get rid of the whole `mock`
and `network` part.

See: BEDS-1058