### PR TITLE
feat(execution layer): handle genesis block

### DIFF
--- a/backend/pkg/commons/db2/store.go
+++ b/backend/pkg/commons/db2/store.go
@@ -313,27 +313,29 @@ func (store StoreV1) GetBlocksRange(chainID string, start, end uint64) ([]*types
 		return nil, fmt.Errorf("invalid block range provided (high: %v, low: %v)", end, start)
 	}
 
-	var row *database.Row
-	var err error
+	var rows []database.Row
 	// we need to index genesis block (number=0) alone because there is an issue with how we generate block key
 	// block 0 has key chainID:1000000000
 	// block 1 has key chainID:999999999
 	// both are not adjacent in database, thus preventing to retrieve the range [0,1]
 	if start == 0 {
-		row, err = store.blocks.GetRow(blockKey(chainID, start))
+		row, err := store.blocks.GetRow(blockKey(chainID, start))
 		if err != nil {
 			return nil, err
 		}
+		if row != nil {
+			rows = append([]database.Row{*row}, rows...)
+		}
 		start++
 	}
-	rows, err := store.blocks.GetRowsRange(blockKey(chainID, start), blockKey(chainID, end))
-	if err != nil {
-		return nil, err
+	if start <= end {
+		rangeRows, err := store.blocks.GetRowsRange(blockKey(chainID, start), blockKey(chainID, end))
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, rangeRows...)
 	}
 	var blocks []*types.Eth1Block
