### PR TITLE
feat(BlockTableRewardItem): show `full precision` for rewards in tooltip 

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -10,6 +10,7 @@
         "BcPremiumModal",
         "BcTablePager",
         "BcToggle",
+        "BlockTableRewardItem",
         "DashboardChartSummary",
         "DashboardChartSummaryFilter",
         "DashboardGroupManagementModal",

--- a/frontend/components/bc/format/BcFormatAmount.vue
+++ b/frontend/components/bc/format/BcFormatAmount.vue
@@ -26,13 +26,14 @@ type FormatAmountOptions = (
       value: `${number}` | string,
     }
 ) & {
-  fractionDigits?: number,
   hasAdditionalSelectedCurrencyMain?: boolean,
   hasColor?: boolean,
   hasDashForZero?: boolean,
   hasHigherPrecision?: boolean,
   hasSignDisplay?: boolean,
   hasTooltip?: boolean,
+  maximumFractionDigits?: number,
+  minimumFractionDigits?: number,
   /**
    * @description
    * Display currencies take into account, that the currency in the binary data
@@ -133,8 +134,8 @@ const format = (value: string, optionsOverride?: Parameters<typeof formatAmount>
   return formatAmount(value, {
     hasHigherPrecision: props.hasHigherPrecision,
     hasUnitDisplay: getTargetUnit() !== 'base',
-    maximumFractionDigits: props.fractionDigits,
-    minimumFractionDigits: props.fractionDigits,
+    maximumFractionDigits: props.maximumFractionDigits,
+    minimumFractionDigits: props.minimumFractionDigits,
     signDisplay: signDisplay.value,
     sourceCurrency: sourceCurrency.value,
     targetCurrency: targetCurrency.value,

--- a/frontend/components/block/table/BlockTableRewardItem.vue
+++ b/frontend/components/block/table/BlockTableRewardItem.vue
@@ -34,7 +34,7 @@ defineProps<{
             source-currency="elCurrency"
             target-currency="elDisplayCurrency"
             has-additional-selected-currency-main
-            has-higher-precision
+            :maximum-fraction-digits="unitFactorCrypto.base"
           />
         </div>
         <div class="tt-row">
@@ -46,7 +46,7 @@ defineProps<{
               :value="reward?.cl"
               target-currency="clDisplayCurrency"
               has-additional-selected-currency-main
-              has-higher-precision
+              :maximum-fraction-digits="unitFactorCrypto.base"
             />
           </template>
           <span v-else>{{ $t("dashboard.validator.blocks.pending") }}</span>

--- a/frontend/components/dashboard/table/DashboardTableClDeposits.vue
+++ b/frontend/components/dashboard/table/DashboardTableClDeposits.vue
@@ -268,7 +268,7 @@ const {
                   <BcFormatAmount
                     :value="slotProps.data.amount"
                     target-currency="clDisplayCurrency"
-                    :fraction-digits="0"
+                    :maximum-fraction-digits="0"
                   />
                   <template
                     v-if="displayCurrencyDefault.consensusLayer !== selectedCurrencyMain"

--- a/frontend/components/dashboard/table/DashboardTableElDeposits.vue
+++ b/frontend/components/dashboard/table/DashboardTableElDeposits.vue
@@ -295,7 +295,7 @@ const {
                     :value="slotProps.data.amount"
                     source-currency="elCurrency"
                     target-currency="elDisplayCurrency"
-                    :fraction-digits="0"
+                    :maximum-fraction-digits="0"
                   />
                   <template
                     v-if="displayCurrencyDefault.executionLayer !== selectedCurrencyMain"

--- a/frontend/composables/useCurrency.ts
+++ b/frontend/composables/useCurrency.ts
@@ -103,9 +103,6 @@ export const useCurrency = () => {
    * @param {number} [options.maximumFractionDigits] - Defaults:
    *   - fiat: 2 (4 if hasHigherPrecision=true)
    *   - crypto: 6 (8 if hasHigherPrecision=true)
-   * @param {number} [options.minimumFractionDigits] - Default:
-   *   - fiat: 2 (4 if hasHigherPrecision=true)
-   *   - crypto: 6 (8 if hasHigherPrecision=true)
    * @returns {string} The formatted amount with currency code
    */
   const formatAmount = (
@@ -134,10 +131,7 @@ export const useCurrency = () => {
         hasHigherPrecision,
         targetCurrency,
       }),
-      minimumFractionDigits = getFractionDigitDefault({
-        hasHigherPrecision,
-        targetCurrency,
-      }),
+      minimumFractionDigits,
       signDisplay,
       sourceCurrency = clCurrency,
       sourceUnit = 'wei',


### PR DESCRIPTION
See: BEDS-1275