### PR TITLE
fix: display latest effective balance to unauthenticated users

### DIFF
--- a/frontend/components/bc/format/BcFormatAmount.vue
+++ b/frontend/components/bc/format/BcFormatAmount.vue
@@ -42,7 +42,7 @@ type FormatAmountOptions = (
    *
    * E.g.: we get mGno values but want to display them in GNO
    */
-  targetCurrency?: 'clDisplayCurrency' | 'elDisplayCurrency' | CurrencyCode,
+  targetCurrency?: 'clDisplayCurrency' | 'elDisplayCurrency' | 'mainDisplayCurrency' | CurrencyCode,
   targetUnitCrypto?: 'auto',
   zeroDisplay?: 'auto' | 'dash',
 }
@@ -110,6 +110,7 @@ const signDisplay = computed(() => {
 const targetCurrency = computed(() => {
   if (props.targetCurrency === 'elDisplayCurrency') return displayCurrencyDefault.executionLayer
   if (props.targetCurrency === 'clDisplayCurrency') return displayCurrencyDefault.consensusLayer
+  if (props.targetCurrency === 'mainDisplayCurrency') return displayCurrencyDefault.main
   if (!props.targetCurrency) return selectedCurrencyMain.value
   return props.targetCurrency
 })

--- a/frontend/components/dashboard/DashboardValidatorManagementModal.vue
+++ b/frontend/components/dashboard/DashboardValidatorManagementModal.vue
@@ -270,44 +270,25 @@ const totalValidators = computed(() => {
 })
 
 const {
-  displayCurrencyDefault,
-  formatAmount,
-} = useCurrency()
-const userDashboardStore = useUserDashboardStore()
-const {
-  dashboards,
-} = storeToRefs(userDashboardStore)
+  premiumProducts,
+} = useProductsStore()
 
-const currentEffectiveBalance = computed(() => {
-  const currentDashboard = dashboards.value?.validator_dashboards.find(
-    validatorDashboard => `${validatorDashboard.id}` === dashboardKey.value,
-  )
-  return currentDashboard?.effective_balance
-})
-
-const EFFECTIVE_BALANCE_LIMIT_GUEST_DASHBOARD_IN_ETH = '640'
-const effectiveBalanceLimitGuestDashboard = formatAmount(EFFECTIVE_BALANCE_LIMIT_GUEST_DASHBOARD_IN_ETH, {
-  hasCurrencyDisplay: false,
-  maximumFractionDigits: 0,
-  minimumFractionDigits: 0,
-  sourceUnit: 'base',
-  targetCurrency: displayCurrencyDefault.main,
-  targetUnit: 'wei',
-  useGrouping: false,
+const latestEffectiveBalance = computed(() => {
+  return overview.value?.balances.effective_latest
 })
 
 const effectiveBalanceLimitPerDashboard = computed(() => {
-  if (isGuestDashboard.value || !premium_perks.value?.effective_balance_per_dashboard) {
-    return effectiveBalanceLimitGuestDashboard
-  }
-  return premium_perks.value?.effective_balance_per_dashboard
+  const freeProduct = premiumProducts.value['Free']
+  const effectiveBalanceLimitFreeProduct = freeProduct?.premium_perks.effective_balance_per_dashboard
+
+  return premium_perks.value?.effective_balance_per_dashboard ?? effectiveBalanceLimitFreeProduct
 })
 
 const hasReachedLimit = computed(() => {
-  if (!currentEffectiveBalance.value || !effectiveBalanceLimitPerDashboard.value) {
+  if (!latestEffectiveBalance.value || !effectiveBalanceLimitPerDashboard.value) {
     return false
   }
-  return isGreaterEquals(currentEffectiveBalance.value, effectiveBalanceLimitPerDashboard.value)
+  return isGreaterEquals(latestEffectiveBalance.value, effectiveBalanceLimitPerDashboard.value)
 })
 
 const hasPremiumPerkBulkAdding = computed(() => !!premium_perks.value?.bulk_adding)
@@ -595,15 +576,15 @@ const inputValidator = ref('')
                 >
                   <span>
                     <BcFormatAmount
-                      :value="currentEffectiveBalance ?? '0'"
+                      :value="latestEffectiveBalance ?? '0'"
                       :maximum-fraction-digits="0"
-                      :source-currency="displayCurrencyDefault.main"
+                      :target-currency="displayCurrencyDefault.main"
                     />
                     /
                     <BcFormatAmount
-                      :value="effectiveBalanceLimitPerDashboard"
+                      :value="effectiveBalanceLimitPerDashboard || '0'"
                       :maximum-fraction-digits="0"
-                      :source-currency="displayCurrencyDefault.main"
+                      :target-currency="displayCurrencyDefault.main"
                     />
                   </span>
                 </div>

--- a/frontend/components/dashboard/DashboardValidatorManagementModal.vue
+++ b/frontend/components/dashboard/DashboardValidatorManagementModal.vue
@@ -578,13 +578,13 @@ const inputValidator = ref('')
                     <BcFormatAmount
                       :value="latestEffectiveBalance ?? '0'"
                       :maximum-fraction-digits="0"
-                      :target-currency="displayCurrencyDefault.main"
+                      target-currency="mainDisplayCurrency"
                     />
                     /
                     <BcFormatAmount
                       :value="effectiveBalanceLimitPerDashboard || '0'"
                       :maximum-fraction-digits="0"
-                      :target-currency="displayCurrencyDefault.main"
+                      target-currency="mainDisplayCurrency"
                     />
                   </span>
                 </div>

--- a/frontend/components/dashboard/DashboardValidatorOverview.vue
+++ b/frontend/components/dashboard/DashboardValidatorOverview.vue
@@ -133,7 +133,7 @@ const aprInfos = [
               {{ $t('dashboard.validator.overview.validators_balance.balance_effective') }}:
             </span>
             <BcFormatAmount
-              :value="overview?.balances.effective ?? '0'"
+              :value="overview?.balances.effective_current ?? '0'"
             />
           </section>
           <section>

--- a/frontend/pages/dashboard/[[id]]/index.vue
+++ b/frontend/pages/dashboard/[[id]]/index.vue
@@ -81,7 +81,6 @@ const {
   cookieDashboards,
   dashboards,
 } = storeToRefs(userDashboardStore)
-await useAsyncData('user_dashboards', () => refreshDashboards(), { watch: [ isLoggedIn ] })
 
 const seoTitle = computed(() => {
   return getDashboardLabel(dashboardKey.value, 'validator')
@@ -97,20 +96,24 @@ const {
   refreshOverview,
 } = validatorDashboardOverviewStore
 
-const currentEffectiveBalance = computed(() => {
-  const currentDashboard = dashboards.value?.validator_dashboards.find(
-    validatorDashboard => `${validatorDashboard.id}` === dashboardKey.value,
-  )
-  return currentDashboard?.effective_balance
-})
+const {
+  getProducts,
+  premiumProducts,
+} = useProductsStore()
+
+await useAsyncData('get_products', () => getProducts())
 
 const hasReachedLimit = computed(() => {
+  const latestEffectiveBalance = overview.value?.balances.effective_latest
+  const freeProduct = premiumProducts.value['Free']
+  const effectiveBalanceLimitFreeProduct = freeProduct?.premium_perks.effective_balance_per_dashboard
   const effectiveBalancePerDashboard = premium_perks.value?.effective_balance_per_dashboard
+    || effectiveBalanceLimitFreeProduct
 
-  if (!currentEffectiveBalance.value || !effectiveBalancePerDashboard) {
+  if (!latestEffectiveBalance || !effectiveBalancePerDashboard) {
     return false
   }
-  return isGreaterEquals(currentEffectiveBalance.value, effectiveBalancePerDashboard)
+  return isGreaterEquals(latestEffectiveBalance, effectiveBalancePerDashboard)
 })
 
 await useAsyncData('user_dashboards', () => refreshDashboards(), { watch: [ isLoggedIn ] })

--- a/frontend/stores/dashboard/useUserDashboardStore.ts
+++ b/frontend/stores/dashboard/useUserDashboardStore.ts
@@ -106,7 +106,6 @@ export const useUserDashboardStore = defineStore('user_dashboards_store', () => 
         validator_dashboards: [
           ...(dashboards.value?.validator_dashboards || []),
           {
-            effective_balance: '0',
             group_count: 1,
             id: res.data.id,
             is_archived: false,

--- a/frontend/stores/useProductsStore.ts
+++ b/frontend/stores/useProductsStore.ts
@@ -45,6 +45,15 @@ export function useProductsStore() {
     )
   })
 
+  const premiumProducts = computed(() => {
+    if (!data.value?.api_products) return {}
+
+    return Object.fromEntries(data.value.premium_products.map(product => [
+      product.product_name,
+      product,
+    ]))
+  })
+
   async function getProducts() {
     if (data.value) {
       return data.value
@@ -63,6 +72,7 @@ export function useProductsStore() {
     currentPremiumSubscription,
     getProducts,
     isPremiumSubscribedViaApp,
+    premiumProducts,
     products,
   }
 }


### PR DESCRIPTION
This adapts to `API` change that sends `latest effective balance` to a public endpoint: `dashboard.validator_dashboards[index].effective_balance` (private) is now `overview.balances.effective_latest` (public)

Also `overview.balances.effective` is now `overview.balances.effective_current`


This PR also fixes [BEDS-1337](https://bitfly1.atlassian.net/browse/BEDS-1337) because the current effective balance is now fetched from the overview, which was already refreshed when adding/removing validators before this change.

[BEDS-1337]: https://bitfly1.atlassian.net/browse/BEDS-1337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