### PR TITLE
fix(app): replace `user selected currency` with only `available curre…

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
     "conventionalCommits.scopes": [
-        "App",
         "BcButton",
         "BcDataWrapper",
         "BcFormatAmount",
@@ -38,6 +37,7 @@
         "NotificationsOverview",
         "NotificationsTableEmpty",
         "a11y",
+        "app",
         "checkout",
         "ci",
         "color-mode",

--- a/frontend/app.vue
+++ b/frontend/app.vue
@@ -16,6 +16,14 @@ useHead(
 useWindowSizeProvider()
 useBcToastProvider()
 useDateProvider()
+
+const { latestState } = storeToRefs(useLatestStateStore())
+const exchangeRates = computed(() => latestState.value?.exchange_rates ?? [])
+const exchangeRateLengthOnTestNetworks = 1
+if (exchangeRates.value.length === exchangeRateLengthOnTestNetworks) {
+  const { selectedCurrencyMain } = useCurrency()
+  selectedCurrencyMain.value = exchangeRates.value[0].code as CurrencyCode
+}
 </script>
 
 <template>


### PR DESCRIPTION
…ncy`

If you change networks and the `exchange rate` of the selected currency is not available anymore.