### PR TITLE
feat(executionlayer): metrics for bigtable + client GetBlock

### DIFF
--- a/backend/pkg/commons/db2/database/bigtable.go
+++ b/backend/pkg/commons/db2/database/bigtable.go
@@ -11,6 +11,8 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/gobitfly/beaconchain/pkg/commons/metrics"
 )
 
 var ErrNotFound = fmt.Errorf("not found")
@@ -473,4 +475,70 @@ func bigtableReadOptions(options options, rowRange bigtable.RowRange) []bigtable
 		}
 	}
 	return readOptions
+}
+
+type TableMetric struct {
+	db TableWrapper
+}
+
+func WrapWithMetrics(db *BigTable, table string) TableMetric {
+	return TableMetric{
+		db: Wrap(db, table),
+	}
+}
+
+func (t TableMetric) BulkAdd(itemsByKey map[string][]Item, opts ...Option) error {
+	start := time.Now()
+	defer func(start time.Time) {
+		metrics.BigtableMetric.WithLabelValues(t.db.table, "BulkAdd").Observe(time.Since(start).Seconds())
+	}(start)
+	return t.db.BulkAdd(itemsByKey, opts...)
+}
+
+func (t TableMetric) Read(prefix string, opts ...Option) ([]Row, error) {
+	start := time.Now()
+	defer func(start time.Time) {
+		metrics.BigtableMetric.WithLabelValues(t.db.table, "Read").Observe(time.Since(start).Seconds())
+	}(start)
+	return t.db.Read(prefix, opts...)
+}
+
+func (t TableMetric) GetRow(key string) (*Row, error) {
+	start := time.Now()
+	defer func(start time.Time) {
+		metrics.BigtableMetric.WithLabelValues(t.db.table, "GetRow").Observe(time.Since(start).Seconds())
+	}(start)
+	return t.db.GetRow(key)
+}
+
+func (t TableMetric) GetRowsWithKeys(keys []string) ([]Row, error) {
+	start := time.Now()
+	defer func(start time.Time) {
+		metrics.BigtableMetric.WithLabelValues(t.db.table, "GetRowsWithKeys").Observe(time.Since(start).Seconds())
+	}(start)
+	return t.db.GetRowsWithKeys(keys)
+}
+
+func (t TableMetric) GetRowsRange(high, low string, opts ...Option) ([]Row, error) {
+	start := time.Now()
+	defer func(start time.Time) {
+		metrics.BigtableMetric.WithLabelValues(t.db.table, "GetRowsRange").Observe(time.Since(start).Seconds())
+	}(start)
+	return t.db.GetRowsRange(high, low, opts...)
+}
+
+func (t TableMetric) DeleteRowsWithKeys(keys []string, opts ...Option) error {
+	start := time.Now()
+	defer func(start time.Time) {
+		metrics.BigtableMetric.WithLabelValues(t.db.table, "DeleteRowsWithKeys").Observe(time.Since(start).Seconds())
+	}(start)
+	return t.db.DeleteRowsWithKeys(keys, opts...)
+}
+
+func (t TableMetric) Close() error {
+	return t.db.Close()
+}
+
+func (t TableMetric) Clear() error {
+	return t.db.Clear()
 }

--- a/backend/pkg/commons/db2/store.go
+++ b/backend/pkg/commons/db2/store.go
@@ -35,10 +35,10 @@ func NewStoreV1(data, metadata, updates, blocks database.Database, cache CachedB
 
 func NewStoreV1FromBigtable(bigtable *database.BigTable, cache CachedBalanceUpdates) StoreV1 {
 	return StoreV1{
-		data:     database.Wrap(bigtable, DataTable),
-		metadata: database.Wrap(bigtable, MetadataTable),
-		updates:  database.Wrap(bigtable, UpdatesTable),
-		blocks:   database.Wrap(bigtable, BlocksTable),
+		data:     database.WrapWithMetrics(bigtable, DataTable),
+		metadata: database.WrapWithMetrics(bigtable, MetadataTable),
+		updates:  database.WrapWithMetrics(bigtable, UpdatesTable),
+		blocks:   database.WrapWithMetrics(bigtable, BlocksTable),
 		cache:    cache,
 	}
 }

--- a/backend/pkg/commons/metrics/bigtable.go
+++ b/backend/pkg/commons/metrics/bigtable.go
@@ -1,0 +1,13 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	BigtableMetric = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "bigtable_request_time_seconds",
+		Help: "Time taken by request to execute on a Bigtable table",
+	}, []string{"table", "request"})
+)

