### PR TITLE
feat(backend ci): run unit test on push + check coverage

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -1,0 +1,39 @@
+name: backend-test.yml
+
+env:
+  # raise that threshold over time
+  COVERAGE_THRESHOLD: 2
+
+on:
+  push:
+    paths:
+      - 'backend/**'
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
+
+      - name: unit tests
+        working-directory: ./backend
+        run: |
+          export TERM=xterm
+          go test `go list ./... | grep -v "pkg/consapi\|pkg/api\|internal/th\|internal/contracts\|pkg/commons/types\|pkg/commons/contracts\|cmd"` -coverprofile coverage.out -covermode atomic -race
+
+      - name: coverage
+        working-directory: ./backend
+        run: |
+          echo "Quality Gate: checking test coverage is above threshold ..."
+          echo "Threshold             : $COVERAGE_THRESHOLD %"
+          totalCoverage=`go tool cover -func=coverage.out | grep ^total | grep -Eo '[0-9]+\.[0-9]+'`
+          echo "Current test coverage : $totalCoverage %"
+          if (( $(echo "$totalCoverage $COVERAGE_THRESHOLD" | awk '{print ($1 > $2)}') )); then
+              echo "OK"
+          else
+              echo "Current test coverage is below threshold. Please add more unit tests or adjust threshold to a lower value."
+              echo "Failed"
+              exit 1
+          fi

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -7,3 +7,4 @@ local_deployment/.env
 __gitignore
 cmd/playground
 pkg/api/docs/swagger.json
+coverage.out

--- a/backend/pkg/consapi/client_node_test.go
+++ b/backend/pkg/consapi/client_node_test.go
@@ -202,7 +202,7 @@ func TestGetEvents(t *testing.T) {
 
 	for event := range res {
 		if event.Error != nil {
-			t.Errorf("Error getting event: %v", event.Error)
+			t.Fatalf("Error getting event: %v", event.Error)
 		}
 
 		if event.Event == types.EventHead {


### PR DESCRIPTION
* run unit test and check coverage threshold on each push that modify `backend`
* skip `pkg/consapi` and `pkg/api` because they are not working right now
* skip `internal/th` it's a test helper package
* skip `internal/contracts` and `backend/pkg/commons/types` because it's mostly generated code

Feel free to suggest other packages to skip