### PR TITLE
fix(notifications): use goroutines to reduce notifications delay

### DIFF
--- a/backend/pkg/notification/queuing.go
+++ b/backend/pkg/notification/queuing.go
@@ -33,27 +33,32 @@ func queueNotifications(epoch uint64, notificationsByUserID types.NotificationsP
 
 	err = QueueEmailNotifications(epoch, notificationsByUserID, tx)
 	if err != nil {
+		metrics.Errors.WithLabelValues("notifications_queuing_email").Inc()
 		return fmt.Errorf("error queuing email notifications: %w", err)
 	}
 
 	err = QueuePushNotification(epoch, notificationsByUserID, tx)
 	if err != nil {
+		metrics.Errors.WithLabelValues("notifications_queuing_push").Inc()
 		return fmt.Errorf("error queuing push notifications: %w", err)
 	}
 
 	err = QueueWebhookNotifications(notificationsByUserID, tx)
 	if err != nil {
+		metrics.Errors.WithLabelValues("notifications_queuing_webhook").Inc()
 		return fmt.Errorf("error queuing webhook notifications: %w", err)
 	}
 
 	err = tx.Commit()
 	if err != nil {
+		metrics.Errors.WithLabelValues("notifications_queuing_tx_commit").Inc()
 		return fmt.Errorf("error committing transaction: %w", err)
 	}
 
 	err = ExportNotificationHistory(epoch, notificationsByUserID)
 	if err != nil {
-		log.Error(err, "error exporting notification historyw", 0)
+		log.Error(err, "error exporting notification history", 0)
+		metrics.Errors.WithLabelValues("notifications_export_history").Inc()
 	}
 
 	subByEpoch := map[uint64][]uint64{}

--- a/backend/pkg/notification/sending.go
+++ b/backend/pkg/notification/sending.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gobitfly/beaconchain/pkg/commons/db"
@@ -20,6 +21,8 @@ import (
 	"github.com/jmoiron/sqlx"
 	"golang.org/x/sync/errgroup"
 )
+
+const NOTIFICATION_DISPATCH_TYPES = 4
 
 const NOTIFICAION_EMAIL_RATE_LIMIT_BUCKET = "n_mails"
 const NOTIFICAION_PUSH_RATE_LIMIT_BUCKET = "n_push"
@@ -144,27 +147,54 @@ func garbageCollectOldPendingEvents() error {
 }
 
 func dispatchNotifications() error {
-	err := sendEmailNotifications()
-	if err != nil {
-		return fmt.Errorf("error sending email notifications, err: %w", err)
+	start := time.Now()
+	log.Infof("Notifications dispatching started")
+
+	// sending (email, push, webhook, discord) notifications
+	var wg sync.WaitGroup
+	errChan := make(chan error, NOTIFICATION_DISPATCH_TYPES)
+	wg.Add(NOTIFICATION_DISPATCH_TYPES)
+
+	// parallel execution using Goroutines
+	go func() {
+		defer wg.Done()
+		if err := sendEmailNotifications(); err != nil {
+			errChan <- fmt.Errorf("error sending email notifications: %w", err)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		if err := sendPushNotifications(); err != nil {
+			errChan <- fmt.Errorf("error sending push notifications: %w", err)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		if err := sendWebhookNotifications(); err != nil {
+			errChan <- fmt.Errorf("error sending webhook notifications: %w", err)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		if err := sendDiscordNotifications(); err != nil {
+			errChan <- fmt.Errorf("error sending discord notifications: %w", err)
+		}
+	}()
+
+	wg.Wait()
+	close(errChan)
+
+	var finalErr error
+	for err := range errChan {
+		log.Error(err, "notification dispatch error", 0)
+		finalErr = err
 	}
 
-	err = sendPushNotifications()
-	if err != nil {
-		return fmt.Errorf("error sending push notifications, err: %w", err)
-	}
-
-	err = sendWebhookNotifications()
-	if err != nil {
-		return fmt.Errorf("error sending webhook notifications, err: %w", err)
-	}
-
-	err = sendDiscordNotifications()
-	if err != nil {
-		return fmt.Errorf("error sending webhook discord notifications, err: %w", err)
-	}
-
-	return nil
+	log.Infof("Notifications dispatching finished in %v", time.Since(start))
+	return finalErr
 }
 
 func sendEmailNotifications() error {


### PR DESCRIPTION
Reducing notification delays by parallelizing notifications sending and queuing with Goroutines