### PR TITLE
refactor: separate validation, response and business logic

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -23,7 +23,7 @@ jobs:
         working-directory: ./backend
         run: |
           export TERM=xterm
-          go test `go list ./... | grep -v "pkg/consapi\|pkg/api\|internal/th\|internal/contracts\|pkg/commons/types\|pkg/commons/contracts\|cmd"` -coverprofile coverage.out -covermode atomic -race
+          go test `go list ./... | grep -v "pkg/consapi\|internal/th\|internal/contracts\|pkg/commons/types\|pkg/commons/contracts\|cmd"` -coverprofile coverage.out -covermode atomic -race
 
       - name: coverage
         working-directory: ./backend

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/golang-lru v1.0.2
 	github.com/hashicorp/golang-lru/v2 v2.0.7
+	github.com/holiman/uint256 v1.3.1
 	github.com/invopop/jsonschema v0.12.0
 	github.com/jackc/pgconn v1.14.3
 	github.com/jackc/pgtype v1.14.2
@@ -189,7 +190,6 @@ require (
 	github.com/herumi/bls-eth-go-binary v1.31.0 // indirect
 	github.com/holiman/billy v0.0.0-20240216141850-2abb0c79d3c4 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
-	github.com/holiman/uint256 v1.3.1 // indirect
 	github.com/huandu/go-clone v1.6.0 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/imkira/go-interpol v1.1.0 // indirect

--- a/backend/pkg/api/auth.go
+++ b/backend/pkg/api/auth.go
@@ -87,3 +87,14 @@ func csrfInjecterMiddleware(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 	})
 }
