### PR TITLE
Add metrics for dropped events. Also renamed recently added notification queue to be status-generic

### DIFF
--- a/backend/pkg/commons/metrics/metrics.go
+++ b/backend/pkg/commons/metrics/metrics.go
@@ -74,6 +74,10 @@ var (
 		Name: "notifications_sent",
 		Help: "Counter of notifications sent with the channel and notification type in the label",
 	}, []string{"channel", "status"})
+	NotificationsDropped = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "notifications_dropped",
+		Help: "Counter of notifications deleted from the queue",
+	}, []string{"status"})
 	State = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "state",
 		Help: "Gauge for various states",
@@ -83,8 +87,8 @@ var (
 		Help: "Generic counter of events with name in labels",
 	}, []string{"name"})
 	NotificationsQueue_Event_Size = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "notifications_queue_event_pending_size",
-		Help: "Number of pending notifications in the queue by event type",
+		Name: "notifications_queue_event_size",
+		Help: "Number of notifications in the queue by event type and status",
 	}, []string{"event_type", "status"})
 	NotificationsQueue_Channel_Size = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "notifications_queue_channel_pending_size",
@@ -92,7 +96,7 @@ var (
 	}, []string{"channel", "status"})
 	NotificationsQueue_Pending_Time = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "notifications_queue_pending_duration_milliseconds",
-		Help: "Duration of still pending notifications in the queue",
+		Help: "How long pending notifications have been in the queue",
 	}, []string{"channel", "event_type"})
 	NotificationsQueue_Sent_Time = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "notifications_queue_sent_duration_milliseconds",

--- a/backend/pkg/commons/metrics/metrics.go
+++ b/backend/pkg/commons/metrics/metrics.go
@@ -91,8 +91,8 @@ var (
 		Help: "Number of notifications in the queue by event type and status",
 	}, []string{"event_type", "status"})
 	NotificationsQueue_Channel_Size = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "notifications_queue_channel_pending_size",
-		Help: "Number of pending notifications in the queue by channel",
+		Name: "notifications_queue_channel_size",
+		Help: "Number of notifications in the queue by channel and status",
 	}, []string{"channel", "status"})
 	NotificationsQueue_Pending_Time = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "notifications_queue_pending_duration_milliseconds",

--- a/backend/pkg/notification/sending.go
+++ b/backend/pkg/notification/sending.go
@@ -66,9 +66,14 @@ func notificationSender() {
 		// Record metrics related to Notification Queue like size of queue and duration of pending notifications
 		collectNotificationQueueMetrics()
 
-		err = garbageCollectNotificationQueue()
+		err = garbageCollectSentEvents()
 		if err != nil {
-			log.Error(err, "error garbage collecting notification queue", 0)
+			log.Error(err, "error garbage collecting sent notifications", 0)
+		}
+
+		err = garbageCollectOldPendingEvents()
+		if err != nil {
+			log.Error(err, "error garbage collecting old pending notifications", 0)
 		}
 
 		log.InfoWithFields(log.Fields{"duration": time.Since(start)}, "notifications dispatched and garbage collected")
@@ -109,16 +114,32 @@ func notificationSender() {
 	}
 }
 
-// garbageCollectNotificationQueue deletes entries from the notification queue that have been processed
-func garbageCollectNotificationQueue() error {
-	rows, err := db.WriterDb.Exec(`DELETE FROM notification_queue WHERE (sent < now() - INTERVAL '30 minutes') OR (created < now() - INTERVAL '1 hour')`)
+func garbageCollectSentEvents() error {
+	rows, err := db.WriterDb.Exec(`DELETE FROM notification_queue WHERE sent < now() - INTERVAL '30 minutes'`)
 	if err != nil {
-		return fmt.Errorf("error deleting from notification_queue %w", err)
+		return fmt.Errorf("error deleting sent events from notification_queue %w", err)
 	}
 
 	rowsAffected, _ := rows.RowsAffected()
 
-	log.Infof("deleted %v rows from the notification_queue", rowsAffected)
+	log.Infof("deleted %v sent events from the notification_queue", rowsAffected)
+
+	metrics.NotificationsDropped.WithLabelValues(string(Sent)).Add(float64(rowsAffected))
+
+	return nil
+}
+
+func garbageCollectOldPendingEvents() error {
+	rows, err := db.WriterDb.Exec(`DELETE FROM notification_queue WHERE created < now() - INTERVAL '1 hour'`)
+	if err != nil {
+		return fmt.Errorf("error deleting pending events from notification_queue %w", err)
+	}
+
+	rowsAffected, _ := rows.RowsAffected()
+
+	log.Infof("deleted %v old pending events from the notification_queue", rowsAffected)
+
+	metrics.NotificationsDropped.WithLabelValues(string(Pending)).Add(float64(rowsAffected))
 
 	return nil
 }

--- a/backend/pkg/notification/sending.go
+++ b/backend/pkg/notification/sending.go
@@ -689,6 +689,13 @@ func ExtractEventNameFromNotification(notification Notification) (*types.EventNa
 		}
 	}
 
+	// Also grab legacy labels, unfortunately some systems still submit these.
+	for eventName, eventDescription := range types.LegacyEventLabel {
+		if strings.Contains(notification.Content, eventDescription) {
+			return &eventName, nil
+		}
+	}
+
 	return nil, fmt.Errorf("no EventName found for notification %d matching any event descriptions", notification.Id)
 }
 


### PR DESCRIPTION
Add metrics for dropped events. Now we will be able to see how many events are removed from the queue, for each reason (i.e. removed because it was sent and is no longer relevant, or removed because it's been pending too long).

Also now includes LegacyEvents. These events were previously not able to get parsed and so were included in the metrics as "unknown_event".