### PR TITLE
BEDS-1185 / use ubuntu-latest to enable caching

### DIFF
--- a/.github/workflows/backend-converted-types-check.yml
+++ b/.github/workflows/backend-converted-types-check.yml
@@ -13,6 +13,12 @@ on:
       - 'frontend/types/api/**'
     branches:
       - '*'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to run the workflow on'
+        required: true
+        default: 'staging'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -26,13 +32,14 @@ permissions:
 jobs:
   build:
     name: converted-types-check
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: 'backend/go.mod'
           cache-dependency-path: 'backend/go.sum'
+          cache: true
       - name: Check if all backend-types have been converted to frontend-types
         working-directory: backend
         run: |


### PR DESCRIPTION
use ubuntu-latest runner instead of self-hosted runner to hit and restore go cache without errors

Current solution with self-hosted runner needs to be changed, because it fails to restore cache:

```
Failed to restore: "/usr/bin/tar" failed with error: The process '/usr/bin/tar' failed with exit code 2
Cache Size: ~1458 MB ([1528826845](tel:1528826845) B)
/usr/bin/tar -xf /home/ubuntu/actions-runner/_work/_temp/71adc993-518c-4b34-bdca-ba61ad04eed5/cache.tzst -P -C /home/ubuntu/actions-runner/_work/beaconchain/beaconchain --use-compress-program unzstd
/usr/bin/tar: ../../../../go/pkg/mod/go.opentelemetry.io/auto/sdk@v1.1.0/limit_test.go: Cannot open: File exists
/usr/bin/tar: ../../../../go/pkg/mod/go.opentelemetry.io/auto/sdk@v1.1.0/tracer_provider.go: Cannot open: File exists
/usr/bin/tar: ../../../../go/pkg/mod/go.opentelemetry.io/auto/sdk@v1.1.0/go.sum: Cannot open: File exists
```