### PR TITLE
fix: `DashboardCreationNetworkMask` showing additional `sepolia network`

### DIFF
--- a/frontend/utils/mock.ts
+++ b/frontend/utils/mock.ts
@@ -1,6 +1,5 @@
 import type { InternalGetLatestStateResponse } from '~/types/api/latest_state'
 import type { ApiDataResponse } from '~/types/api/common'
-import { isMainNet } from '~/types/network'
 
 let mockSlot = 10000
 
@@ -39,59 +38,18 @@ export function simulateAPIresponseAboutNetworkList(): ApiDataResponse<
   ApiChainInfo[]
 > {
   const result = { data: [] } as ApiDataResponse<ApiChainInfo[]>
-  if (isMainNet(Number(useRuntimeConfig().public.chainIdByDefault))) {
-    result.data.push(
-      {
-        chain_id: 1,
-        name: 'ethereum',
-      },
-      {
-        chain_id: 100,
-        name: 'gnosis',
-      },
-    )
-    if (useRuntimeConfig().public.showInDevelopment) {
-      result.data.push(
-        {
-          chain_id: 42161,
-          name: 'arbitrum',
-        },
-        {
-          chain_id: 8453,
-          name: 'base',
-        },
-      )
-    }
-  }
-  else {
-    result.data.push(
-      {
-        chain_id: 17000,
-        name: 'holesky',
-      },
-      {
-        chain_id: 10200,
-        name: 'chiado',
-      },
-    )
-    if (useRuntimeConfig().public.showInDevelopment) {
-      result.data.push(
-        {
-          chain_id: 421614,
-          name: 'arbitrum testnet',
-        },
-        {
-          chain_id: 84532,
-          name: 'base testnet',
-        },
-      )
-    }
-  }
   result.data.push(
     {
-      chain_id: 11155111,
-      name: 'sepolia',
+      chain_id: Number(useRuntimeConfig().public.chainIdByDefault),
+      name: 'ehtereum',
     },
   )
+  result.data.push(
+    {
+      chain_id: 100,
+      name: 'gnosis',
+    },
+  )
+
   return result
 }


### PR DESCRIPTION
`Sepolia` was added additionally instead of replacing the `ethereum network`

See: 4536a0ecfbec8a607c9d0c40faef140f57ae0db8