### PR TITLE
Beds 1139/add missed rewards to front end

### DIFF
--- a/frontend/components/dashboard/table/DashboardTableSummaryDetails.vue
+++ b/frontend/components/dashboard/table/DashboardTableSummaryDetails.vue
@@ -39,33 +39,33 @@ watch(
 
 type CombinedPropOrUndefined = SummaryDetailsEfficiencyCombinedProp | undefined
 
-const data = computed<SummaryRow[][]>(() => {
-  const list: SummaryRow[][] = [
+const summarySections = computed<SummaryRow[][]>(() => {
+  const sections: SummaryRow[][] = [
     [],
     [],
     [],
   ]
 
-  const addToList = (
+  const addToSection = (
     index: number,
-    prop?: SummaryDetailsEfficiencyCombinedProp,
+    summaryProperty?: SummaryDetailsEfficiencyCombinedProp,
   ) => {
-    if (!prop) {
+    if (!summaryProperty) {
       return
     }
-    const title = $t(`dashboard.validator.summary.row.${prop}`)
+    const title = $t(`dashboard.validator.summary.row.${summaryProperty}`)
     const row = {
-      prop,
+      summaryProperty,
       title,
     }
-    list[index].push(row)
+    sections[index].push(row)
   }
 
-  const addPropsTolist = (
-    index: number,
-    props: CombinedPropOrUndefined[],
+  const addSummaryPropertiesToSection = (
+    sectionIndex: number,
+    summaryProperties: CombinedPropOrUndefined[],
   ) => {
-    props.forEach(p => addToList(index, p))
+    summaryProperties.forEach(summaryProperty => addToSection(sectionIndex, summaryProperty))
   }
 
   const rewardCols: CombinedPropOrUndefined[]
@@ -75,7 +75,7 @@ const data = computed<SummaryRow[][]>(() => {
     .attestations
     ? []
     : rewardCols
-  addPropsTolist(0, [
+  addSummaryPropertiesToSection(0, [
     (!props.tableVisibility.efficiency ? 'efficiency' : undefined),
     ...addCols,
     'attestations',
@@ -86,7 +86,7 @@ const data = computed<SummaryRow[][]>(() => {
     'attestation_avg_incl_dist',
   ])
 
-  addPropsTolist(1, [
+  addSummaryPropertiesToSection(1, [
     'sync',
     'validators_sync',
     'proposals',
@@ -96,18 +96,18 @@ const data = computed<SummaryRow[][]>(() => {
   ])
 
   addCols = !props.tableVisibility.attestations ? [] : rewardCols
-  addPropsTolist(2, [
+  addSummaryPropertiesToSection(2, [
     'apr',
     'luck',
     'missed_rewards',
     ...addCols,
   ])
 
-  return list
+  return sections
 })
 
 const rowClass = (data: SummaryRow) => {
-  if (!data.prop) {
+  if (!data.property) {
     return 'bold' // headline without prop
   }
   const classNames: Partial<
@@ -123,7 +123,7 @@ const rowClass = (data: SummaryRow) => {
     slashings: 'bold spacing-top',
     sync: props.tableVisibility.efficiency ? 'bold' : 'bold spacing-top',
   }
-  return classNames[data.prop]
+  return classNames[data.property]
 }
 </script>
 
@@ -133,25 +133,25 @@ const rowClass = (data: SummaryRow) => {
     class="details-container"
   >
     <div
-      v-for="(list, index) in data"
+      v-for="(summarySection, index) in summarySections"
       :key="index"
       class="group"
     >
       <div
-        v-for="(prop, pIndex) in list"
-        :key="pIndex"
-        :class="rowClass(prop)"
+        v-for="(summaryRow, rowIndex) in summarySection"
+        :key="rowIndex"
+        :class="rowClass(summaryRow)"
         class="row"
       >
         <div class="label">
-          {{ prop.title }}
+          {{ summaryRow.title }}
         </div>
         <DashboardTableSummaryValue
-          v-if="prop.prop"
+          v-if="summaryRow.property"
           class="value"
           :data="summary"
           :absolute
-          :property="prop.prop"
+          :property="summaryRow.property"
           :time-frame
           :row="props.row"
           :in-detail-view="true"

--- a/frontend/components/dashboard/table/DashboardTableSummaryDetails.vue
+++ b/frontend/components/dashboard/table/DashboardTableSummaryDetails.vue
@@ -99,6 +99,7 @@ const data = computed<SummaryRow[][]>(() => {
   addPropsTolist(2, [
     'apr',
     'luck',
+    'missed_rewards',
     ...addCols,
   ])
 

--- a/frontend/types/dashboard/summary.ts
+++ b/frontend/types/dashboard/summary.ts
@@ -58,7 +58,7 @@ export type SummaryDetailsEfficiencySpecialProp =
   (typeof SummaryDetailsEfficiencySpecialProps)[number]
 
 export type SummaryRow = {
-  prop?: SummaryDetailsEfficiencyCombinedProp,
+  property?: SummaryDetailsEfficiencyCombinedProp,
   title: string,
 }
 


### PR DESCRIPTION
The `missed_rewards` detail row was already implemented, just not included in the details view, so I added it again.

Extra: I renamed some variable names in `DashboardTableSummaryDetails` to make the code more descriptive. It was very hard to understand with the previous names.