+
+func contentTypeMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// if body is not empty, check if content type is set to json
+		if (r.Method == http.MethodPost || r.Method == http.MethodPut) && r.ContentLength > 0 && r.Header.Get("Content-Type") != "application/json" {
+			http.Error(w, "bad request: Content-Type header must be application/json", http.StatusBadRequest)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/backend/pkg/api/handlers/auth.go
+++ b/backend/pkg/api/handlers/auth.go
@@ -226,7 +226,7 @@ func (h *HandlerService) InternalPostUsers(w http.ResponseWriter, r *http.Reques
 		Email    string `json:"email"`
 		Password string `json:"password"`
 	}{}
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -321,7 +321,7 @@ func (h *HandlerService) InternalPostUserPasswordReset(w http.ResponseWriter, r 
 	req := struct {
 		Email string `json:"email"`
 	}{}
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -360,7 +360,7 @@ func (h *HandlerService) InternalPostUserPasswordResetHash(w http.ResponseWriter
 	req := struct {
 		Password string `json:"password"`
 	}{}
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -428,7 +428,7 @@ func (h *HandlerService) InternalPostLogin(w http.ResponseWriter, r *http.Reques
 		Email    string `json:"email"`
 		Password string `json:"password"`
 	}{}
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -563,7 +563,7 @@ func (h *HandlerService) InternalPostMobileEquivalentExchange(w http.ResponseWri
 		RefreshToken string `json:"refresh_token"`
 		DeviceID     string `json:"client_id"`
 	}{}
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -629,7 +629,7 @@ func (h *HandlerService) InternalPostUsersMeNotificationSettingsPairedDevicesTok
 	req := struct {
 		Token string `json:"token"`
 	}{}
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -658,7 +658,7 @@ const USER_SUBSCRIPTION_LIMIT = 8
 func (h *HandlerService) InternalHandleMobilePurchase(w http.ResponseWriter, r *http.Request) {
 	var v validationError
 	req := types.MobileSubscription{}
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -794,7 +794,7 @@ func (h *HandlerService) InternalPostUserEmail(w http.ResponseWriter, r *http.Re
 		Email    string `json:"new_email"`
 		Password string `json:"password"`
 	}{}
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -869,7 +869,7 @@ func (h *HandlerService) InternalPutUserPassword(w http.ResponseWriter, r *http.
 		OldPassword string `json:"old_password"`
 		NewPassword string `json:"new_password"`
 	}{}
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}

--- a/backend/pkg/api/handlers/handler_service.go
+++ b/backend/pkg/api/handlers/handler_service.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/gobitfly/beaconchain/pkg/commons/log"
+	"github.com/gorilla/mux"
 	"github.com/invopop/jsonschema"
 
 	"github.com/alexedwards/scs/v2"
@@ -50,7 +51,9 @@ func NewHandlerService(dataAccessor dataaccess.DataAccessor, dummy dataaccess.Da
 // if the request is mocked, the data access dummy is returned; otherwise the data access service.
 // should only be used if getting mocked data for the endpoint is appropriate
 func (h *HandlerService) getDataAccessor(ctx context.Context) dataaccess.DataAccessor {
-	if isMocked, ok := ctx.Value(types.CtxIsMockedKey).(bool); ok && isMocked {
+	isMocked, isMockedOk := ctx.Value(types.CtxIsMockedKey).(bool)                         // set in StoreIsMockedFlagMiddleware
+	isMockingAllowed, isMockingAllowedOk := ctx.Value(types.CtxIsMockingAllowedKey).(bool) // set in Handle function
+	if isMockedOk && isMocked && isMockingAllowedOk && isMockingAllowed {
 		return h.daDummy
 	}
 	return h.daService
@@ -58,6 +61,45 @@ func (h *HandlerService) getDataAccessor(ctx context.Context) dataaccess.DataAcc
 
 // all networks available in the system, filled on startup in NewHandlerService
 var allNetworks []types.NetworkInfo
+
+type InputValidator[T any] interface {
+	Validate(params map[string]string, payload io.ReadCloser) (T, error)
+}
+
+type BusinessLogicFunc[Input any, Response any] func(ctx context.Context, input Input) (Response, error)
+
+func Handle[Input InputValidator[Input], Response any](defaultCode int, logicFunc BusinessLogicFunc[Input, Response], isMockingAllowed bool) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// prepare input
+		vars := mux.Vars(r)
+		q := r.URL.Query()
+		for k, v := range q {
+			if _, ok := vars[k]; ok || len(v) == 0 {
+				continue
+			}
+			vars[k] = v[0]
+		}
+		// input validation
+		var i Input
+		input, err := i.Validate(vars, r.Body)
+		if err != nil {
+			handleErr(w, r, err)
+			return
+		}
+		ctx := r.Context()
+		if isMockingAllowed {
+			ctx = context.WithValue(ctx, types.CtxIsMockingAllowedKey, true)
+		}
+		// business logic
+		response, err := logicFunc(ctx, input)
+		if err != nil {
+			handleErr(w, r, err)
+			return
+		}
+
+		writeResponse(w, r, defaultCode, response)
+	}
+}
 
 // --------------------------------------
 // errors

--- a/backend/pkg/api/handlers/handler_service.go
+++ b/backend/pkg/api/handlers/handler_service.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -123,33 +122,6 @@ type validatorSet struct {
 	PublicKeys []string
 }
 
-// parseDashboardId is a helper function to validate the string dashboard id param.
-func parseDashboardId(id string) (interface{}, error) {
-	var v validationError
-	if reInteger.MatchString(id) {
-		// given id is a normal id
-		id := v.checkUint(id, "dashboard_id")
-		if v.hasErrors() {
-			return nil, v
-		}
-		return types.VDBIdPrimary(id), nil
-	}
-	if reValidatorDashboardPublicId.MatchString(id) {
-		// given id is a public id
-		return types.VDBIdPublic(id), nil
-	}
-	// given id must be an encoded set of validators
-	decodedId, err := base64.RawURLEncoding.DecodeString(id)
-	if err != nil {
-		return nil, newBadRequestErr("given value '%s' is not a valid dashboard id", id)
-	}
-	indexes, publicKeys := v.checkValidatorList(string(decodedId), forbidEmpty)
-	if v.hasErrors() {
-		return nil, newBadRequestErr("given value '%s' is not a valid dashboard id", id)
-	}
-	return validatorSet{Indexes: indexes, PublicKeys: publicKeys}, nil
-}
-
 // getDashboardId is a helper function to convert the dashboard id param to a VDBId.
 // precondition: dashboardIdParam must be a valid dashboard id and either a primary id, public id, or list of validators.
 func (h *HandlerService) getDashboardId(ctx context.Context, dashboardIdParam interface{}) (*types.VDBId, error) {
@@ -187,8 +159,9 @@ func (h *HandlerService) handleDashboardId(ctx context.Context, param string) (*
 		return dashboardId, nil
 	}
 	// validate dashboard id param
-	dashboardIdParam, err := parseDashboardId(param)
-	if err != nil {
+	var v validationError
+	dashboardIdParam := v.checkDashboardId(param)
+	if err := v.AsError(); err != nil {
 		return nil, err
 	}
 	// convert to VDBId

--- a/backend/pkg/api/handlers/input_validation.go
+++ b/backend/pkg/api/handlers/input_validation.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"bytes"
 	"cmp"
 	"encoding/json"
 	"fmt"
@@ -142,14 +141,8 @@ func (v *validationError) checkUserEmailToken(token string) string {
 
 // check request structure (body contains valid json and all required parameters are present)
 // return error only if internal error occurs, otherwise add error to validationError and/or return nil
-func (v *validationError) checkBody(data interface{}, r *http.Request) error {
-	// check if content type is application/json
-	if contentType := r.Header.Get("Content-Type"); !reJsonContentType.MatchString(contentType) {
-		v.add("request body", "'Content-Type' header must be 'application/json'")
-	}
-
-	bodyBytes, err := io.ReadAll(r.Body)
-	r.Body = io.NopCloser(bytes.NewReader(bodyBytes)) // unconsume body for error logging
+func (v *validationError) checkBody(data interface{}, requestBody io.ReadCloser) error {
+	bodyBytes, err := io.ReadAll(requestBody)
 	if err != nil {
 		return newInternalServerErr("error reading request body")
 	}

--- a/backend/pkg/api/handlers/input_validation.go
+++ b/backend/pkg/api/handlers/input_validation.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"cmp"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -92,6 +93,13 @@ func (v *validationError) add(paramName, problem string) {
 
 func (v *validationError) hasErrors() bool {
 	return v != nil && len(*v) > 0
+}
+
+func (v *validationError) AsError() error {
+	if v.hasErrors() {
+		return newBadRequestErr("%s", v.Error())
+	}
+	return nil
 }
 
 // --------------------------------------
@@ -552,4 +560,29 @@ func (v *validationError) checkTimestamps(r *http.Request, chartLimits ChartTime
 
 		return afterTs, beforeTs
 	}
+}
+
+func (v *validationError) checkDashboardId(id string) interface{} {
+	if reInteger.MatchString(id) {
+		// given id is a normal id
+		id := v.checkUint(id, "dashboard_id")
+		return types.VDBIdPrimary(id)
+	}
+	if reValidatorDashboardPublicId.MatchString(id) {
+		// given id is a public id
+		return types.VDBIdPublic(id)
+	}
+	// given id must be an encoded set of validators
+	decodedId, err := base64.RawURLEncoding.DecodeString(id)
+	if err != nil {
+		v.add("dashboard_id", fmt.Sprintf("given value '%s' is not a valid dashboard id", id))
+		return nil
+	}
+	var validatorListError validationError
+	indexes, publicKeys := validatorListError.checkValidatorList(string(decodedId), forbidEmpty)
+	if validatorListError.hasErrors() {
+		v.add("dashboard_id", fmt.Sprintf("given value '%s' is not a valid dashboard id", id))
+		return nil
+	}
+	return validatorSet{Indexes: indexes, PublicKeys: publicKeys}
 }

--- a/backend/pkg/api/handlers/internal.go
+++ b/backend/pkg/api/handlers/internal.go
@@ -348,10 +348,6 @@ func (h *HandlerService) InternalPutValidatorDashboardName(w http.ResponseWriter
 	h.PublicPutValidatorDashboardName(w, r)
 }
 
-func (h *HandlerService) InternalPostValidatorDashboardGroups(w http.ResponseWriter, r *http.Request) {
-	h.PublicPostValidatorDashboardGroups(w, r)
-}
-
 func (h *HandlerService) InternalPutValidatorDashboardGroups(w http.ResponseWriter, r *http.Request) {
 	h.PublicPutValidatorDashboardGroups(w, r)
 }
@@ -431,11 +427,6 @@ func (h *HandlerService) InternalGetValidatorDashboardSlotViz(w http.ResponseWri
 func (h *HandlerService) InternalGetValidatorDashboardSummary(w http.ResponseWriter, r *http.Request) {
 	h.PublicGetValidatorDashboardSummary(w, r)
 }
-
-func (h *HandlerService) InternalGetValidatorDashboardGroupSummary(w http.ResponseWriter, r *http.Request) {
-	h.PublicGetValidatorDashboardGroupSummary(w, r)
-}
-
 func (h *HandlerService) InternalGetValidatorDashboardSummaryChart(w http.ResponseWriter, r *http.Request) {
 	h.PublicGetValidatorDashboardSummaryChart(w, r)
 }

--- a/backend/pkg/api/handlers/internal.go
+++ b/backend/pkg/api/handlers/internal.go
@@ -106,7 +106,7 @@ func (h *HandlerService) InternalPostAdConfigurations(w http.ResponseWriter, r *
 	}
 
 	var req types.AdConfigurationData
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -183,7 +183,7 @@ func (h *HandlerService) InternalPutAdConfiguration(w http.ResponseWriter, r *ht
 
 	key := v.checkKeyNotEmpty(mux.Vars(r)["key"])
 	var req types.AdConfigurationUpdateData
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}

--- a/backend/pkg/api/handlers/public.go
+++ b/backend/pkg/api/handlers/public.go
@@ -168,7 +168,7 @@ func (h *HandlerService) PublicPostValidatorDashboards(w http.ResponseWriter, r 
 		Network intOrString `json:"network" swaggertype:"string" enums:"ethereum,gnosis"`
 	}
 	var req request
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -312,7 +312,7 @@ func (h *HandlerService) PublicPutValidatorDashboardName(w http.ResponseWriter, 
 		Name string `json:"name"`
 	}
 	var req request
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -353,7 +353,7 @@ func (h *HandlerService) PublicPostValidatorDashboardGroups(w http.ResponseWrite
 		Name string `json:"name"`
 	}
 	var req request
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -419,7 +419,7 @@ func (h *HandlerService) PublicPutValidatorDashboardGroups(w http.ResponseWriter
 		Name string `json:"name"`
 	}
 	var req request
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -557,7 +557,7 @@ func (h *HandlerService) PublicPostValidatorDashboardValidators(w http.ResponseW
 	req := request{
 		GroupId: types.DefaultGroupId, // default value
 	}
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -766,7 +766,7 @@ func (h *HandlerService) PublicPostValidatorDashboardValidatorBulkDeletions(w ht
 		Validators []intOrString `json:"validators"`
 	}
 	var req request
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -813,7 +813,7 @@ func (h *HandlerService) PublicPostValidatorDashboardPublicIds(w http.ResponseWr
 		} `json:"share_settings"`
 	}
 	var req request
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -869,7 +869,7 @@ func (h *HandlerService) PublicPutValidatorDashboardPublicId(w http.ResponseWrit
 		} `json:"share_settings"`
 	}
 	var req request
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -962,7 +962,7 @@ func (h *HandlerService) PublicPutValidatorDashboardArchiving(w http.ResponseWri
 		IsArchived bool `json:"is_archived"`
 	}
 	var req request
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -2271,7 +2271,7 @@ func (h *HandlerService) PublicPutUserNotificationSettingsGeneral(w http.Respons
 		return
 	}
 	var req types.NotificationSettingsGeneral
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -2347,7 +2347,7 @@ func (h *HandlerService) PublicPutUserNotificationSettingsNetworks(w http.Respon
 		IsNewRewardRoundSubscribed    bool    `json:"is_new_reward_round_subscribed"`
 	}
 	var req request
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -2411,7 +2411,7 @@ func (h *HandlerService) PublicPutUserNotificationSettingsPairedDevices(w http.R
 		IsNotificationsEnabled bool   `json:"is_notifications_enabled"`
 	}
 	var req request
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -2512,7 +2512,7 @@ func (h *HandlerService) PublicPutUserNotificationSettingsClient(w http.Response
 		IsSubscribed bool `json:"is_subscribed"`
 	}
 	var req request
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -2622,7 +2622,7 @@ func (h *HandlerService) PublicPutUserNotificationSettingsValidatorDashboard(w h
 	}
 
 	var req types.NotificationSettingsValidatorDashboard
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -2695,7 +2695,7 @@ func (h *HandlerService) PublicPutUserNotificationSettingsAccountDashboard(w htt
 		IsERC1155TokenTransfersSubscribed bool    `json:"is_erc1155_token_transfers_subscribed"`
 	}
 	var req request
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}
@@ -2802,7 +2802,7 @@ func (h *HandlerService) PublicPostUserNotificationsTestWebhook(w http.ResponseW
 		IsWebhookDiscordEnabled bool   `json:"is_webhook_discord_enabled,omitempty"`
 	}
 	var req request
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}

--- a/backend/pkg/api/handlers/public.go
+++ b/backend/pkg/api/handlers/public.go
@@ -333,70 +333,6 @@ func (h *HandlerService) PublicPutValidatorDashboardName(w http.ResponseWriter, 
 	returnOk(w, r, response)
 }
 
-// PublicPostValidatorDashboardGroups godoc
-//
-//	@Description	Create a new group in a specified validator dashboard.
-//	@Security		ApiKeyInHeader || ApiKeyInQuery
-//	@Tags			Validator Dashboard Management
-//	@Accept			json
-//	@Produce		json
-//	@Param			dashboard_id	path		integer												true	"The ID of the dashboard."
-//	@Param			request			body		handlers.PublicPostValidatorDashboardGroups.request	true	"request"
-//	@Success		201				{object}	types.ApiDataResponse[types.VDBPostCreateGroupData]
-//	@Failure		400				{object}	types.ApiErrorResponse
-//	@Failure		409				{object}	types.ApiErrorResponse	"Conflict. The request could not be performed by the server because the authenticated user has already reached their group limit."
-//	@Router			/validator-dashboards/{dashboard_id}/groups [post]
-func (h *HandlerService) PublicPostValidatorDashboardGroups(w http.ResponseWriter, r *http.Request) {
-	var v validationError
-	dashboardId := v.checkPrimaryDashboardId(mux.Vars(r)["dashboard_id"])
-	type request struct {
-		Name string `json:"name"`
-	}
-	var req request
-	if err := v.checkBody(&req, r.Body); err != nil {
-		handleErr(w, r, err)
-		return
-	}
-	name := v.checkNameNotEmpty(req.Name)
-	if v.hasErrors() {
-		handleErr(w, r, v)
-		return
-	}
-	ctx := r.Context()
-	// check if user has reached the maximum number of groups
-	userId, err := GetUserIdByContext(ctx)
-	if err != nil {
-		handleErr(w, r, err)
-		return
-	}
-	userInfo, err := h.getDataAccessor(ctx).GetUserInfo(ctx, userId)
-	if err != nil {
-		handleErr(w, r, err)
-		return
-	}
-	groupCount, err := h.getDataAccessor(ctx).GetValidatorDashboardGroupCount(ctx, dashboardId)
-	if err != nil {
-		handleErr(w, r, err)
-		return
-	}
-	if groupCount >= userInfo.PremiumPerks.ValidatorGroupsPerDashboard {
-		returnConflict(w, r, errors.New("maximum number of validator dashboard groups reached"))
-		return
-	}
-
-	data, err := h.getDataAccessor(ctx).CreateValidatorDashboardGroup(ctx, dashboardId, name)
-	if err != nil {
-		handleErr(w, r, err)
-		return
-	}
-
-	response := types.ApiDataResponse[types.VDBPostCreateGroupData]{
-		Data: *data,
-	}
-
-	returnCreated(w, r, response)
-}
-
 // PublicGetValidatorDashboardGroups godoc
 //
 //	@Description	Update a groups name in a specified validator dashboard.
@@ -1115,51 +1051,6 @@ func (h *HandlerService) PublicGetValidatorDashboardSummary(w http.ResponseWrite
 	response := types.GetValidatorDashboardSummaryResponse{
 		Data:   data,
 		Paging: *paging,
-	}
-	returnOk(w, r, response)
-}
-
-// PublicGetValidatorDashboardGroupSummary godoc
-//
-//	@Description	Get summary information for a specified group in a specified dashboard
-//	@Tags			Validator Dashboard
-//	@Produce		json
-//	@Param			dashboard_id	path		string	true	"The ID of the dashboard."
-//	@Param			group_id		path		integer	true	"The ID of the group."
-//	@Param			period			query		string	true	"Time period to get data for."	Enums(all_time, last_30d, last_7d, last_24h, last_1h)
-//	@Param			modes			query		string	false	"Provide a comma separated list of protocol modes which should be respected for validator calculations. Possible values are `rocket_pool``."
-//	@Success		200				{object}	types.GetValidatorDashboardGroupSummaryResponse
-//	@Failure		400				{object}	types.ApiErrorResponse
-//	@Router			/validator-dashboards/{dashboard_id}/groups/{group_id}/summary [get]
-func (h *HandlerService) PublicGetValidatorDashboardGroupSummary(w http.ResponseWriter, r *http.Request) {
-	var v validationError
-	vars := mux.Vars(r)
-	ctx := r.Context()
-	dashboardId, err := h.handleDashboardId(ctx, vars["dashboard_id"])
-	q := r.URL.Query()
-	protocolModes := v.checkProtocolModes(q.Get("modes"))
-	if v.hasErrors() {
-		handleErr(w, r, v)
-		return
-	}
-	if err != nil {
-		handleErr(w, r, err)
-		return
-	}
-	groupId := v.checkGroupId(vars["group_id"], forbidEmpty)
-	period := checkEnum[enums.TimePeriod](&v, r.URL.Query().Get("period"), "period")
-	if v.hasErrors() {
-		handleErr(w, r, v)
-		return
-	}
-
-	data, err := h.getDataAccessor(ctx).GetValidatorDashboardGroupSummary(ctx, *dashboardId, groupId, period, protocolModes)
-	if err != nil {
-		handleErr(w, r, err)
-		return
-	}
-	response := types.GetValidatorDashboardGroupSummaryResponse{
-		Data: *data,
 	}
 	returnOk(w, r, response)
 }

--- a/backend/pkg/api/handlers/search.go
+++ b/backend/pkg/api/handlers/search.go
@@ -92,7 +92,7 @@ func (h *HandlerService) InternalPostSearch(w http.ResponseWriter, r *http.Reque
 		Networks []intOrString   `json:"networks,omitempty"`
 		Types    []searchTypeKey `json:"types,omitempty"`
 	}{}
-	if err := v.checkBody(&req, r); err != nil {
+	if err := v.checkBody(&req, r.Body); err != nil {
 		handleErr(w, r, err)
 		return
 	}

--- a/backend/pkg/api/handlers/validator_dashboard.go
+++ b/backend/pkg/api/handlers/validator_dashboard.go
@@ -1,0 +1,107 @@
+package handlers
+
+import (
+	"context"
+	"io"
+
+	"github.com/gobitfly/beaconchain/pkg/api/enums"
+	"github.com/gobitfly/beaconchain/pkg/api/types"
+)
+
+// PostValidatorDashboardGroups godoc
+//
+//	@Description	Create a new group in a specified validator dashboard.
+//	@Security		ApiKeyInHeader || ApiKeyInQuery
+//	@Tags			Validator Dashboard Management
+//	@Accept			json
+//	@Produce		json
+//	@Param			dashboard_id	path		integer												true	"The ID of the dashboard."
+//	@Param			request			body		types.PostValidatorDashboardGroupsRequest	true	"request"
+//	@Success		201				{object}	types.ApiDataResponse[types.VDBPostCreateGroupData]
+//	@Failure		400				{object}	types.ApiErrorResponse
+//	@Failure		409				{object}	types.ApiErrorResponse	"Conflict. The request could not be performed by the server because the authenticated user has already reached their group limit."
+//	@Router			/validator-dashboards/{dashboard_id}/groups [post]
+func (i inputPostValidatorDashboardGroups) Validate(params map[string]string, body io.ReadCloser) (inputPostValidatorDashboardGroups, error) {
+	var v validationError
+	var req types.PostValidatorDashboardGroupsRequest
+	if err := v.checkBody(&req, body); err != nil {
+		return i, err
+	}
+	i.dashboardId = v.checkPrimaryDashboardId(params["dashboard_id"])
+	i.name = v.checkNameNotEmpty(req.Name)
+	return i, v.AsError()
+}
+
+type inputPostValidatorDashboardGroups struct {
+	dashboardId types.VDBIdPrimary
+	name        string
+}
+
+func (h *HandlerService) PostValidatorDashboardGroups(ctx context.Context, input inputPostValidatorDashboardGroups) (types.ApiDataResponse[types.VDBPostCreateGroupData], error) {
+	var r types.ApiDataResponse[types.VDBPostCreateGroupData]
+	dataAccessor := h.getDataAccessor(ctx)
+	userId, err := GetUserIdByContext(ctx)
+	if err != nil {
+		return r, err
+	}
+	userInfo, err := dataAccessor.GetUserInfo(ctx, userId)
+	if err != nil {
+		return r, err
+	}
+	groupCount, err := dataAccessor.GetValidatorDashboardGroupCount(ctx, input.dashboardId)
+	if err != nil {
+		return r, err
+	}
+	if groupCount >= userInfo.PremiumPerks.ValidatorGroupsPerDashboard {
+		return r, newConflictErr("maximum number of validator dashboard groups reached")
+	}
+
+	data, err := dataAccessor.CreateValidatorDashboardGroup(ctx, input.dashboardId, input.name)
+	if err != nil {
+		return r, err
+	}
+	r.Data = *data
+	return r, nil
+}
+
+// GetValidatorDashboardGroupSummary godoc
+//
+//	@Description	Get summary information for a specified group in a specified dashboard
+//	@Tags			Validator Dashboard
+//	@Produce		json
+//	@Param			dashboard_id	path		string	true	"The ID of the dashboard."
+//	@Param			group_id		path		integer	true	"The ID of the group."
+//	@Param			period			query		string	true	"Time period to get data for."	Enums(all_time, last_30d, last_7d, last_24h, last_1h)
+//	@Param			modes			query		string	false	"Provide a comma separated list of protocol modes which should be respected for validator calculations. Possible values are `rocket_pool``."
+//	@Success		200				{object}	types.GetValidatorDashboardGroupSummaryResponse
+//	@Failure		400				{object}	types.ApiErrorResponse
+//	@Router			/validator-dashboards/{dashboard_id}/groups/{group_id}/summary [get]
+func (i inputGetValidatorDashboardGroupSummary) Validate(params map[string]string, _ io.ReadCloser) (inputGetValidatorDashboardGroupSummary, error) {
+	var v validationError
+	i.dashboardIdParam = v.checkDashboardId(params["dashboard_id"])
+	i.groupId = v.checkGroupId(params["group_id"], forbidEmpty)
+	i.period = checkEnum[enums.TimePeriod](&v, params["period"], "period")
+	i.protocolModes = v.checkProtocolModes(params["modes"])
+	return i, v.AsError()
+}
+
+type inputGetValidatorDashboardGroupSummary struct {
+	dashboardIdParam interface{}
+	groupId          int64
+	protocolModes    types.VDBProtocolModes
+	period           enums.TimePeriod
+}
+
+func (h *HandlerService) GetValidatorDashboardGroupSummary(ctx context.Context, input inputGetValidatorDashboardGroupSummary) (types.GetValidatorDashboardGroupSummaryResponse, error) {
+	var r types.GetValidatorDashboardGroupSummaryResponse
+	dashboardId, err := h.getDashboardId(ctx, input.dashboardIdParam)
+	if err != nil {
+		return r, err
+	}
+	data, err := h.getDataAccessor(ctx).GetValidatorDashboardGroupSummary(ctx, *dashboardId, input.groupId, input.period, input.protocolModes)
+	if err != nil {
+		return r, err
+	}
+	r.Data = *data
+	return r, nil
+}

--- a/backend/pkg/api/handlers/validator_dashboard_test.go
+++ b/backend/pkg/api/handlers/validator_dashboard_test.go
@@ -1,0 +1,133 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	dataaccess "github.com/gobitfly/beaconchain/pkg/api/data_access"
+	"github.com/gobitfly/beaconchain/pkg/api/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// ------------------------------------------------------------
+
+type dataAccessStub struct {
+	dataaccess.DummyService
+}
+
+func (da *dataAccessStub) GetUserInfo(ctx context.Context, id uint64) (*types.UserInfo, error) {
+	return &types.UserInfo{
+		PremiumPerks: types.PremiumPerks{
+			ValidatorGroupsPerDashboard: 1,
+		},
+	}, nil
+}
+
+func (da *dataAccessStub) GetValidatorDashboardGroupCount(ctx context.Context, dashboardId types.VDBIdPrimary) (uint64, error) {
+	var count uint64
+	if dashboardId == 1 {
+		count = 1
+	}
+	return count, nil
+}
+
+// ------------------------------------------------------------
+
+func handlerTestSetup() (context.Context, *HandlerService) {
+	ctx := context.WithValue(context.Background(), types.CtxUserIdKey, uint64(1))
+	da := &dataAccessStub{}
+	return ctx, NewHandlerService(da, da, nil, false)
+}
+
+func stringAsBody(s string) io.ReadCloser {
+	return io.NopCloser(strings.NewReader(s))
+}
+
+// ------------------------------------------------------------
+
+func TestInputPostValidatorDashboardGroupsValidate(t *testing.T) {
+	var i inputPostValidatorDashboardGroups
+	params := make(map[string]string)
+	t.Run("success", func(t *testing.T) {
+		params["dashboard_id"] = "1"
+		body := stringAsBody(`{"name":"test"}`)
+		i, err := i.Validate(params, body)
+		assert.Nil(t, err)
+		assert.Equal(t, types.VDBIdPrimary(1), i.dashboardId)
+		assert.Equal(t, "test", i.name)
+	})
+	t.Run("empty name", func(t *testing.T) {
+		params["dashboard_id"] = "1"
+		body := stringAsBody(`{"name":""}`)
+		_, err := i.Validate(params, body)
+		assert.NotNil(t, err)
+	})
+}
+func TestPostValidatorDashboardGroups(t *testing.T) {
+	ctx, h := handlerTestSetup()
+
+	t.Run("success", func(t *testing.T) {
+		input := inputPostValidatorDashboardGroups{
+			dashboardId: 0,
+			name:        "test",
+		}
+		_, err := h.PostValidatorDashboardGroups(ctx, input)
+		assert.Nil(t, err)
+	})
+	t.Run("group count reached", func(t *testing.T) {
+		input := inputPostValidatorDashboardGroups{
+			dashboardId: 1,
+			name:        "test",
+		}
+		_, err := h.PostValidatorDashboardGroups(ctx, input)
+		assert.NotNil(t, err)
+		assert.True(t, errors.Is(err, errConflict))
+	})
+}
+
+// ------------------------------------------------------------
+
+func TestInputGetValidatorDashboardGroupSummaryValidate(t *testing.T) {
+	var i inputGetValidatorDashboardGroupSummary
+	t.Run("success", func(t *testing.T) {
+		params := map[string]string{
+			"dashboard_id": "1",
+			"group_id":     "1",
+			"period":       "all_time",
+		}
+		i, err := i.Validate(params, nil)
+		assert.Nil(t, err)
+		assert.Equal(t, types.VDBIdPrimary(1), i.dashboardIdParam)
+		assert.Equal(t, int64(1), i.groupId)
+	})
+	t.Run("empty dashboard_id", func(t *testing.T) {
+		params := map[string]string{
+			"dashboard_id": "",
+			"group_id":     "1",
+			"period":       "all_time",
+		}
+		_, err := i.Validate(params, nil)
+		assert.NotNil(t, err)
+	})
+	t.Run("empty group_id", func(t *testing.T) {
+		params := map[string]string{
+			"dashboard_id": "1",
+			"group_id":     "",
+			"period":       "all_time",
+		}
+		_, err := i.Validate(params, nil)
+		assert.NotNil(t, err)
+	})
+	t.Run("empty period", func(t *testing.T) {
+		params := map[string]string{
+			"dashboard_id": "1",
+			"group_id":     "1",
+			"period":       "",
+		}
+		_, err := i.Validate(params, nil)
+		assert.NotNil(t, err)
+	})
+}

--- a/backend/pkg/api/router.go
+++ b/backend/pkg/api/router.go
@@ -285,6 +285,7 @@ func addValidatorDashboardRoutes(hs *handlers.HandlerService, publicRouter, inte
 		internalDashboardRouter.Use(hs.VDBArchivedCheckMiddleware)
 	}
 
+	const allowMocking = true
 	endpoints := []endpoint{
 		{http.MethodGet, "/{dashboard_id}", hs.PublicGetValidatorDashboard, hs.InternalGetValidatorDashboard},
 		{http.MethodPut, "/{dashboard_id}/name", hs.PublicPutValidatorDashboardName, hs.InternalPutValidatorDashboardName},

--- a/backend/pkg/api/router.go
+++ b/backend/pkg/api/router.go
@@ -23,6 +23,7 @@ type endpoint struct {
 
 func NewApiRouter(dataAccessor dataaccess.DataAccessor, dummy dataaccess.DataAccessor, cfg *types.Config) *mux.Router {
 	router := mux.NewRouter()
+	router.Use(contentTypeMiddleware)
 	apiRouter := router.PathPrefix("/api").Subrouter()
 	publicRouter := apiRouter.PathPrefix("/v2").Subrouter()
 	legacyRouter := apiRouter.PathPrefix("/v1").Subrouter()

--- a/backend/pkg/api/router.go
+++ b/backend/pkg/api/router.go
@@ -289,7 +289,7 @@ func addValidatorDashboardRoutes(hs *handlers.HandlerService, publicRouter, inte
 	endpoints := []endpoint{
 		{http.MethodGet, "/{dashboard_id}", hs.PublicGetValidatorDashboard, hs.InternalGetValidatorDashboard},
 		{http.MethodPut, "/{dashboard_id}/name", hs.PublicPutValidatorDashboardName, hs.InternalPutValidatorDashboardName},
-		{http.MethodPost, "/{dashboard_id}/groups", hs.PublicPostValidatorDashboardGroups, hs.InternalPostValidatorDashboardGroups},
+		{http.MethodPost, "/{dashboard_id}/groups", handlers.Handle(http.StatusCreated, hs.PostValidatorDashboardGroups, allowMocking), handlers.Handle(http.StatusCreated, hs.PostValidatorDashboardGroups, allowMocking)},
 		{http.MethodPut, "/{dashboard_id}/groups/{group_id}", hs.PublicPutValidatorDashboardGroups, hs.InternalPutValidatorDashboardGroups},
 		{http.MethodDelete, "/{dashboard_id}/groups/{group_id}", hs.PublicDeleteValidatorDashboardGroup, hs.InternalDeleteValidatorDashboardGroup},
 		{http.MethodDelete, "/{dashboard_id}/groups/{group_id}/validators", hs.PublicDeleteValidatorDashboardGroupValidators, hs.InternalDeleteValidatorDashboardGroupValidators},
@@ -303,7 +303,7 @@ func addValidatorDashboardRoutes(hs *handlers.HandlerService, publicRouter, inte
 		{http.MethodGet, "/{dashboard_id}/slot-viz", hs.PublicGetValidatorDashboardSlotViz, hs.InternalGetValidatorDashboardSlotViz},
 		{http.MethodGet, "/{dashboard_id}/summary", hs.PublicGetValidatorDashboardSummary, hs.InternalGetValidatorDashboardSummary},
 		{http.MethodGet, "/{dashboard_id}/summary/validators", hs.PublicGetValidatorDashboardSummaryValidators, hs.InternalGetValidatorDashboardSummaryValidators},
-		{http.MethodGet, "/{dashboard_id}/groups/{group_id}/summary", hs.PublicGetValidatorDashboardGroupSummary, hs.InternalGetValidatorDashboardGroupSummary},
+		{http.MethodGet, "/{dashboard_id}/groups/{group_id}/summary", handlers.Handle(http.StatusOK, hs.GetValidatorDashboardGroupSummary, allowMocking), handlers.Handle(http.StatusOK, hs.GetValidatorDashboardGroupSummary, allowMocking)},
 		{http.MethodGet, "/{dashboard_id}/summary-chart", hs.PublicGetValidatorDashboardSummaryChart, hs.InternalGetValidatorDashboardSummaryChart},
 		{http.MethodGet, "/{dashboard_id}/rewards", hs.PublicGetValidatorDashboardRewards, hs.InternalGetValidatorDashboardRewards},
 		{http.MethodGet, "/{dashboard_id}/groups/{group_id}/rewards/{epoch}", hs.PublicGetValidatorDashboardGroupRewards, hs.InternalGetValidatorDashboardGroupRewards},

--- a/backend/pkg/api/types/data_access.go
+++ b/backend/pkg/api/types/data_access.go
@@ -332,5 +332,6 @@ type CtxKey string
 
 const CtxUserIdKey CtxKey = "user_id"
 const CtxIsMockedKey CtxKey = "is_mocked"
+const CtxIsMockingAllowedKey CtxKey = "is_mocking_allowed"
 const CtxMockSeedKey CtxKey = "mock_seed"
 const CtxDashboardIdKey CtxKey = "dashboard_id"

--- a/backend/pkg/api/types/validator_dashboard.go
+++ b/backend/pkg/api/types/validator_dashboard.go
@@ -374,3 +374,7 @@ type PostValidatorDashboardValidatorsRequest struct {
 	WithdrawalCredential string        `json:"withdrawal_credential,omitempty"`
 	Graffiti             string        `json:"graffiti,omitempty"`
 }
+
+type PostValidatorDashboardGroupsRequest struct {
+	Name string `json:"name"`
+}

--- a/frontend/types/api/validator_dashboard.ts
+++ b/frontend/types/api/validator_dashboard.ts
@@ -331,3 +331,6 @@ export interface PostValidatorDashboardValidatorsRequest {
   withdrawal_credential?: string;
   graffiti?: string;
 }
+export interface PostValidatorDashboardGroupsRequest {
+  name: string;
+}


### PR DESCRIPTION
Adds a pattern for splitting the HTTP logic from the business logic in the API handler funcs. Adds a few example test cases. Changes the test workflow to include these tests.