### PR TITLE
refactor(dashboard): added unit tests for dashboard helpers

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -7,6 +7,7 @@ require (
 	cloud.google.com/go/secretmanager v1.14.1
 	firebase.google.com/go/v4 v4.14.1
 	github.com/ClickHouse/clickhouse-go/v2 v2.30.3
+	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/Gurpartap/storekit-go v0.0.0-20201205024111-36b6cd5c6a21
 	github.com/Tangui-Bitfly/ethsimtracer v0.0.0-20241031103622-e76546c3d9c1
 	github.com/alexedwards/scs/redisstore v0.0.0-20240316134038-7e11d57e8885

--- a/backend/pkg/api/data_access/general.go
+++ b/backend/pkg/api/data_access/general.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/gobitfly/beaconchain/pkg/api/types"
 	"github.com/gobitfly/beaconchain/pkg/commons/db"
+	"github.com/jmoiron/sqlx"
 )
 
 // retrieve (primary) ens name and optional name (=label) maintained by beaconcha.in, if present
@@ -130,4 +131,45 @@ func applySortAndPagination(defaultColumns []types.SortColumn, primary types.Sor
 	}
 
 	return queryOrder, queryWhere, nil
+}
+
+// Generic function to execute a query
+// Ensures T is a slice in compile-time
+// Retrieves multiple rows and stores them in a slice
+// Used when the query returns multiple results (e.g., SELECT * FROM users)
+// The destination must be a slice ([]T)
+func runQueryRows[T ~[]E, E any](ctx context.Context, db *sqlx.DB, ds *goqu.SelectDataset) (T, error) {
+	query, args, err := ds.Prepared(true).ToSQL()
+	if err != nil {
+		var zero T
+		return zero, fmt.Errorf("error preparing query: %w", err)
+	}
+
+	var result T // slice of type T
+	err = db.SelectContext(ctx, &result, query, args...)
+	if err != nil {
+		return result, fmt.Errorf("error executing query: %w", err)
+	}
+
+	return result, nil
+}
+
+// Generic function to execute a query
+// Retrieves a single row and stores it in a struct or variable
+// Used when the query is expected to return only one row (e.g., SELECT * FROM users WHERE id = ?)
+// The destination must be a single struct or variable (T)
+func runQuery[T any](ctx context.Context, db *sqlx.DB, ds *goqu.SelectDataset) (T, error) {
+	query, args, err := ds.Prepared(true).ToSQL()
+	if err != nil {
+		var zero T
+		return zero, fmt.Errorf("error preparing query: %w", err)
+	}
+
+	var result T
+	err = db.GetContext(ctx, &result, query, args...)
+	if err != nil {
+		return result, fmt.Errorf("error executing query: %w", err)
+	}
+
+	return result, nil
 }