--- a/backend/pkg/commons/metrics/executionlayer.go
+++ b/backend/pkg/commons/metrics/executionlayer.go
@@ -35,4 +35,9 @@ var (
 		Name: "indexing_reorg_total",
 		Help: "Total number of block impacted by chain reorganizations",
 	}, []string{"chainID"})
+
+	ClientGetBlock = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "client_get_block_time_seconds",
+		Help: "Time taken to retrieve a block from the blockchain and parse it",
+	}, []string{"chainID"})
 )

--- a/backend/pkg/commons/metrics/executionlayer.go
+++ b/backend/pkg/commons/metrics/executionlayer.go
@@ -9,35 +9,35 @@ var (
 	IndexingBlockDifference = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "indexing_block_difference",
 		Help: "Difference between the latest on-chain block and the last indexed block",
-	}, []string{"chainID"})
+	}, []string{"chain_id"})
 
 	IndexingTime = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "indexing_time_seconds",
 		Help: "Time taken to index the new blocks",
-	}, []string{"chainID"})
+	}, []string{"chain_id"})
 
 	IndexingTransformerProcessingTime = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "indexing_transformer_processing_time_seconds",
 		Help: "Time taken by a transformer to index a block",
-	}, []string{"chainID", "transformer"})
+	}, []string{"chain_id", "transformer"})
 
 	IndexingPendingBalanceUpdate = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "indexing_pending_balance_update",
 		Help: "Pending balances to update",
-	}, []string{"chainID"})
+	}, []string{"chain_id"})
 
 	IndexingPendingENSUpdate = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "indexing_pending_ens_update",
 		Help: "Pending ENS to update",
-	}, []string{"chainID"})
+	}, []string{"chain_id"})
 
 	IndexingReorgTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "indexing_reorg_total",
 		Help: "Total number of block impacted by chain reorganizations",
-	}, []string{"chainID"})
+	}, []string{"chain_id"})
 
 	ClientGetBlock = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "client_get_block_time_seconds",
 		Help: "Time taken to retrieve a block from the blockchain and parse it",
-	}, []string{"chainID"})
+	}, []string{"chain_id"})
 )

--- a/backend/pkg/executionlayer/blockindexer.go
+++ b/backend/pkg/executionlayer/blockindexer.go
@@ -3,6 +3,7 @@ package executionlayer
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"sync/atomic"
 	"time"
 
@@ -10,11 +11,29 @@ import (
 
 	"github.com/gobitfly/beaconchain/pkg/commons/db2"
 	"github.com/gobitfly/beaconchain/pkg/commons/log"
+	"github.com/gobitfly/beaconchain/pkg/commons/metrics"
 	"github.com/gobitfly/beaconchain/pkg/commons/types"
 )
 
 type Client interface {
 	GetBlock(number uint64, traceMode string) (*types.Eth1Block, *types.GetBlockTimings, error)
+	GetChainID() *big.Int
+}
+
+type clientWithMetrics struct {
+	client Client
+}
+
+func (c clientWithMetrics) GetBlock(number uint64, traceMode string) (*types.Eth1Block, *types.GetBlockTimings, error) {
+	start := time.Now()
+	defer func(start time.Time) {
+		metrics.ClientGetBlock.WithLabelValues(c.client.GetChainID().String()).Observe(time.Since(start).Seconds())
+	}(start)
+	return c.client.GetBlock(number, traceMode)
+}
+
+func (c clientWithMetrics) GetChainID() *big.Int {
+	return c.client.GetChainID()
 }
 
 type Store interface {
@@ -41,7 +60,7 @@ func NewBlockIndexer(store Store, lastBlockStore db2.LastBlocksStore, config Blo
 		store:          store,
 		lastBlockStore: lastBlockStore,
 		transformers:   transformers,
-		client:         client,
+		client:         clientWithMetrics{client},
 		config:         config,
 	}
 }


### PR DESCRIPTION
* metric for bigtable, contains the table and the action done
* metric for GetBlock from the client

**Tested on**: mainnet and gnosis with live indexing

Example result on mainnet and with poor performance laptop
<img width="1404" alt="Screenshot 2025-03-28 at 12 41 40" src="https://github.com/user-attachments/assets/b4894d06-50c5-4ac3-9e8d-9341f92c535d" />

