### PR TITLE
BEDS-1106/fix percent formatting

### DIFF
--- a/frontend/components/dashboard/DashboardValidatorOverview.vue
+++ b/frontend/components/dashboard/DashboardValidatorOverview.vue
@@ -77,27 +77,25 @@ const openValidatorModal = () => {
 }
 
 const efficiencyInfos = computed(() =>
-  TimeFrames.map(k => ({
-    label: $t(`statistics.${k}`),
-    value: formatPercent(overview.value?.efficiency[k] ?? 0),
+  TimeFrames.map(timeFrame => ({
+    label: $t(`statistics.${timeFrame}`),
+    value: formatToPercent(overview.value?.efficiency[timeFrame] ?? 0),
   })),
 )
 
-const rewardsInfos = TimeFrames.map(k =>
-  createInfo(k, overview.value?.rewards[k] ?? {
+const rewardsInfos = TimeFrames.map(timeFrame =>
+  createInfo(timeFrame, overview.value?.rewards[timeFrame] ?? {
     cl: '0',
     el: '0',
   }, formatValueWei),
 )
 
-const apr = computed(() => formatPercent(totalElClNumbers(overview.value?.apr.last_30d ?? {
+const apr = computed(() => formatToPercent(totalElClNumbers(overview.value?.apr.last_30d ?? {
   cl: 0,
   el: 0,
-})),
-)
-
-const aprInfos = TimeFrames.map(k =>
-  createInfo(k, overview.value?.apr[k] ?? {
+})))
+const aprInfos = TimeFrames.map(timeFrame =>
+  createInfo(timeFrame, overview.value?.apr[timeFrame] ?? {
     cl: 0,
     el: 0,
   }, formatToPercent),

--- a/frontend/components/dashboard/table/DashboardTableSummaryValue.vue
+++ b/frontend/components/dashboard/table/DashboardTableSummaryValue.vue
@@ -391,7 +391,7 @@ const openValidatorModal = () => {
         {{
           $t(`dashboard.validator.summary.tooltip.${compare}`, {
             name: groupName,
-            average: formatPercent(row.average_network_efficiency),
+            average: formatToPercent(row.average_network_efficiency),
           })
         }}
       </span>

--- a/frontend/utils/bigMath.ts
+++ b/frontend/utils/bigMath.ts
@@ -60,9 +60,6 @@ export const subWei = (total: string, value: string): BigNumber | undefined => {
 
 export const totalElClNumbers = (
   value: ClElValue<number>,
-): number | undefined => {
-  if (!value) {
-    return
-  }
+) => {
   return value.el + value.cl
 }

--- a/frontend/utils/format.ts
+++ b/frontend/utils/format.ts
@@ -47,17 +47,6 @@ export function commmifyLeft(value: string): string {
   return formatted
 }
 
-export function formatAndCalculatePercent(
-  value?: number,
-  base?: number,
-  config?: NumberFormatConfig,
-): string {
-  if (!base) {
-    return ''
-  }
-  return formatPercent(calculatePercent(value, base), config)
-}
-
 /**
  * Should be used only when you work with a network different from the current one.
  * Wherever you would write `formatEpochToDate(currentNetwork.value, ...)` you
@@ -144,30 +133,6 @@ export function formatGoTimestamp(
 
 export function formatNumber(value?: number): string {
   return value?.toLocaleString('en-US') ?? ''
-}
-
-export function formatPercent(
-  percent?: number,
-  config?: NumberFormatConfig,
-): string {
-  if (percent === undefined) {
-    return ''
-  }
-  const {
-    addPositiveSign, fixed, precision,
-  } = {
-    ...{
-      addPositiveSign: false,
-      fixed: 2,
-      precision: 2,
-    },
-    ...config,
-  }
-  let result = trim(percent, precision, fixed)
-  if (addPositiveSign) {
-    result = addPlusSign(result)
-  }
-  return `${result}%`
 }
 
 /**


### PR DESCRIPTION
We were using two different percent formatting functions, which caused inconsistencies in the resulting values.
This MR replaces the uses of the older by the newer one and removes it.