### PR TITLE
BEDS 1140/vali group

### DIFF
--- a/backend/pkg/api/data_access/dummy.go
+++ b/backend/pkg/api/data_access/dummy.go
@@ -808,3 +808,7 @@ func (d *DummyService) GetPairedDeviceUserId(ctx context.Context, pairedDeviceId
 func (d *DummyService) GetHasUserActiveSubscription(ctx context.Context, userId uint64) (bool, error) {
 	return getDummyData[bool](ctx)
 }
+
+func (d *DummyService) GetValidatorDashboardValidatorsOfList(ctx context.Context, dashboardId t.VDBIdPrimary, validators []t.VDBValidator) ([]t.VDBValidator, error) {
+	return getDummyData[[]t.VDBValidator](ctx)
+}

--- a/backend/pkg/api/data_access/vdb.go
+++ b/backend/pkg/api/data_access/vdb.go
@@ -29,6 +29,7 @@ type ValidatorDashboardRepository interface {
 	GetValidatorDashboardGroupCount(ctx context.Context, dashboardId t.VDBIdPrimary) (uint64, error)
 	GetValidatorDashboardGroupExists(ctx context.Context, dashboardId t.VDBIdPrimary, groupId uint64) (bool, error)
 
+	GetValidatorDashboardValidatorsOfList(ctx context.Context, dashboardId t.VDBIdPrimary, validators []t.VDBValidator) ([]t.VDBValidator, error)
 	AddValidatorDashboardValidators(ctx context.Context, dashboardId t.VDBIdPrimary, groupId uint64, validators []t.VDBValidator) ([]t.VDBPostValidatorsData, error)
 	AddValidatorDashboardValidatorsByDepositAddress(ctx context.Context, dashboardId t.VDBIdPrimary, groupId uint64, address string, limit uint64) ([]t.VDBPostValidatorsData, error)
 	AddValidatorDashboardValidatorsByWithdrawalCredential(ctx context.Context, dashboardId t.VDBIdPrimary, groupId uint64, credential string, limit uint64) ([]t.VDBPostValidatorsData, error)

--- a/backend/pkg/api/data_access/vdb_management.go
+++ b/backend/pkg/api/data_access/vdb_management.go
@@ -827,6 +827,28 @@ func (d *DataAccessService) AddValidatorDashboardValidators(ctx context.Context,
 	return result, nil
 }
 
+func (d *DataAccessService) GetValidatorDashboardValidatorsOfList(ctx context.Context, dashboardId t.VDBIdPrimary, validators []t.VDBValidator) ([]t.VDBValidator, error) {
+	var result []uint64
+
+	ds := goqu.Dialect("postgres").
+		Select(goqu.L("DISTINCT uvdv.validator_index")).
+		From(goqu.I("users_val_dashboards_validators").As("uvdv")).
+		Where(goqu.L("uvdv.dashboard_id = ?", dashboardId)).
+		Where(goqu.L("uvdv.validator_index = ANY(?)", pq.Array(validators)))
+
+	query, args, err := ds.Prepared(true).ToSQL()
+	if err != nil {
+		return nil, err
+	}
+
+	err = d.alloyReader.SelectContext(ctx, &result, query, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 // Updates the group for validators already in the dashboard linked to the deposit address.
 // Adds up to limit new validators associated with the deposit address, if not already in the dashboard.
 func (d *DataAccessService) AddValidatorDashboardValidatorsByDepositAddress(ctx context.Context, dashboardId t.VDBIdPrimary, groupId uint64, address string, limit uint64) ([]t.VDBPostValidatorsData, error) {

--- a/backend/pkg/api/handlers/public.go
+++ b/backend/pkg/api/handlers/public.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/gobitfly/beaconchain/pkg/api/enums"
 	"github.com/gobitfly/beaconchain/pkg/api/types"
+	"github.com/gobitfly/beaconchain/pkg/commons/utils"
 	"github.com/gorilla/mux"
 	"github.com/shopspring/decimal"
 )
@@ -554,9 +557,7 @@ func (h *HandlerService) PublicPostValidatorDashboardValidators(w http.ResponseW
 		return
 	}
 	var limit uint64
-	if isUserAdmin(userInfo) {
-		limit = math.MaxUint32 // no limit for admins
-	} else if dashboardLimit >= existingValidatorCount {
+	if dashboardLimit > existingValidatorCount {
 		limit = dashboardLimit - existingValidatorCount
 	}
 
@@ -574,10 +575,25 @@ func (h *HandlerService) PublicPostValidatorDashboardValidators(w http.ResponseW
 			handleErr(w, r, err)
 			return
 		}
-		if len(validators) > int(limit) {
-			validators = validators[:limit]
+		// get validators that are already in the dashboard
+		existingValidatorsInDashboard, err := h.getDataAccessor(ctx).GetValidatorDashboardValidatorsOfList(ctx, dashboardId, validators)
+		if err != nil {
+			handleErr(w, r, err)
+			return
 		}
-		data, dataErr = h.getDataAccessor(ctx).AddValidatorDashboardValidators(ctx, dashboardId, groupId, validators)
+		// add up to `limit` validators that are not already in the dashboard to the list
+		validatorMap := utils.SliceToMap(existingValidatorsInDashboard)
+		slices.Sort(validators)
+		for i := 0; i < len(validators) && limit > 0; i++ {
+			validator := validators[i]
+			if _, ok := validatorMap[validator]; ok {
+				continue
+			}
+			validatorMap[validator] = struct{}{}
+			limit--
+		}
+		// add validators to dashboard
+		data, dataErr = h.getDataAccessor(ctx).AddValidatorDashboardValidators(ctx, dashboardId, groupId, slices.Collect(maps.Keys(validatorMap)))
 
 	case req.DepositAddress != "":
 		depositAddress := v.checkRegex(reEthereumAddress, req.DepositAddress, "deposit_address")

--- a/backend/pkg/api/handlers/public.go
+++ b/backend/pkg/api/handlers/public.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"math"
 	"net/http"
+	"regexp"
 	"slices"
 	"time"
 
@@ -565,59 +566,16 @@ func (h *HandlerService) PublicPostValidatorDashboardValidators(w http.ResponseW
 	var dataErr error
 	switch {
 	case req.Validators != nil:
-		indices, pubkeys := v.checkValidators(req.Validators, forbidEmpty)
-		if v.hasErrors() {
-			handleErr(w, r, v)
-			return
-		}
-		validators, err := h.getDataAccessor(ctx).GetValidatorsFromSlices(ctx, indices, pubkeys)
-		if err != nil {
-			handleErr(w, r, err)
-			return
-		}
-		// get validators that are already in the dashboard
-		existingValidatorsInDashboard, err := h.getDataAccessor(ctx).GetValidatorDashboardValidatorsOfList(ctx, dashboardId, validators)
-		if err != nil {
-			handleErr(w, r, err)
-			return
-		}
-		// add up to `limit` validators that are not already in the dashboard to the list
-		validatorMap := utils.SliceToMap(existingValidatorsInDashboard)
-		slices.Sort(validators)
-		for i := 0; i < len(validators) && limit > 0; i++ {
-			validator := validators[i]
-			if _, ok := validatorMap[validator]; ok {
-				continue
-			}
-			validatorMap[validator] = struct{}{}
-			limit--
-		}
-		// add validators to dashboard
-		data, dataErr = h.getDataAccessor(ctx).AddValidatorDashboardValidators(ctx, dashboardId, groupId, slices.Collect(maps.Keys(validatorMap)))
+		data, dataErr = h.addValidatorDashboardValidatorsBySlice(r, dashboardId, groupId, limit, req.Validators)
 
 	case req.DepositAddress != "":
-		depositAddress := v.checkRegex(reEthereumAddress, req.DepositAddress, "deposit_address")
-		if v.hasErrors() {
-			handleErr(w, r, v)
-			return
-		}
-		data, dataErr = h.getDataAccessor(ctx).AddValidatorDashboardValidatorsByDepositAddress(ctx, dashboardId, groupId, depositAddress, limit)
+		data, dataErr = h.addValidatorDashboardValidators(r, dashboardId, groupId, limit, req.DepositAddress, "deposit_address", reEthereumAddress, h.getDataAccessor(ctx).AddValidatorDashboardValidatorsByDepositAddress)
 
 	case req.WithdrawalCredential != "":
-		withdrawalCredential := v.checkRegex(reWithdrawalCredential, req.WithdrawalCredential, "withdrawal_credential")
-		if v.hasErrors() {
-			handleErr(w, r, v)
-			return
-		}
-		data, dataErr = h.getDataAccessor(ctx).AddValidatorDashboardValidatorsByWithdrawalCredential(ctx, dashboardId, groupId, withdrawalCredential, limit)
+		data, dataErr = h.addValidatorDashboardValidators(r, dashboardId, groupId, limit, req.WithdrawalCredential, "withdrawal_credential", reWithdrawalCredential, h.getDataAccessor(ctx).AddValidatorDashboardValidatorsByWithdrawalCredential)
 
 	case req.Graffiti != "":
-		graffiti := v.checkRegex(reGraffiti, req.Graffiti, "graffiti")
-		if v.hasErrors() {
-			handleErr(w, r, v)
-			return
-		}
-		data, dataErr = h.getDataAccessor(ctx).AddValidatorDashboardValidatorsByGraffiti(ctx, dashboardId, groupId, graffiti, limit)
+		data, dataErr = h.addValidatorDashboardValidators(r, dashboardId, groupId, limit, req.Graffiti, "graffiti", reGraffiti, h.getDataAccessor(ctx).AddValidatorDashboardValidatorsByGraffiti)
 	}
 
 	if dataErr != nil {
@@ -629,6 +587,55 @@ func (h *HandlerService) PublicPostValidatorDashboardValidators(w http.ResponseW
 	}
 
 	returnCreated(w, r, response)
+}
+
+func (h *HandlerService) addValidatorDashboardValidatorsBySlice(r *http.Request, dashboardId types.VDBIdPrimary, groupId uint64, limit uint64, validatorsParam []intOrString) ([]types.VDBPostValidatorsData, error) {
+	var v validationError
+	indices, pubkeys := v.checkValidators(validatorsParam, forbidEmpty)
+	if v.hasErrors() {
+		return nil, v
+	}
+	ctx := r.Context()
+	validators, err := h.getDataAccessor(ctx).GetValidatorsFromSlices(ctx, indices, pubkeys)
+	if err != nil {
+		return nil, err
+	}
+	// get validators that are already in the dashboard
+	existingValidatorsInDashboard, err := h.getDataAccessor(ctx).GetValidatorDashboardValidatorsOfList(ctx, dashboardId, validators)
+	if err != nil {
+		return nil, err
+	}
+	// add up to `limit` validators that are not already in the dashboard to the list
+	validatorMap := utils.SliceToMap(existingValidatorsInDashboard)
+	slices.Sort(validators)
+	for i := 0; i < len(validators) && limit > 0; i++ {
+		validator := validators[i]
+		if _, ok := validatorMap[validator]; ok {
+			continue
+		}
+		validatorMap[validator] = struct{}{}
+		limit--
+	}
+	// add validators to dashboard
+	return h.getDataAccessor(ctx).AddValidatorDashboardValidators(ctx, dashboardId, groupId, slices.Collect(maps.Keys(validatorMap)))
+}
+
+func (h *HandlerService) addValidatorDashboardValidators(
+	r *http.Request,
+	dashboardId types.VDBIdPrimary,
+	groupId uint64,
+	limit uint64,
+	param string,
+	paramName string,
+	validationRegex *regexp.Regexp,
+	addFunc func(ctx context.Context, dashboardId types.VDBIdPrimary, groupId uint64, address string, limit uint64) ([]types.VDBPostValidatorsData, error),
+) ([]types.VDBPostValidatorsData, error) {
+	var v validationError
+	validatedParam := v.checkRegex(validationRegex, param, paramName)
+	if v.hasErrors() {
+		return nil, v
+	}
+	return addFunc(r.Context(), dashboardId, groupId, validatedParam, limit)
 }
 
 // PublicGetValidatorDashboardValidators godoc

--- a/backend/pkg/commons/utils/utils.go
+++ b/backend/pkg/commons/utils/utils.go
@@ -241,10 +241,10 @@ func ConstantTimeDelay(start time.Time, intendedMinWait time.Duration) {
 	}
 }
 
-func SliceToMap[T comparable](s []T) map[T]bool {
-	m := make(map[T]bool)
+func SliceToMap[T comparable](s []T) map[T]struct{} {
+	m := make(map[T]struct{})
 	for _, v := range s {
-		m[v] = true
+		m[v] = struct{}{}
 	}
 	return m
 }

--- a/backend/pkg/commons/utils/utils_test.go
+++ b/backend/pkg/commons/utils/utils_test.go
@@ -1,0 +1,125 @@
+package utils
+
+import (
+	"maps"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Define a generic test case type.
+type sliceToMapTestCase[T comparable] struct {
+	name     string
+	input    []T
+	expected map[T]struct{}
+}
+
+// runSliceToMapTests is a generic helper that executes all test cases for a given type T.
+func runSliceToMapTests[T comparable](t *testing.T, testCases []sliceToMapTestCase[T]) {
+	for _, tc := range testCases {
+		// Capture tc to avoid issues with the loop variable in parallel tests.
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			result := SliceToMap(tc.input)
+			assert.True(t, maps.Equal(tc.expected, result))
+		})
+	}
+}
+
+//
+// Now, we can define our tests for various types.
+//
+
+// Test for int slices.
+func TestSliceToMap_Int(t *testing.T) {
+	testCases := []sliceToMapTestCase[int]{
+		{
+			name:     "nil slice",
+			input:    nil,
+			expected: map[int]struct{}{},
+		},
+		{
+			name:     "empty slice",
+			input:    []int{},
+			expected: map[int]struct{}{},
+		},
+		{
+			name:     "unique elements",
+			input:    []int{1, 2, 3, 4, 5},
+			expected: map[int]struct{}{1: {}, 2: {}, 3: {}, 4: {}, 5: {}},
+		},
+		{
+			name:     "duplicate elements",
+			input:    []int{1, 2, 2, 3, 3, 3, 4, 1, 1, 2, 2, 3, 3, 3, 1, 2, 4},
+			expected: map[int]struct{}{1: {}, 2: {}, 3: {}, 4: {}},
+		},
+	}
+
+	runSliceToMapTests(t, testCases)
+}
+
+// Test for string slices.
+func TestSliceToMap_String(t *testing.T) {
+	testCases := []sliceToMapTestCase[string]{
+		{
+			name:     "nil slice",
+			input:    nil,
+			expected: map[string]struct{}{},
+		},
+		{
+			name:     "empty slice",
+			input:    []string{},
+			expected: map[string]struct{}{},
+		},
+		{
+			name:     "unique elements",
+			input:    []string{"apple", "banana", "cherry"},
+			expected: map[string]struct{}{"apple": {}, "banana": {}, "cherry": {}},
+		},
+		{
+			name:     "duplicate elements",
+			input:    []string{"apple", "banana", "apple", "cherry", "banana", "cherry"},
+			expected: map[string]struct{}{"apple": {}, "banana": {}, "cherry": {}},
+		},
+	}
+
+	runSliceToMapTests(t, testCases)
+}
+
+// A custom struct type that is comparable.
+type testStruct struct {
+	ID   int
+	Name string
+}
+
+// Test for custom struct slices.
+func TestSliceToMap_CustomType(t *testing.T) {
+	a := testStruct{ID: 1, Name: "Alice"}
+	b := testStruct{ID: 2, Name: "Bob"}
+	c := testStruct{ID: 3, Name: "Charlie"}
+
+	testCases := []sliceToMapTestCase[testStruct]{
+		{
+			name:     "nil slice",
+			input:    nil,
+			expected: map[testStruct]struct{}{},
+		},
+		{
+			name:     "empty slice",
+			input:    []testStruct{},
+			expected: map[testStruct]struct{}{},
+		},
+		{
+			name:     "unique elements",
+			input:    []testStruct{a, b, c},
+			expected: map[testStruct]struct{}{a: {}, b: {}, c: {}},
+		},
+		{
+			name:     "duplicate elements",
+			input:    []testStruct{a, b, a, a, b},
+			expected: map[testStruct]struct{}{a: {}, b: {}},
+		},
+	}
+
+	runSliceToMapTests(t, testCases)
+}


### PR DESCRIPTION
- if a validator was part of a dashboard and that dashboard had reached its limit, the validators group couldn't be changed when providing an index list
- fixed by this PR