--- a/backend/pkg/api/data_access/general_test.go
+++ b/backend/pkg/api/data_access/general_test.go
@@ -1,0 +1,78 @@
+package dataaccess
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/doug-martin/goqu/v9"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+)
+
+func SetupTestDB(t *testing.T) (*sqlx.DB, sqlmock.Sqlmock) {
+	mockDB, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	return sqlx.NewDb(mockDB, "sqlmock"), mock
+}
+
+func TestSelectContext(t *testing.T) {
+	sqlxDB, mock := SetupTestDB(t)
+	defer sqlxDB.Close()
+
+	ctx := context.Background()
+	ds := goqu.Dialect("postgres").From(goqu.I("users")).Select(goqu.C("id"), goqu.C("name"))
+
+	mockRows := sqlmock.NewRows([]string{"id", "name"}).
+		AddRow(1, "Rami").
+		AddRow(2, "Lucca").
+		AddRow(3, "Sasha").
+		AddRow(4, "Invis")
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT "id", "name" FROM "users"`)).WillReturnRows(mockRows)
+
+	type User struct {
+		ID   int    `db:"id"`
+		Name string `db:"name"`
+	}
+
+	var expectedUsers = []User{
+		{ID: 1, Name: "Rami"},
+		{ID: 2, Name: "Lucca"},
+		{ID: 3, Name: "Sasha"},
+		{ID: 4, Name: "Invis"},
+	}
+
+	result, err := runQueryRows[[]User](ctx, sqlxDB, ds)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedUsers, result)
+	assert.NoError(t, mock.ExpectationsWereMet())
+
+	// Invalid expression
+	// T is a slice, this will fail to compile
+	//_, err = runQueryRows[User](ctx, sqlxDB, ds)
+}
+
+func TestGetContext(t *testing.T) {
+	sqlxDB, mock := SetupTestDB(t)
+	defer sqlxDB.Close()
+
+	ctx := context.Background()
+	ds := goqu.Dialect("postgres").From(goqu.I("users")).Select(goqu.C("id"), goqu.C("name")).Where(goqu.Ex{"id": 1})
+
+	mockRows := sqlmock.NewRows([]string{"id", "name"}).AddRow(1, "Axel")
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT "id", "name" FROM "users" WHERE ("id" = $1)`)).WithArgs(1).WillReturnRows(mockRows)
+
+	type User struct {
+		ID   int    `db:"id"`
+		Name string `db:"name"`
+	}
+
+	var expectedUser = User{ID: 1, Name: "Axel"}
+
+	result, err := runQuery[User](ctx, sqlxDB, ds)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedUser, result)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/backend/pkg/api/data_access/mobile.go
+++ b/backend/pkg/api/data_access/mobile.go
@@ -428,7 +428,7 @@ func (d *DataAccessService) GetValidatorDashboardMobileValidators(ctx context.Co
 	var efficienciesMap map[uint64]float64
 	wg.Go(func() error {
 		var err error
-		clickhouseTable, _, err := d.getTablesForPeriod(period)
+		clickhouseTable, _, err := getTablesForPeriod(period)
 		if err != nil {
 			return err
 		}

--- a/backend/pkg/api/data_access/vdb_helpers.go
+++ b/backend/pkg/api/data_access/vdb_helpers.go
@@ -400,3 +400,217 @@ func (d *DataAccessService) calculateValidatorDashboardBalance(ctx context.Conte
 	}
 	return balances, nil
 }
+
+// Builds a query to select the maximum timestamp from the validator_dashboard_data view for an interval (epoch, hourly, daily, weekly)
+func buildLatestExportedChartQuery(view, dateColumn string) *goqu.SelectDataset {
+	return goqu.Dialect("postgres").From(view).Select(goqu.MAX(dateColumn))
+}
+
+// Converts a time.Time value into a Unix timestamp (uint64).
+func processLastExportedChartResult(ts time.Time) (uint64, error) {
+	return uint64(ts.Unix()), nil
+}
+
+// Retrieves the latest exported chart timestamp for a given aggregation level
+// 1. Determines the appropriate view and date column based on the aggregation type
+// 2. Constructs and executes the query to fetch the latest timestamp
+// 3. Converts the result into a Unix timestamp and returns it
+func (d *DataAccessService) GetLatestExportedChartTs(ctx context.Context, aggregation enums.ChartAggregation) (uint64, error) {
+	view, dateColumn, err := getViewAndDateColumn(aggregation)
+	if err != nil {
+		return 0, err
+	}
+
+	ds := buildLatestExportedChartQuery(view, dateColumn)
+
+	ts, err := runQuery[time.Time](ctx, d.clickhouseReader, ds)
+	if err != nil {
+		return 0, err
+	}
+
+	return processLastExportedChartResult(ts)
+}
+
+type SyncCommitteeResult struct {
+	ValidatorIndex uint64 `db:"validatorindex"`
+	Period         uint64 `db:"period"`
+}
+
+// Pass the latest (most recently finalized epoch)
+// to determine validators current and upcoming sync committees
+func (d *DataAccessService) getCurrentAndUpcomingSyncCommittees(ctx context.Context, latestEpoch uint64) (map[uint64]bool, map[uint64]bool, error) {
+	currentSyncPeriod := utils.SyncPeriodOfEpoch(latestEpoch)
+	ds := buildSyncCommitteeQuery(currentSyncPeriod)
+	queryResult, err := runQueryRows[[]SyncCommitteeResult](ctx, d.readerDb, ds)
+	if err != nil {
+		return nil, nil, err
+	}
+	return processSyncCommitteeResults(queryResult, utils.SyncPeriodOfEpoch(latestEpoch))
+}
+
+// Builds a query to fetch sync committee validators for the current and next period
+func buildSyncCommitteeQuery(currentSyncPeriod uint64) *goqu.SelectDataset {
+	return goqu.Dialect("postgres").
+		Select(
+			goqu.L("validatorindex"),
+			goqu.L("period"),
+		).
+		From("sync_committees").
+		Where(goqu.L("period IN (?, ?)", currentSyncPeriod, currentSyncPeriod+1))
+}
+
+// Processes query results and categorizes validators into current and upcoming sync committees
+func processSyncCommitteeResults(queryResult []SyncCommitteeResult, currentSyncPeriod uint64) (map[uint64]bool, map[uint64]bool, error) {
+	currentSyncCommitteeValidators := make(map[uint64]bool)
+	upcomingSyncCommitteeValidators := make(map[uint64]bool)
+
+	for _, entry := range queryResult {
+		if entry.Period == currentSyncPeriod {
+			currentSyncCommitteeValidators[entry.ValidatorIndex] = true
+		} else {
+			upcomingSyncCommitteeValidators[entry.ValidatorIndex] = true
+		}
+	}
+
+	return currentSyncCommitteeValidators, upcomingSyncCommitteeValidators, nil
+}
+
+// Retrieves the start epoch for a given time period (last 1h, 24h, 7d, 30d)
+func (d *DataAccessService) getEpochStart(ctx context.Context, period enums.TimePeriod) (uint64, error) {
+	clickhouseTable, _, err := getTablesForPeriod(period)
+	if err != nil {
+		return 0, err
+	}
+
+	ds := buildEpochStartQuery(clickhouseTable)
+	epochStart, err := runQuery[uint64](ctx, d.clickhouseReader, ds)
+	if err != nil {
+		return 0, err
+	}
+
+	return epochStart, nil
+}
+
+// Builds a query to retrieve the earliest epoch start value
+// Orders results in ascending order and limits to the first row.
+func buildEpochStartQuery(table string) *goqu.SelectDataset {
+	return goqu.Dialect("postgres").
+		Select(goqu.L("epoch_start")).
+		From(goqu.L(fmt.Sprintf("%s FINAL", table))).
+		Order(goqu.L("epoch_start").Asc()).
+		Limit(1)
+}
+
+// Retrieves past sync committee validators for the given validator indices and epoch range
+// 1. Determines the sync period range from the epochStart and latestEpoch values
+// 2. Constructs a query to fetch validators who were part of past sync committees within the given range
+// 3. Processes the results to count occurrences of each validator in past committees
+func (d *DataAccessService) getPastSyncCommittees(ctx context.Context, indices []uint64, epochStart uint64, latestEpoch uint64) (map[uint64]uint64, error) {
+	pastSyncPeriodCutoff := utils.SyncPeriodOfEpoch(epochStart)
+	currentSyncPeriod := utils.SyncPeriodOfEpoch(latestEpoch)
+
+	ds := buildPastSyncCommitteesQuery(indices, pastSyncPeriodCutoff, currentSyncPeriod)
+
+	validatorIndices, err := runQueryRows[[]uint64](ctx, d.alloyReader, ds)
+	if err != nil {
+		return nil, err
+	}
+
+	return processPastSyncCommitteesResults(validatorIndices)
+}
+
+// Builds a query to retrieve past sync committee validators within a given sync period range
+func buildPastSyncCommitteesQuery(indices []uint64, pastSyncPeriodCutoff, currentSyncPeriod uint64) *goqu.SelectDataset {
+	return goqu.Dialect("postgres").
+		Select(goqu.L("sc.validatorindex")).
+		From(goqu.L("sync_committees sc")).
+		Where(goqu.L("period >= ? AND period < ? AND validatorindex = ANY(?)", pastSyncPeriodCutoff, currentSyncPeriod, pq.Array(indices)))
+}
+
+// Processes past sync committee results by counting occurrences of each validator
+func processPastSyncCommitteesResults(validatorIndices []uint64) (map[uint64]uint64, error) {
+	validatorCountMap := make(map[uint64]uint64)
+	for _, validatorIndex := range validatorIndices {
+		validatorCountMap[validatorIndex]++
+	}
+	return validatorCountMap, nil
+}
+
+// Determines the validator dashboard data table and associated time duration in hours
+// based on the given time period (1h, 24h, 7d, 30d, all_time)
+func getTablesForPeriod(period enums.TimePeriod) (string, int, error) {
+	table := ""
+	hours := 0
+
+	switch period {
+	case enums.TimePeriods.Last1h:
+		table = "validator_dashboard_data_rolling_1h"
+		hours = 1
+	case enums.TimePeriods.Last24h:
+		table = "validator_dashboard_data_rolling_24h"
+		hours = 24
+	case enums.TimePeriods.Last7d:
+		table = "validator_dashboard_data_rolling_7d"
+		hours = 7 * 24
+	case enums.TimePeriods.Last30d:
+		table = "validator_dashboard_data_rolling_30d"
+		hours = 30 * 24
+	case enums.TimePeriods.AllTime:
+		table = "validator_dashboard_data_rolling_total"
+		hours = -1
+	default:
+		return "", 0, fmt.Errorf("not-implemented time period: %v", period)
+	}
+
+	return table, hours, nil
+}
+
+// Retrieves the validator dashboard data table and corresponding date column
+// for a given chart aggregation range (epoch, hourly, daily, weekly)
+func getTableAndDateColumn(aggregation enums.ChartAggregation) (string, string, error) {
+	var table, dateColumn string
+
+	switch aggregation {
+	case enums.IntervalEpoch:
+		table = "validator_dashboard_data_epoch"
+		dateColumn = "epoch_timestamp"
+	case enums.IntervalHourly:
+		table = "validator_dashboard_data_hourly"
+		dateColumn = "t"
+	case enums.IntervalDaily:
+		table = "validator_dashboard_data_daily"
+		dateColumn = "t"
+	case enums.IntervalWeekly:
+		table = "validator_dashboard_data_weekly"
+		dateColumn = "t"
+	default:
+		return "", "", fmt.Errorf("unexpected aggregation type: %v", aggregation)
+	}
+
+	return table, dateColumn, nil
+}
+
+// Retrieves the validator dashboard data view and corresponding date column
+// for a given chart aggregation range (epoch, hourly, daily, weekly)
+func getViewAndDateColumn(aggregation enums.ChartAggregation) (string, string, error) {
+	var view, dateColumn string
+
+	switch aggregation {
+	case enums.IntervalEpoch:
+		view = "view_validator_dashboard_data_epoch_max_ts"
+		dateColumn = "t"
+	case enums.IntervalHourly:
+		view = "view_validator_dashboard_data_hourly_max_ts"
+		dateColumn = "t"
+	case enums.IntervalDaily:
+		view = "view_validator_dashboard_data_daily_max_ts"
+		dateColumn = "t"
+	case enums.IntervalWeekly:
+		view = "view_validator_dashboard_data_weekly_max_ts"
+		dateColumn = "t"
+	default:
+		return "", "", fmt.Errorf("unexpected aggregation type: %v", aggregation)
+	}
+
+	return view, dateColumn, nil
+}

--- a/backend/pkg/api/data_access/vdb_helpers_test.go
+++ b/backend/pkg/api/data_access/vdb_helpers_test.go
@@ -1,0 +1,386 @@
+package dataaccess
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gobitfly/beaconchain/pkg/api/enums"
+	"github.com/gobitfly/beaconchain/pkg/commons/types"
+	"github.com/gobitfly/beaconchain/pkg/commons/utils"
+	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupConfig() {
+	cfg := types.Config{
+		Chain: types.Chain{
+			ClConfig: types.ClChainConfig{
+				EpochsPerSyncCommitteePeriod: 32,
+				AltairForkEpoch:              0,
+			},
+		},
+	}
+	utils.Config = &cfg
+}
+
+func setupTestDataAccess(t *testing.T) (da *DataAccessService, mock sqlmock.Sqlmock) {
+	setupConfig()
+
+	mockDB, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	sqlxDB := sqlx.NewDb(mockDB, "sqlmock")
+	dataAccess := &DataAccessService{
+		clickhouseReader: sqlxDB,
+		readerDb:         sqlxDB,
+		alloyReader:      sqlxDB,
+	}
+
+	return dataAccess, mock
+}
+
+func assertTestError(t *testing.T, actual error, expected string) {
+	if expected == "" {
+		assert.NoError(t, actual)
+	} else {
+		assert.EqualError(t, actual, expected)
+	}
+}
+
+func TestGetCurrentAndUpcomingSyncCommittees(t *testing.T) {
+	dataAccessService, mock := setupTestDataAccess(t)
+	defer dataAccessService.Close()
+
+	latestEpoch := uint64(128)
+	currentSyncPeriod := utils.SyncPeriodOfEpoch(latestEpoch)
+
+	tests := []struct {
+		name             string
+		mockRows         *sqlmock.Rows
+		mockError        error
+		expectedCurrent  map[uint64]bool
+		expectedUpcoming map[uint64]bool
+		expectedError    string
+	}{
+		{
+			name: "Valid data",
+			mockRows: sqlmock.NewRows([]string{"validatorindex", "period"}).
+				AddRow(1, currentSyncPeriod).
+				AddRow(2, currentSyncPeriod).
+				AddRow(3, currentSyncPeriod+1).
+				AddRow(4, currentSyncPeriod+1),
+			mockError:        nil,
+			expectedCurrent:  map[uint64]bool{1: true, 2: true},
+			expectedUpcoming: map[uint64]bool{3: true, 4: true},
+			expectedError:    "",
+		},
+		{
+			name:             "Database error",
+			mockRows:         nil,
+			mockError:        errors.New("db query failed"),
+			expectedCurrent:  nil,
+			expectedUpcoming: nil,
+			expectedError:    "error executing query: db query failed",
+		},
+		{
+			name:             "Empty result",
+			mockRows:         sqlmock.NewRows([]string{"validatorindex", "period"}),
+			mockError:        nil,
+			expectedCurrent:  map[uint64]bool{},
+			expectedUpcoming: map[uint64]bool{},
+			expectedError:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := `SELECT validatorindex, period FROM "sync_committees" WHERE period IN \(\$1, \$2\)`
+			if tt.mockError != nil {
+				mock.ExpectQuery(query).WillReturnError(tt.mockError)
+			} else {
+				mock.ExpectQuery(query).WillReturnRows(tt.mockRows)
+			}
+
+			ctx := context.Background()
+			current, upcoming, err := dataAccessService.getCurrentAndUpcomingSyncCommittees(ctx, latestEpoch)
+
+			assertTestError(t, err, tt.expectedError)
+			assert.Equal(t, tt.expectedCurrent, current)
+			assert.Equal(t, tt.expectedUpcoming, upcoming)
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestGetPastSyncCommittees(t *testing.T) {
+	dataAccessService, mock := setupTestDataAccess(t)
+	defer dataAccessService.Close()
+
+	tests := []struct {
+		name          string
+		indicies      []uint64
+		epochStart    uint64
+		latestEpoch   uint64
+		mockRows      *sqlmock.Rows
+		mockError     error
+		expectedMap   map[uint64]uint64
+		expectedError string
+	}{
+		{
+			name:        "Valid data",
+			indicies:    []uint64{1, 2, 3},
+			epochStart:  100,
+			latestEpoch: 200,
+			mockRows: sqlmock.NewRows([]string{"validatorindex"}).
+				AddRow(1).
+				AddRow(2).
+				AddRow(2),
+			mockError:     nil,
+			expectedMap:   map[uint64]uint64{1: 1, 2: 2},
+			expectedError: "",
+		},
+		{
+			name:          "Query error",
+			indicies:      []uint64{1, 2, 3},
+			epochStart:    100,
+			latestEpoch:   200,
+			mockRows:      nil,
+			mockError:     errors.New("db query failed"),
+			expectedMap:   nil,
+			expectedError: "error executing query: db query failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := "SELECT sc.validatorindex FROM sync_committees sc WHERE period >= $1 AND period < $2 AND validatorindex = ANY($3)"
+
+			if tt.mockError != nil {
+				mock.ExpectQuery(regexp.QuoteMeta(query)).
+					WithArgs(utils.SyncPeriodOfEpoch(tt.epochStart), utils.SyncPeriodOfEpoch(tt.latestEpoch), pq.Array(tt.indicies)).
+					WillReturnError(tt.mockError)
+			} else {
+				mock.ExpectQuery(regexp.QuoteMeta(query)).
+					WithArgs(utils.SyncPeriodOfEpoch(tt.epochStart), utils.SyncPeriodOfEpoch(tt.latestEpoch), pq.Array(tt.indicies)).
+					WillReturnRows(tt.mockRows)
+			}
+
+			ctx := context.Background()
+			result, err := dataAccessService.getPastSyncCommittees(ctx, tt.indicies, tt.epochStart, tt.latestEpoch)
+
+			assertTestError(t, err, tt.expectedError)
+			assert.Equal(t, tt.expectedMap, result)
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestGetLatestExportedChartTs(t *testing.T) {
+	dataAccessService, mock := setupTestDataAccess(t)
+	defer dataAccessService.Close()
+
+	// Define the test cases
+	tests := []struct {
+		name          string
+		aggregation   enums.ChartAggregation
+		mockRows      *sqlmock.Rows
+		mockError     error
+		expectedTs    uint64
+		expectedError string
+	}{
+		{
+			name:        "Valid data",
+			aggregation: enums.IntervalDaily,
+			mockRows: sqlmock.NewRows([]string{"max"}).
+				AddRow(time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)),
+			mockError:     nil,
+			expectedTs:    uint64(time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC).Unix()),
+			expectedError: "",
+		},
+		{
+			name:        "Invalid data type",
+			aggregation: enums.IntervalDaily,
+			mockRows: sqlmock.NewRows([]string{"max"}).
+				AddRow("invalid_timestamp"),
+			mockError:     nil,
+			expectedTs:    0,
+			expectedError: "error executing query: sql: Scan error on column index 0, name \"max\": unsupported Scan, storing driver.Value type string into type *time.Time",
+		},
+		{
+			name:          "Empty result",
+			aggregation:   enums.IntervalDaily,
+			mockRows:      sqlmock.NewRows([]string{"max"}),
+			mockError:     nil,
+			expectedTs:    0,
+			expectedError: "error executing query: sql: no rows in result set",
+		},
+		{
+			name:          "Query error",
+			aggregation:   enums.IntervalDaily,
+			mockRows:      nil,
+			mockError:     fmt.Errorf("db query failed"),
+			expectedTs:    0,
+			expectedError: "error executing query: db query failed",
+		},
+	}
+
+	// Run the test cases
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			view, dateColumn, err := getViewAndDateColumn(tt.aggregation)
+			assert.NoError(t, err)
+
+			// Mock the query
+			query := fmt.Sprintf("SELECT MAX\\(\"%s\"\\) FROM \"%s\"", dateColumn, view)
+			if tt.mockError != nil {
+				mock.ExpectQuery(query).WillReturnError(tt.mockError)
+			} else {
+				mock.ExpectQuery(query).WillReturnRows(tt.mockRows)
+			}
+
+			// Run the function under test
+			ctx := context.Background()
+			ts, err := dataAccessService.GetLatestExportedChartTs(ctx, enums.IntervalDaily)
+
+			assertTestError(t, err, tt.expectedError)
+			assert.Equal(t, tt.expectedTs, ts)
+
+			// Ensure all expectations are met
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestGetEpochStart(t *testing.T) {
+	dataAccessService, mock := setupTestDataAccess(t)
+	defer dataAccessService.Close()
+
+	tests := []struct {
+		name          string
+		period        enums.TimePeriod
+		mockRows      *sqlmock.Rows
+		mockError     error
+		expectedVal   uint64
+		expectedError string
+	}{
+		{
+			name:   "Valid data",
+			period: enums.Last24h,
+			mockRows: sqlmock.NewRows([]string{"epoch_start"}).
+				AddRow(12345),
+			mockError:     nil,
+			expectedVal:   12345,
+			expectedError: "",
+		},
+		{
+			name:   "Invalid data type",
+			period: enums.Last24h,
+			mockRows: sqlmock.NewRows([]string{"epoch_start"}).
+				AddRow("invalid_value"),
+			mockError:     nil,
+			expectedVal:   0,
+			expectedError: "error executing query: sql: Scan error on column index 0, name \"epoch_start\": converting driver.Value type string (\"invalid_value\") to a uint64: invalid syntax",
+		},
+		{
+			name:          "Empty result",
+			period:        enums.Last24h,
+			mockRows:      sqlmock.NewRows([]string{"epoch_start"}),
+			mockError:     nil,
+			expectedVal:   0,
+			expectedError: "error executing query: sql: no rows in result set",
+		},
+		{
+			name:          "Query error",
+			period:        enums.Last24h,
+			mockRows:      nil,
+			mockError:     fmt.Errorf("db query failed"),
+			expectedVal:   0,
+			expectedError: "error executing query: db query failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			table, _, err := getTablesForPeriod(tt.period)
+			assert.NoError(t, err)
+
+			query := fmt.Sprintf("SELECT epoch_start FROM %s FINAL ORDER BY epoch_start ASC LIMIT \\$1", table)
+			if tt.mockError != nil {
+				mock.ExpectQuery(query).WillReturnError(tt.mockError)
+			} else {
+				mock.ExpectQuery(query).WithArgs(1).WillReturnRows(tt.mockRows)
+			}
+
+			ctx := context.Background()
+			val, err := dataAccessService.getEpochStart(ctx, tt.period)
+			assertTestError(t, err, tt.expectedError)
+			assert.Equal(t, tt.expectedVal, val)
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+type getTableTestCase[T any, R1 any, R2 any] struct {
+	name      string
+	input     T
+	expected1 R1
+	expected2 R2
+	expectErr error
+}
+
+func runGetTableTest[T any, R1 any, R2 any](t *testing.T, cases []getTableTestCase[T, R1, R2], testFunc func(T) (R1, R2, error)) {
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result1, result2, err := testFunc(tc.input)
+
+			assert.Equal(t, tc.expected1, result1)
+			assert.Equal(t, tc.expected2, result2)
+			if tc.expectErr != nil {
+				assert.EqualError(t, err, tc.expectErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetTable(t *testing.T) {
+	t.Run("GetTablesForPeriod", func(t *testing.T) {
+		cases := []getTableTestCase[enums.TimePeriod, string, int]{
+			{"Last 1 hour", enums.TimePeriods.Last1h, "validator_dashboard_data_rolling_1h", 1, nil},
+			{"Last 24 hours", enums.TimePeriods.Last24h, "validator_dashboard_data_rolling_24h", 24, nil},
+			{"Last 7 days", enums.TimePeriods.Last7d, "validator_dashboard_data_rolling_7d", 7 * 24, nil},
+			{"Last 30 days", enums.TimePeriods.Last30d, "validator_dashboard_data_rolling_30d", 30 * 24, nil},
+			{"All time", enums.TimePeriods.AllTime, "validator_dashboard_data_rolling_total", -1, nil},
+			{"Invalid time period", enums.TimePeriod(999), "", 0, fmt.Errorf("not-implemented time period: %v", enums.TimePeriod(999))},
+		}
+		runGetTableTest(t, cases, getTablesForPeriod)
+	})
+
+	t.Run("GetTableAndDateColumn", func(t *testing.T) {
+		cases := []getTableTestCase[enums.ChartAggregation, string, string]{
+			{"Epoch aggregation", enums.IntervalEpoch, "validator_dashboard_data_epoch", "epoch_timestamp", nil},
+			{"Hourly aggregation", enums.IntervalHourly, "validator_dashboard_data_hourly", "t", nil},
+			{"Daily aggregation", enums.IntervalDaily, "validator_dashboard_data_daily", "t", nil},
+			{"Weekly aggregation", enums.IntervalWeekly, "validator_dashboard_data_weekly", "t", nil},
+			{"Invalid aggregation", enums.ChartAggregation(999), "", "", fmt.Errorf("unexpected aggregation type: %v", enums.ChartAggregation(999))},
+		}
+		runGetTableTest(t, cases, getTableAndDateColumn)
+	})
+
+	t.Run("GetViewAndDateColumn", func(t *testing.T) {
+		cases := []getTableTestCase[enums.ChartAggregation, string, string]{
+			{"Epoch aggregation", enums.IntervalEpoch, "view_validator_dashboard_data_epoch_max_ts", "t", nil},
+			{"Hourly aggregation", enums.IntervalHourly, "view_validator_dashboard_data_hourly_max_ts", "t", nil},
+			{"Daily aggregation", enums.IntervalDaily, "view_validator_dashboard_data_daily_max_ts", "t", nil},
+			{"Weekly aggregation", enums.IntervalWeekly, "view_validator_dashboard_data_weekly_max_ts", "t", nil},
+			{"Invalid aggregation", enums.ChartAggregation(999), "", "", fmt.Errorf("unexpected aggregation type: %v", enums.ChartAggregation(999))},
+		}
+		runGetTableTest(t, cases, getViewAndDateColumn)
+	})
+}

--- a/backend/pkg/api/data_access/vdb_summary.go
+++ b/backend/pkg/api/data_access/vdb_summary.go
@@ -37,7 +37,7 @@ func (d *DataAccessService) GetValidatorDashboardSummary(ctx context.Context, da
 	wg := errgroup.Group{}
 
 	// Get the table name based on the period
-	clickhouseTable, _, err := d.getTablesForPeriod(period)
+	clickhouseTable, _, err := getTablesForPeriod(period)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -517,7 +517,7 @@ func (d *DataAccessService) GetValidatorDashboardGroupSummary(ctx context.Contex
 	}
 
 	// Get the table names based on the period
-	clickhouseTable, hours, err := d.getTablesForPeriod(period)
+	clickhouseTable, hours, err := getTablesForPeriod(period)
 	if err != nil {
 		return nil, err
 	}
@@ -635,7 +635,7 @@ func (d *DataAccessService) GetValidatorDashboardGroupSummary(ctx context.Contex
 
 	getLastScheduledBlockAndSyncDate := func() (time.Time, time.Time, error) {
 		// we need to go to the all time table for last scheduled block/sync committee epoch
-		clickhouseTotalTable, _, err := d.getTablesForPeriod(enums.AllTime)
+		clickhouseTotalTable, _, err := getTablesForPeriod(enums.AllTime)
 		if err != nil {
 			return time.Time{}, time.Time{}, err
 		}
@@ -1000,24 +1000,9 @@ func (d *DataAccessService) GetValidatorDashboardSummaryChart(ctx context.Contex
 		return ret, nil
 	}
 
-	// log.Infof("retrieving data between %v and %v for aggregation %v", time.Unix(int64(afterTs), 0), time.Unix(int64(beforeTs), 0), aggregation)
-	dataTable := ""
-	dateColumn := ""
-	switch aggregation {
-	case enums.IntervalEpoch:
-		dataTable = "validator_dashboard_data_epoch"
-		dateColumn = "epoch_timestamp"
-	case enums.IntervalHourly:
-		dataTable = "validator_dashboard_data_hourly"
-		dateColumn = "t"
-	case enums.IntervalDaily:
-		dataTable = "validator_dashboard_data_daily"
-		dateColumn = "t"
-	case enums.IntervalWeekly:
-		dataTable = "validator_dashboard_data_weekly"
-		dateColumn = "t"
-	default:
-		return nil, fmt.Errorf("unexpected aggregation type: %v", aggregation)
+	dataTable, dateColumn, err := getTableAndDateColumn(aggregation)
+	if err != nil {
+		return ret, nil
 	}
 
 	var queryResults []*t.VDBValidatorSummaryChartRow
@@ -1197,36 +1182,6 @@ func (d *DataAccessService) GetValidatorDashboardSummaryChart(ctx context.Contex
 	return ret, nil
 }
 
-func (d *DataAccessService) GetLatestExportedChartTs(ctx context.Context, aggregation enums.ChartAggregation) (uint64, error) {
-	var table string
-	var dateColumn string
-	switch aggregation {
-	case enums.IntervalEpoch:
-		table = "view_validator_dashboard_data_epoch_max_ts"
-		dateColumn = "t"
-	case enums.IntervalHourly:
-		table = "view_validator_dashboard_data_hourly_max_ts"
-		dateColumn = "t"
-	case enums.IntervalDaily:
-		table = "view_validator_dashboard_data_daily_max_ts"
-		dateColumn = "t"
-	case enums.IntervalWeekly:
-		table = "view_validator_dashboard_data_weekly_max_ts"
-		dateColumn = "t"
-	default:
-		return 0, fmt.Errorf("unexpected aggregation type: %v", aggregation)
-	}
-
-	query := fmt.Sprintf(`SELECT max(%s) FROM %s`, dateColumn, table)
-	var ts time.Time
-	err := d.clickhouseReader.GetContext(ctx, &ts, query)
-	if err != nil {
-		return 0, fmt.Errorf("error retrieving latest exported chart timestamp: %w", err)
-	}
-
-	return uint64(ts.Unix()), nil
-}
-
 func (d *DataAccessService) GetValidatorDashboardSummaryValidators(ctx context.Context, dashboardId t.VDBId, groupId int64) (*t.VDBGeneralSummaryValidators, error) {
 	result := &t.VDBGeneralSummaryValidators{}
 
@@ -1347,12 +1302,6 @@ func (d *DataAccessService) GetValidatorDashboardSyncSummaryValidators(ctx conte
 	var resultMutex = &sync.RWMutex{}
 	wg := errgroup.Group{}
 
-	// Get the table name based on the period
-	clickhouseTable, _, err := d.getTablesForPeriod(period)
-	if err != nil {
-		return nil, err
-	}
-
 	// Get the validator indices
 	var groupIds []uint64
 	if !dashboardId.AggregateGroups && groupId != t.AllGroups {
@@ -1388,48 +1337,14 @@ func (d *DataAccessService) GetValidatorDashboardSyncSummaryValidators(ctx conte
 
 	// Get the past sync committee validators
 	wg.Go(func() error {
-		// Get the cutoff period for past sync committees
-		ds := goqu.Dialect("postgres").
-			Select(
-				goqu.L("epoch_start")).
-			From(goqu.L(fmt.Sprintf("%s FINAL", clickhouseTable))).
-			Order(goqu.L("epoch_start").Asc()).
-			Limit(1)
-
-		query, args, err := ds.Prepared(true).ToSQL()
+		epochStart, err := d.getEpochStart(ctx, period)
 		if err != nil {
-			return fmt.Errorf("error preparing query: %w", err)
+			return err
 		}
 
-		var epochStart uint64
-		err = d.clickhouseReader.GetContext(ctx, &epochStart, query, args...)
+		validatorCountMap, err := d.getPastSyncCommittees(ctx, validatorIndices, epochStart, cache.LatestEpoch.Get())
 		if err != nil {
-			return fmt.Errorf("error retrieving cutoff epoch for past sync committees: %w", err)
-		}
-		pastSyncPeriodCutoff := utils.SyncPeriodOfEpoch(epochStart)
-
-		// Get the past sync committee validators
-		currentSyncPeriod := utils.SyncPeriodOfEpoch(latestEpoch)
-		ds = goqu.Dialect("postgres").
-			Select(
-				goqu.L("sc.validatorindex")).
-			From(goqu.L("sync_committees sc")).
-			Where(goqu.L("period >= ? AND period < ? AND validatorindex = ANY(?)", pastSyncPeriodCutoff, currentSyncPeriod, pq.Array(validatorIndices)))
-
-		query, args, err = ds.Prepared(true).ToSQL()
-		if err != nil {
-			return fmt.Errorf("error preparing query: %w", err)
-		}
-
-		var validatorIndices []uint64
-		err = d.alloyReader.SelectContext(ctx, &validatorIndices, query, args...)
-		if err != nil {
-			return fmt.Errorf("error retrieving data for past sync committees: %w", err)
-		}
-
-		validatorCountMap := make(map[uint64]uint64)
-		for _, validatorIndex := range validatorIndices {
-			validatorCountMap[validatorIndex]++
+			return err
 		}
 
 		resultMutex.Lock()
@@ -1457,7 +1372,7 @@ func (d *DataAccessService) GetValidatorDashboardSlashingsSummaryValidators(ctx 
 	result := &t.VDBSlashingsSummaryValidators{}
 
 	// Get the table names based on the period
-	clickhouseTable, _, err := d.getTablesForPeriod(period)
+	clickhouseTable, _, err := getTablesForPeriod(period)
 	if err != nil {
 		return nil, err
 	}
@@ -1692,7 +1607,7 @@ func (d *DataAccessService) GetValidatorDashboardProposalSummaryValidators(ctx c
 	}
 
 	// Get the table name based on the period
-	clickhouseTable, _, err := d.getTablesForPeriod(period)
+	clickhouseTable, _, err := getTablesForPeriod(period)
 	if err != nil {
 		return nil, err
 	}
@@ -1789,69 +1704,4 @@ func (d *DataAccessService) GetValidatorDashboardProposalSummaryValidators(ctx c
 	}
 
 	return result, nil
-}
-
-func (d *DataAccessService) getCurrentAndUpcomingSyncCommittees(ctx context.Context, latestEpoch uint64) (map[uint64]bool, map[uint64]bool, error) {
-	currentSyncCommitteeValidators := make(map[uint64]bool)
-	upcomingSyncCommitteeValidators := make(map[uint64]bool)
-
-	currentSyncPeriod := utils.SyncPeriodOfEpoch(latestEpoch)
-	ds := goqu.Dialect("postgres").
-		Select(
-			goqu.L("validatorindex"),
-			goqu.L("period")).
-		From("sync_committees").
-		Where(goqu.L("period IN (?, ?)", currentSyncPeriod, currentSyncPeriod+1))
-
-	var queryResult []struct {
-		ValidatorIndex uint64 `db:"validatorindex"`
-		Period         uint64 `db:"period"`
-	}
-
-	query, args, err := ds.Prepared(true).ToSQL()
-	if err != nil {
-		return nil, nil, fmt.Errorf("error preparing query: %w", err)
-	}
-
-	err = d.readerDb.SelectContext(ctx, &queryResult, query, args...)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error retrieving sync committee current and next period data: %w", err)
-	}
-
-	for _, queryEntry := range queryResult {
-		if queryEntry.Period == currentSyncPeriod {
-			currentSyncCommitteeValidators[queryEntry.ValidatorIndex] = true
-		} else {
-			upcomingSyncCommitteeValidators[queryEntry.ValidatorIndex] = true
-		}
-	}
-
-	return currentSyncCommitteeValidators, upcomingSyncCommitteeValidators, nil
-}
-
-func (d *DataAccessService) getTablesForPeriod(period enums.TimePeriod) (string, int, error) {
-	clickhouseTable := ""
-	hours := 0
-
-	switch period {
-	case enums.TimePeriods.Last1h:
-		clickhouseTable = "validator_dashboard_data_rolling_1h"
-		hours = 1
-	case enums.TimePeriods.Last24h:
-		clickhouseTable = "validator_dashboard_data_rolling_24h"
-		hours = 24
-	case enums.TimePeriods.Last7d:
-		clickhouseTable = "validator_dashboard_data_rolling_7d"
-		hours = 7 * 24
-	case enums.TimePeriods.Last30d:
-		clickhouseTable = "validator_dashboard_data_rolling_30d"
-		hours = 30 * 24
-	case enums.TimePeriods.AllTime:
-		clickhouseTable = "validator_dashboard_data_rolling_total"
-		hours = -1
-	default:
-		return "", 0, fmt.Errorf("not-implemented time period: %v", period)
-	}
-
-	return clickhouseTable, hours, nil
 }


### PR DESCRIPTION
Before we cover functions like `GetValidatorDashboardSummary` or `GetValidatorDashboardGroupSummary` with unit tests we need to cleanup and refactor a codebase.

Helper functions to be moved to` vdb_helpers.go` to avoid mess in `vdb_dashboard.go`

Every function is split into build query, execute query, process results

Generic `executeQuery` function is added 