-	if row != nil {
-		rows = append([]database.Row{*row}, rows...)
-	}
 	for _, row := range rows {
 		var block types.Eth1Block
 		if err := proto.Unmarshal(row.Values[fmt.Sprintf("%s:%s", defaultBlocksFamily, blocksDataColumn)], &block); err != nil {

--- a/backend/pkg/commons/db2/store.go
+++ b/backend/pkg/commons/db2/store.go
@@ -313,11 +313,27 @@ func (store StoreV1) GetBlocksRange(chainID string, start, end uint64) ([]*types
 		return nil, fmt.Errorf("invalid block range provided (high: %v, low: %v)", end, start)
 	}
 
+	var row *database.Row
+	var err error
+	// we need to index genesis block (number=0) alone because there is an issue with how we generate block key
+	// block 0 has key chainID:1000000000
+	// block 1 has key chainID:999999999
+	// both are not adjacent in database, thus preventing to retrieve the range [0,1]
+	if start == 0 {
+		row, err = store.blocks.GetRow(blockKey(chainID, start))
+		if err != nil {
+			return nil, err
+		}
+		start++
+	}
 	rows, err := store.blocks.GetRowsRange(blockKey(chainID, start), blockKey(chainID, end))
 	if err != nil {
 		return nil, err
 	}
 	var blocks []*types.Eth1Block
+	if row != nil {
+		rows = append([]database.Row{*row}, rows...)
+	}
 	for _, row := range rows {
 		var block types.Eth1Block
 		if err := proto.Unmarshal(row.Values[fmt.Sprintf("%s:%s", defaultBlocksFamily, blocksDataColumn)], &block); err != nil {
@@ -412,7 +428,7 @@ func (store StoreV1) GetLastBlockInDataTable(chainID string) (uint64, error) {
 		return 0, err
 	}
 	if len(rows) != 1 {
-		return 0, nil
+		return 0, database.ErrNotFound
 	}
 	reversedLastBlockStr := strings.TrimPrefix(rows[0].Key, prefix)
 	reversedLastBlock, ok := new(big.Int).SetString(reversedLastBlockStr, 10)
@@ -430,7 +446,7 @@ func (store StoreV1) GetLastBlockInBlocksTable(chainID string) (uint64, error) {
 		return 0, err
 	}
 	if len(rows) != 1 {
-		return 0, nil
+		return 0, database.ErrNotFound
 	}
 	reversedLastBlockStr := strings.TrimPrefix(rows[0].Key, prefix)
 	reversedLastBlock, ok := new(big.Int).SetString(reversedLastBlockStr, 10)

--- a/backend/pkg/commons/db2/store_test.go
+++ b/backend/pkg/commons/db2/store_test.go
@@ -15,28 +15,42 @@ func TestStoreV1(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer bt.Close()
 	store := NewStoreV1FromBigtable(bt, CachedBalanceUpdates{database.NoopCache{}})
 
 	t.Run("block range", func(t *testing.T) {
-		defer bt.Close()
-		if err := store.SaveBlock("1", &types.Eth1Block{
-			Number: 10,
-		}); err != nil {
-			t.Fatal(err)
+		tests := []struct {
+			name       string
+			start, end uint64
+		}{
+			{
+				name:  "normal",
+				start: 10,
+				end:   20,
+			},
+			{
+				name:  "genesis",
+				start: 0,
+				end:   1,
+			},
 		}
-
-		if err := store.SaveBlock("1", &types.Eth1Block{
-			Number: 11,
-		}); err != nil {
-			t.Fatal(err)
-		}
-
-		blocks, err := store.GetBlocksRange("1", 10, 11)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if got, want := len(blocks), 2; got != want {
-			t.Errorf("got %v, want %v", got, want)
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				for i := tt.start; i <= tt.end; i++ {
+					if err := store.SaveBlock("1", &types.Eth1Block{
+						Number: i,
+					}); err != nil {
+						t.Fatal(err)
+					}
+				}
+				blocks, err := store.GetBlocksRange("1", tt.start, tt.end)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got, want := len(blocks), int(tt.end-tt.start)+1; got != want {
+					t.Errorf("got %v, want %v", got, want)
+				}
+			})
 		}
 	})
 }

--- a/backend/pkg/commons/db2/store_test.go
+++ b/backend/pkg/commons/db2/store_test.go
@@ -33,6 +33,11 @@ func TestStoreV1(t *testing.T) {
 				start: 0,
 				end:   1,
 			},
+			{
+				name:  "start and end at genesis ",
+				start: 0,
+				end:   0,
+			},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {

--- a/backend/pkg/executionlayer/blockindexer.go
+++ b/backend/pkg/executionlayer/blockindexer.go
@@ -2,6 +2,7 @@ package executionlayer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"sync/atomic"
@@ -10,6 +11,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/gobitfly/beaconchain/pkg/commons/db2"
+	"github.com/gobitfly/beaconchain/pkg/commons/db2/database"
 	"github.com/gobitfly/beaconchain/pkg/commons/log"
 	"github.com/gobitfly/beaconchain/pkg/commons/metrics"
 	"github.com/gobitfly/beaconchain/pkg/commons/types"
@@ -161,7 +163,9 @@ func (indexer *BlockIndexer) IndexEvents(chainID string, start, end uint64) erro
 
 	lastBlockInCache, err := indexer.lastBlockStore.GetInDataTable(chainID)
 	if err != nil {
-		return err
+		if !errors.Is(err, database.ErrNotFound) {
+			return err
+		}
 	}
 
 	if end > lastBlockInCache {

--- a/backend/pkg/executionlayer/executionlayer.go
+++ b/backend/pkg/executionlayer/executionlayer.go
@@ -3,6 +3,7 @@ package executionlayer
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -117,7 +118,7 @@ func (service *IndexerService) SyncLive() {
 				break
 			}
 			indexingMetrics.BlockDifference(state.chainID, state.node-state.LastProcessed())
-			startBlock := max(state.LastProcessed()+1, 0)
+			startBlock := state.NextBlock()
 			bulk := min(service.indexer.config.Bulk, state.node-startBlock+1)
 			endBlock := min(startBlock+bulk-1, state.node)
 			start := time.Now()
@@ -198,23 +199,31 @@ func NewStateReader(chainID string, client *ethclient.Client, lastBlockStore db2
 }
 
 func (r StateReader) state() (syncState, error) {
+	var genesis bool
 	lastBlock, err := r.client.BlockNumber(context.Background())
 	if err != nil {
 		return syncState{}, fmt.Errorf("get chain head: %w", err)
 	}
 	lastBlockFromBlocksTable, err := r.lastBlockStore.GetInBlocksTable(r.chainID)
 	if err != nil {
-		return syncState{}, fmt.Errorf("get last block from blocks table: %w", err)
+		if !errors.Is(err, database.ErrNotFound) {
+			return syncState{}, fmt.Errorf("get last block from blocks table: %w", err)
+		}
+		genesis = true
 	}
 	lastBlockFromDataTable, err := r.lastBlockStore.GetInDataTable(r.chainID)
 	if err != nil {
-		return syncState{}, fmt.Errorf("get last block from data table: %w", err)
+		if !errors.Is(err, database.ErrNotFound) {
+			return syncState{}, fmt.Errorf("get last block from data table: %w", err)
+		}
+		genesis = true
 	}
 	return syncState{
 		chainID: r.chainID,
 		node:    lastBlock,
 		blocks:  lastBlockFromBlocksTable,
 		data:    lastBlockFromDataTable,
+		genesis: genesis,
 	}, nil
 }
 
@@ -223,6 +232,8 @@ type syncState struct {
 	node    uint64
 	blocks  uint64
 	data    uint64
+
+	genesis bool
 }
 
 // LastProcessed returns the real last block processed by taking the smallest block between state.data and state.blocks
@@ -230,13 +241,25 @@ func (state syncState) LastProcessed() uint64 {
 	return min(state.data, state.blocks)
 }
 
+func (state syncState) NextBlock() uint64 {
+	lastProcessed := state.LastProcessed()
+	if state.genesis {
+		return lastProcessed
+	}
+	return lastProcessed + 1
+}
+
 func (state syncState) Fields() map[string]interface{} {
-	return map[string]interface{}{
+	fields := map[string]interface{}{
 		"chainID": state.chainID,
 		"node":    state.node,
 		"blocks":  state.blocks,
 		"data":    state.data,
 	}
+	if state.genesis {
+		fields["genesis"] = true
+	}
+	return fields
 }
 
 type IndexerConfig struct {


### PR DESCRIPTION
### Bigtable issue
Genesis block (number = 0) cause a problem with how we encode it in bigtable
* block 0 has key chainID:1000000000
* block 1 has key chainID:999999999
* block 2 has key chainID:999999998

Since Bigtable keys are lexicographically ordered, blocks are ordered like the following:
* chainID:1000000000 (block 0)
* ...
* chainID:(1000000000-n) (block n)
* ...
* chainID:999999998 (block 2)
* chainID:999999999 (block 1)

This means we cannot request the block range [0,1] because this requires that block 0 and 1 are adjacent in the table.
We must handle genesis block separately and then add it the rest of the range results.

### Last processed block issue
We also need to differentiate between no last block processed (fresh start) and last block processed equal to 0 (block 0 was indexed and we aim to index from block 1).