### PR TITLE
BEDS-1104/fix adding validators via withdrawal address

### DIFF
--- a/frontend/components/dashboard/DashboardValidatorManagementModal.vue
+++ b/frontend/components/dashboard/DashboardValidatorManagementModal.vue
@@ -70,7 +70,7 @@ type ValidatorUpdateBody = {
   graffiti?: string,
   group_id?: number,
   validators?: number[],
-  withdrawal_address?: string,
+  withdrawal_credential?: string,
 }
 
 const size = computed(() => {
@@ -108,7 +108,7 @@ const changeGroup = async (body: ValidatorUpdateBody, groupId?: number) => {
     !body.validators?.length
     && !body.deposit_address
     && !body.graffiti
-    && !body.withdrawal_address
+    && !body.withdrawal_credential
   ) {
     warn('no validators selected to change group')
     return


### PR DESCRIPTION
**Info:**
The `ValidatorUpdateBody` type definition fixed in this PR is currently declared in the frontend, as there's no way to access it from the `api type definitions` right now. Making these types available was requested from the backend and should be added soon.