### PR TITLE
(BEDS-1116) internal subscription grace period

### DIFF
--- a/backend/pkg/commons/db/frontend.go
+++ b/backend/pkg/commons/db/frontend.go
@@ -2,8 +2,10 @@ package db
 
 import (
 	"database/sql"
+	"fmt"
 	"time"
 
+	"github.com/doug-martin/goqu/v9"
 	"github.com/gobitfly/beaconchain/pkg/commons/types"
 	"github.com/jmoiron/sqlx"
 )
@@ -56,14 +58,30 @@ func UpdateUserSubscription(tx *sql.Tx, id uint64, valid bool, expiration int64,
 	now := time.Now()
 	nowTs := now.Unix()
 	var err error
+
+	fields := goqu.Record{
+		"active":        valid,
+		"updated_at":    nowTs,
+		"reject_reason": rejectReason,
+	}
+	if expiration != 0 {
+		fields["expires_at"] = expiration
+	}
+
+	ds := goqu.Dialect("postgres").
+		Update("users_app_subscriptions").
+		Set(fields).
+		Where(goqu.I("id").Eq(id))
+
+	qry, args, err := ds.Prepared(true).ToSQL()
+	if err != nil {
+		return fmt.Errorf("error preparing query: %w", err)
+	}
+
 	if tx == nil {
-		_, err = FrontendWriterDB.Exec("UPDATE users_app_subscriptions SET active = $1, updated_at = TO_TIMESTAMP($2), expires_at = TO_TIMESTAMP($3), reject_reason = $4 WHERE id = $5;",
-			valid, nowTs, expiration, rejectReason, id,
-		)
+		_, err = FrontendWriterDB.Exec(qry, args)
 	} else {
-		_, err = tx.Exec("UPDATE users_app_subscriptions SET active = $1, updated_at = TO_TIMESTAMP($2), expires_at = TO_TIMESTAMP($3), reject_reason = $4 WHERE id = $5;",
-			valid, nowTs, expiration, rejectReason, id,
-		)
+		_, err = tx.Exec(qry, args)
 	}
 
 	return err

--- a/backend/pkg/userservice/appsubscription_oracle.go
+++ b/backend/pkg/userservice/appsubscription_oracle.go
@@ -229,9 +229,15 @@ func verifyGoogle(client *playstore.Client, receipt *types.PremiumData) (*Verify
 		}
 	}
 
+	expirationDate := resp.ExpiryTimeMillis / 1000
+	if valid && resp.PaymentState != nil && *resp.PaymentState == 0 && resp.AutoRenewing {
+		// user is in grace period, don't update internal subscription end
+		expirationDate = 0
+	}
+
 	return &VerifyResponse{
 		Valid:          valid && !canceled,
-		ExpirationDate: resp.ExpiryTimeMillis / 1000,
+		ExpirationDate: expirationDate,
 		RejectReason:   reason,
 	}, nil
 }

--- a/backend/pkg/userservice/appsubscription_oracle.go
+++ b/backend/pkg/userservice/appsubscription_oracle.go
@@ -339,7 +339,7 @@ func verifyApple(apple *api.StoreClient, receipt *types.PremiumData) (*VerifyRes
 					response.RejectReason = "invalid_expires_date"
 					return response, nil
 				}
-				expiresDateUint64 := int64(math.Round(expiresDateFloat))
+				expiresDateUint64 := int64(math.Round(expiresDateFloat)) / 1000
 
 				response.Valid = true
 				response.ExpirationDate = expiresDateUint64


### PR DESCRIPTION
A convention involving the unused column `users_app_subscriptions.expires_at` in combination with the `active` flag is introduced: when a subscription is active and it expired in the past, it’s currently in a grace period. That’s less effort than adding a new `inGracePeriod` column or something. Should be merged along with https://github.com/gobitfly/eth2-beaconchain-explorer/pull/2998 for stripe.

This was mostly a research task; see payment provider docs for reference:
- [Google](https://web.archive.org/web/20220205152852/https://developer.android.com/google/play/billing/subscriptions#grace): subscription end date returned from API changes dynamically based on state, need internal handling
- [Apple](https://developer.apple.com/documentation/appstoreserverapi/expiresdate/): Currently used field is correct, there's another one for grace periods (`gracePeriodExpirationDate`)
- [Stripe](https://docs.stripe.com/api/invoices/object#invoice_object-lines-data-period-end): Currently the constant 0 is written as end, need to change. [More context](https://stackoverflow.com/questions/39456889/stripe-invoice-start-created-and-end-date-are-all-the-same-for-first-invoice)

Note that for existing subscriptions this feature can only be ensured to work after the user made an update (e.g. paid an invoice, changed plans etc.).