### PR TITLE
(BEDS-1162) Fix: don't increase mailsSent count if limit reached

### DIFF
--- a/backend/pkg/api/data_access/notifications.go
+++ b/backend/pkg/api/data_access/notifications.go
@@ -20,7 +20,6 @@ import (
 	"github.com/doug-martin/goqu/v9/exp"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/go-redis/redis/v8"
 	"github.com/gobitfly/beaconchain/pkg/api/enums"
 	t "github.com/gobitfly/beaconchain/pkg/api/types"
 	"github.com/gobitfly/beaconchain/pkg/commons/db"
@@ -193,27 +192,21 @@ func (d *DataAccessService) GetNotificationOverview(ctx context.Context, userId 
 
 	// 24h counts
 	eg.Go(func() error {
-		var err error
-		day := time.Now().Truncate(utils.Day).Unix()
-		getMessageCount := func(prefix string) (uint64, error) {
-			key := fmt.Sprintf("%s:%d:%d", prefix, userId, day)
-			res := d.persistentRedisDbClient.Get(ctx, key)
-			if res.Err() == redis.Nil {
-				return 0, nil
-			} else if res.Err() != nil {
-				return 0, res.Err()
-			}
-			return res.Uint64()
-		}
-		response.Last24hEmailCount, err = getMessageCount(notification.NOTIFICAION_EMAIL_RATE_LIMIT_BUCKET)
+		notificationCount, err := db.GetSentMessagesCount(ctx, notification.NOTIFICAION_EMAIL_RATE_LIMIT_BUCKET, types.UserId(userId))
 		if err != nil {
 			return err
 		}
-		response.Last24hPushCount, err = getMessageCount(notification.NOTIFICAION_PUSH_RATE_LIMIT_BUCKET)
+		response.Last24hEmailCount = uint64(notificationCount)
+
+		notificationCount, err = db.GetSentMessagesCount(ctx, notification.NOTIFICAION_PUSH_RATE_LIMIT_BUCKET, types.UserId(userId))
 		if err != nil {
 			return err
 		}
-		response.Last24hWebhookCount, err = getMessageCount(notification.NOTIFICAION_WEBHOOK_RATE_LIMIT_BUCKET)
+		response.Last24hPushCount = uint64(notificationCount)
+
+		notificationCount, err = db.GetSentMessagesCount(ctx, notification.NOTIFICAION_WEBHOOK_RATE_LIMIT_BUCKET, types.UserId(userId))
+		response.Last24hWebhookCount = uint64(notificationCount)
+
 		return err
 	})
 

--- a/backend/pkg/commons/db/subscriptions.go
+++ b/backend/pkg/commons/db/subscriptions.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-redis/redis/v8"
 	"github.com/gobitfly/beaconchain/pkg/commons/log"
 	"github.com/gobitfly/beaconchain/pkg/commons/types"
 	"github.com/gobitfly/beaconchain/pkg/commons/utils"
@@ -278,8 +279,8 @@ func UpdateSubscriptionLastSent(tx *sqlx.Tx, ts uint64, epoch uint64, subID uint
 	return err
 }
 
-// CountSentMessage increases the count of sent messages for this day given a specific prefix and userId
-func CountSentMessage(prefix string, userId types.UserId) (int64, error) {
+// IncrSentMessagesCount increases the count of sent messages for this day given a specific prefix and userId
+func IncrSentMessagesCount(prefix string, userId types.UserId) (int64, error) {
 	day := time.Now().Truncate(utils.Day).Unix()
 	key := fmt.Sprintf("%s:%d:%d", prefix, userId, day)
 
@@ -293,4 +294,18 @@ func CountSentMessage(prefix string, userId types.UserId) (int64, error) {
 	}
 
 	return incr.Val(), err
+}
+
+// GetSentMessagesCount returns the number of sent messages for this day given a specific prefix and userId
+func GetSentMessagesCount(ctx context.Context, prefix string, userId types.UserId) (int64, error) {
+	day := time.Now().Truncate(utils.Day).Unix()
+	key := fmt.Sprintf("%s:%d:%d", prefix, userId, day)
+
+	res := PersistentRedisDbClient.Get(ctx, key)
+	if res.Err() == redis.Nil {
+		return 0, nil
+	} else if res.Err() != nil {
+		return 0, res.Err()
+	}
+	return res.Int64()
 }

--- a/backend/pkg/commons/db/subscriptions.go
+++ b/backend/pkg/commons/db/subscriptions.go
@@ -280,20 +280,52 @@ func UpdateSubscriptionLastSent(tx *sqlx.Tx, ts uint64, epoch uint64, subID uint
 }
 
 // IncrSentMessagesCount increases the count of sent messages for this day given a specific prefix and userId
-func IncrSentMessagesCount(prefix string, userId types.UserId) (int64, error) {
+func IncrSentMessagesCount(prefix string, userId types.UserId, step, maxCount int64) (int64, int64, error) {
+	var inc, curCount int64
+	var err error
+
+	ctx := context.Background()
 	day := time.Now().Truncate(utils.Day).Unix()
 	key := fmt.Sprintf("%s:%d:%d", prefix, userId, day)
 
-	pipe := PersistentRedisDbClient.TxPipeline()
-	incr := pipe.Incr(context.Background(), key)
-	pipe.Expire(context.Background(), key, utils.Day)
-	_, err := pipe.Exec(context.Background())
+	incToMax := func(tx *redis.Tx) error {
+		curCount, err = tx.Get(ctx, key).Int64()
+		if err != nil && err != redis.Nil {
+			return err
+		}
 
-	if incr.Err() != nil {
-		return 0, incr.Err()
+		if maxCount == -1 {
+			// no limit
+			inc = step
+		} else {
+			inc = min(step, max(maxCount-curCount, 0))
+			if curCount >= maxCount {
+				// max reached
+				return nil
+			}
+		}
+		curCount += inc
+
+		// committed only if the watched key remains unchanged
+		_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+			pipe.Set(ctx, key, curCount, utils.Day)
+			return nil
+		})
+		return err
 	}
 
-	return incr.Val(), err
+	// retry optimistic lock on error
+	for range 100 {
+		err = PersistentRedisDbClient.Watch(ctx, incToMax, key)
+		if err != redis.TxFailedErr {
+			break
+		}
+	}
+	if err == redis.TxFailedErr {
+		return 0, 0, fmt.Errorf("optimistic locking failed: %w", err)
+	}
+
+	return inc, curCount, err
 }
 
 // GetSentMessagesCount returns the number of sent messages for this day given a specific prefix and userId

--- a/backend/pkg/commons/mail/mail.go
+++ b/backend/pkg/commons/mail/mail.go
@@ -78,26 +78,21 @@ func createTextMessage(msg types.Email) string {
 // It will return a ratelimit-error if the configured ratelimit is exceeded.
 func SendMailRateLimited(content types.TransitEmailContent, maxEmailsPerDay int64, bucket string) error {
 	sendThresholdReachedMail := false
-	count, err := db.GetSentMessagesCount(context.Background(), bucket, content.UserId)
+	incr, newCount, err := db.IncrSentMessagesCount(bucket, content.UserId, 1, maxEmailsPerDay)
 	if err != nil {
-		return err
+		log.Error(err, "error incrementing sent email count", 0)
 	}
 	timeLeft := time.Until(time.Now().Add(utils.Day).Truncate(utils.Day))
 
-	log.Debugf("user %d has sent %d of %d emails today, time left is %v", content.UserId, count, maxEmailsPerDay, timeLeft)
-	if count >= maxEmailsPerDay {
+	log.Debugf("user %d has sent %d of %d emails today, time left is %v", content.UserId, newCount, maxEmailsPerDay, timeLeft)
+	if incr == 0 {
 		return &types.RateLimitError{TimeLeft: timeLeft}
-	} else if count == maxEmailsPerDay {
-		sendThresholdReachedMail = true
 	}
+	sendThresholdReachedMail = newCount >= maxEmailsPerDay
 
 	err = SendHTMLMail(content.Address, content.Subject, content.Email, content.Attachments)
 	if err != nil {
 		log.Error(err, "error sending email", 0)
-	}
-	_, err = db.IncrSentMessagesCount(bucket, content.UserId)
-	if err != nil {
-		log.Error(err, "error incrementing sent email messages", 0)
 	}
 
 	// make sure the threshold reached email arrives last

--- a/backend/pkg/commons/mail/mail.go
+++ b/backend/pkg/commons/mail/mail.go
@@ -78,14 +78,14 @@ func createTextMessage(msg types.Email) string {
 // It will return a ratelimit-error if the configured ratelimit is exceeded.
 func SendMailRateLimited(content types.TransitEmailContent, maxEmailsPerDay int64, bucket string) error {
 	sendThresholdReachedMail := false
-	count, err := db.CountSentMessage(bucket, content.UserId)
+	count, err := db.GetSentMessagesCount(context.Background(), bucket, content.UserId)
 	if err != nil {
 		return err
 	}
 	timeLeft := time.Until(time.Now().Add(utils.Day).Truncate(utils.Day))
 
 	log.Debugf("user %d has sent %d of %d emails today, time left is %v", content.UserId, count, maxEmailsPerDay, timeLeft)
-	if count > maxEmailsPerDay {
+	if count >= maxEmailsPerDay {
 		return &types.RateLimitError{TimeLeft: timeLeft}
 	} else if count == maxEmailsPerDay {
 		sendThresholdReachedMail = true
@@ -94,6 +94,10 @@ func SendMailRateLimited(content types.TransitEmailContent, maxEmailsPerDay int6
 	err = SendHTMLMail(content.Address, content.Subject, content.Email, content.Attachments)
 	if err != nil {
 		log.Error(err, "error sending email", 0)
+	}
+	_, err = db.IncrSentMessagesCount(bucket, content.UserId)
+	if err != nil {
+		log.Error(err, "error incrementing sent email messages", 0)
 	}
 
 	// make sure the threshold reached email arrives last

--- a/backend/pkg/notification/firebase.go
+++ b/backend/pkg/notification/firebase.go
@@ -63,11 +63,9 @@ func SendPushBatch(userId types.UserId, messages []*messaging.Message, dryRun bo
 
 	currentMessages := messages
 
-	for range messages {
-		_, err := db.IncrSentMessagesCount(NOTIFICAION_PUSH_RATE_LIMIT_BUCKET, userId)
-		if err != nil {
-			log.Error(err, "error counting sent push", 0)
-		}
+	_, _, err = db.IncrSentMessagesCount(NOTIFICAION_PUSH_RATE_LIMIT_BUCKET, userId, int64(len(messages)), -1)
+	if err != nil {
+		log.Error(err, "error increasing sent push count", 0)
 	}
 
 	tries := 0

--- a/backend/pkg/notification/firebase.go
+++ b/backend/pkg/notification/firebase.go
@@ -64,7 +64,7 @@ func SendPushBatch(userId types.UserId, messages []*messaging.Message, dryRun bo
 	currentMessages := messages
 
 	for range messages {
-		_, err := db.CountSentMessage(NOTIFICAION_PUSH_RATE_LIMIT_BUCKET, userId)
+		_, err := db.IncrSentMessagesCount(NOTIFICAION_PUSH_RATE_LIMIT_BUCKET, userId)
 		if err != nil {
 			log.Error(err, "error counting sent push", 0)
 		}

--- a/backend/pkg/notification/queuing.go
+++ b/backend/pkg/notification/queuing.go
@@ -596,11 +596,11 @@ func QueuePushNotification(epoch uint64, notificationsByUserID types.Notificatio
 }
 
 func QueueTestPushNotification(ctx context.Context, userId types.UserId, userDbConn *sqlx.DB, networkDbConn *sqlx.DB) error {
-	count, err := db.IncrSentMessagesCount("n_test_push", userId)
+	incr, _, err := db.IncrSentMessagesCount("n_test_push", userId, 1, 10)
 	if err != nil {
 		return err
 	}
-	if count > 10 {
+	if incr == 0 {
 		return fmt.Errorf("rate limit has been exceeded")
 	}
 	tokens, err := GetUserPushTokenByIds([]types.UserId{userId}, userDbConn)

--- a/backend/pkg/notification/queuing.go
+++ b/backend/pkg/notification/queuing.go
@@ -424,6 +424,7 @@ func RenderEmailsForUserEvents(epoch uint64, notificationsByUserID types.Notific
 
 func QueueEmailNotifications(epoch uint64, notificationsByUserID types.NotificationsPerUserId, tx *sqlx.Tx) error {
 	// for emails multiple notifications will be rendered to one email per user for each run
+	// TODO filter out ratelimited users, don't need to queue or even render emails
 	emails, err := RenderEmailsForUserEvents(epoch, notificationsByUserID)
 	if err != nil {
 		return fmt.Errorf("error rendering emails: %w", err)
@@ -595,7 +596,7 @@ func QueuePushNotification(epoch uint64, notificationsByUserID types.Notificatio
 }
 
 func QueueTestPushNotification(ctx context.Context, userId types.UserId, userDbConn *sqlx.DB, networkDbConn *sqlx.DB) error {
-	count, err := db.CountSentMessage("n_test_push", userId)
+	count, err := db.IncrSentMessagesCount("n_test_push", userId)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/notification/sending.go
+++ b/backend/pkg/notification/sending.go
@@ -252,7 +252,7 @@ func sendWebhookNotifications() error {
 	g.SetLimit(50) // issue at most 50 requests at a time
 	for _, n := range notificationQueueItem {
 		n := n
-		_, err := db.CountSentMessage(NOTIFICAION_WEBHOOK_RATE_LIMIT_BUCKET, n.Content.UserId)
+		_, err := db.IncrSentMessagesCount(NOTIFICAION_WEBHOOK_RATE_LIMIT_BUCKET, n.Content.UserId)
 		if err != nil {
 			log.Error(err, "error counting sent webhook", 0)
 		}
@@ -369,7 +369,7 @@ func sendDiscordNotifications() error {
 	g.SetLimit(50) // issue at most 50 requests at a time
 	for _, n := range notificationQueueItem {
 		n := n
-		_, err := db.CountSentMessage(NOTIFICAION_WEBHOOK_RATE_LIMIT_BUCKET, n.Content.UserId)
+		_, err := db.IncrSentMessagesCount(NOTIFICAION_WEBHOOK_RATE_LIMIT_BUCKET, n.Content.UserId)
 		if err != nil {
 			log.Error(err, "error counting sent webhook", 0)
 		}
@@ -489,7 +489,7 @@ func SendTestEmail(ctx context.Context, userId types.UserId, dbConn *sqlx.DB) er
 }
 
 func SendTestWebhookNotification(ctx context.Context, userId types.UserId, webhookUrl string, isDiscordWebhook bool) error {
-	count, err := db.CountSentMessage("n_test_push", userId)
+	count, err := db.IncrSentMessagesCount("n_test_push", userId)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/notification/sending.go
+++ b/backend/pkg/notification/sending.go
@@ -252,9 +252,9 @@ func sendWebhookNotifications() error {
 	g.SetLimit(50) // issue at most 50 requests at a time
 	for _, n := range notificationQueueItem {
 		n := n
-		_, err := db.IncrSentMessagesCount(NOTIFICAION_WEBHOOK_RATE_LIMIT_BUCKET, n.Content.UserId)
+		_, _, err := db.IncrSentMessagesCount(NOTIFICAION_WEBHOOK_RATE_LIMIT_BUCKET, n.Content.UserId, 1, -1)
 		if err != nil {
-			log.Error(err, "error counting sent webhook", 0)
+			log.Error(err, "error increasing sent webhook count", 0)
 		}
 
 		// do not retry after 5 attempts
@@ -369,9 +369,9 @@ func sendDiscordNotifications() error {
 	g.SetLimit(50) // issue at most 50 requests at a time
 	for _, n := range notificationQueueItem {
 		n := n
-		_, err := db.IncrSentMessagesCount(NOTIFICAION_WEBHOOK_RATE_LIMIT_BUCKET, n.Content.UserId)
+		_, _, err := db.IncrSentMessagesCount(NOTIFICAION_WEBHOOK_RATE_LIMIT_BUCKET, n.Content.UserId, 1, -1)
 		if err != nil {
-			log.Error(err, "error counting sent webhook", 0)
+			log.Error(err, "error increasing sent discord count", 0)
 		}
 
 		// do not retry after 5 attempts
@@ -489,11 +489,11 @@ func SendTestEmail(ctx context.Context, userId types.UserId, dbConn *sqlx.DB) er
 }
 
 func SendTestWebhookNotification(ctx context.Context, userId types.UserId, webhookUrl string, isDiscordWebhook bool) error {
-	count, err := db.IncrSentMessagesCount("n_test_push", userId)
+	incr, _, err := db.IncrSentMessagesCount("n_test_push", userId, 1, 100)
 	if err != nil {
 		return err
 	}
-	if count > 100 {
+	if incr == 0 {
 		return fmt.Errorf("rate limit has been exceeded")
 	}
 


### PR DESCRIPTION
The mail sender does check the `maxEmailsPerDay` limit, but it increases the count anyways which results in wrong numbers being shown.

Fixed & renamed the count setter + added a getter method for clarity.