### PR TITLE
refactor: introduce `statusReport` interface for `newStatusReport` in /monitoring/services

### DIFF
--- a/backend/pkg/api/services/service.go
+++ b/backend/pkg/api/services/service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gobitfly/beaconchain/pkg/commons/log"
 	"github.com/gobitfly/beaconchain/pkg/commons/price"
 	"github.com/gobitfly/beaconchain/pkg/commons/utils"
+	"github.com/gobitfly/beaconchain/pkg/monitoring/services"
 	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
 )
@@ -39,6 +40,7 @@ func NewServices(readerDb, writerDb, alloyReader, alloyWriter, clickhouseReader 
 func (s *Services) InitServices() {
 	wg := &sync.WaitGroup{}
 	log.Infof("initializing services...")
+	services.InitStatusReport()
 	wg.Add(4)
 	go s.startSlotVizDataService(wg)
 	go s.startIndexMappingService(wg)

--- a/backend/pkg/api/services/service_average_network_efficiency.go
+++ b/backend/pkg/api/services/service_average_network_efficiency.go
@@ -26,7 +26,7 @@ func (s *Services) startEfficiencyDataService(wg *sync.WaitGroup) {
 	for {
 		startTime := time.Now()
 		delay := time.Duration(utils.Config.Chain.ClConfig.SlotsPerEpoch*utils.Config.Chain.ClConfig.SecondsPerSlot) * time.Second
-		r := services.NewStatusReport(constants.Event_ApiServiceAvgEfficiency, constants.Default, delay)
+		r := services.StatusReporter.NewStatusReport(constants.Event_ApiServiceAvgEfficiency, constants.Default, delay)
 		r(constants.Running, nil)
 		err := s.updateEfficiencyData() // TODO: only update data if something has changed (new head epoch)
 		if err != nil {

--- a/backend/pkg/api/services/service_average_network_efficiency.go
+++ b/backend/pkg/api/services/service_average_network_efficiency.go
@@ -26,7 +26,7 @@ func (s *Services) startEfficiencyDataService(wg *sync.WaitGroup) {
 	for {
 		startTime := time.Now()
 		delay := time.Duration(utils.Config.Chain.ClConfig.SlotsPerEpoch*utils.Config.Chain.ClConfig.SecondsPerSlot) * time.Second
-		r := services.NewStatusReport(constants.Event_ApiServiceAvgEfficiency, utils.Config.DeploymentType, constants.Default, delay)
+		r := services.NewStatusReport(constants.Event_ApiServiceAvgEfficiency, constants.Default, delay)
 		r(constants.Running, nil)
 		err := s.updateEfficiencyData() // TODO: only update data if something has changed (new head epoch)
 		if err != nil {

--- a/backend/pkg/api/services/service_slot_viz.go
+++ b/backend/pkg/api/services/service_slot_viz.go
@@ -32,7 +32,7 @@ func (s *Services) startSlotVizDataService(wg *sync.WaitGroup) {
 	for {
 		startTime := time.Now()
 		delay := time.Duration(utils.Config.Chain.ClConfig.SecondsPerSlot) * time.Second
-		r := services.NewStatusReport(constants.Event_ApiServiceSlotViz, utils.Config.DeploymentType, constants.Default, delay)
+		r := services.NewStatusReport(constants.Event_ApiServiceSlotViz, constants.Default, delay)
 		r(constants.Running, nil)
 		err := s.updateSlotVizData() // TODO: only update data if something has changed (new head slot or new head epoch)
 		if err != nil {

--- a/backend/pkg/api/services/service_slot_viz.go
+++ b/backend/pkg/api/services/service_slot_viz.go
@@ -32,7 +32,7 @@ func (s *Services) startSlotVizDataService(wg *sync.WaitGroup) {
 	for {
 		startTime := time.Now()
 		delay := time.Duration(utils.Config.Chain.ClConfig.SecondsPerSlot) * time.Second
-		r := services.NewStatusReport(constants.Event_ApiServiceSlotViz, constants.Default, delay)
+		r := services.StatusReporter.NewStatusReport(constants.Event_ApiServiceSlotViz, constants.Default, delay)
 		r(constants.Running, nil)
 		err := s.updateSlotVizData() // TODO: only update data if something has changed (new head slot or new head epoch)
 		if err != nil {

--- a/backend/pkg/api/services/service_validator_mapping.go
+++ b/backend/pkg/api/services/service_validator_mapping.go
@@ -41,7 +41,7 @@ func (s *Services) startIndexMappingService(wg *sync.WaitGroup) {
 		startTime := time.Now()
 		delay := time.Duration(utils.Config.Chain.ClConfig.SecondsPerSlot) * time.Second
 		err = nil // clear error
-		r := services.NewStatusReport(constants.Event_ApiServiceValidatorMapping, constants.Default, delay)
+		r := services.StatusReporter.NewStatusReport(constants.Event_ApiServiceValidatorMapping, constants.Default, delay)
 		r(constants.Running, nil)
 		latestEpoch := cache.LatestEpoch.Get()
 		if currentValidatorMapping.Load() == nil || latestEpoch != lastEpochUpdate {

--- a/backend/pkg/api/services/service_validator_mapping.go
+++ b/backend/pkg/api/services/service_validator_mapping.go
@@ -41,7 +41,7 @@ func (s *Services) startIndexMappingService(wg *sync.WaitGroup) {
 		startTime := time.Now()
 		delay := time.Duration(utils.Config.Chain.ClConfig.SecondsPerSlot) * time.Second
 		err = nil // clear error
-		r := services.NewStatusReport(constants.Event_ApiServiceValidatorMapping, utils.Config.DeploymentType, constants.Default, delay)
+		r := services.NewStatusReport(constants.Event_ApiServiceValidatorMapping, constants.Default, delay)
 		r(constants.Running, nil)
 		latestEpoch := cache.LatestEpoch.Get()
 		if currentValidatorMapping.Load() == nil || latestEpoch != lastEpochUpdate {

--- a/backend/pkg/exporter/modules/base.go
+++ b/backend/pkg/exporter/modules/base.go
@@ -44,6 +44,7 @@ func StartAll(moduleCtx ModuleContext, modules []ModuleInterface, justV2 bool) {
 	if !justV2 {
 		ctx := context.Background()
 		consDB := db2.NewConsensusRepository(db.ReaderDb, db.WriterDb)
+		InitStatusReport()
 
 		networkLivenessUpdater := newNetworkLivenessUpdater(ctx, moduleCtx.ConsClient, consDB)
 		go networkLivenessUpdater.Export()
@@ -51,7 +52,7 @@ func StartAll(moduleCtx ModuleContext, modules []ModuleInterface, justV2 bool) {
 		genesisExporter := newGenesisDepositsExporter(ctx, moduleCtx.ConsClient, consDB)
 		go genesisExporter.Export()
 
-		syncCommitteesExporter := NewSyncCommitteesExporter(ctx, moduleCtx.ConsClient, consDB, statusReporter{})
+		syncCommitteesExporter := NewSyncCommitteesExporter(ctx, moduleCtx.ConsClient, consDB)
 		go syncCommitteesExporter.Export()
 
 		syncCommitteesCountExporter := newSyncCommitteesCountExporter(ctx, consDB)
@@ -65,7 +66,7 @@ func StartAll(moduleCtx ModuleContext, modules []ModuleInterface, justV2 bool) {
 		}
 
 		if utils.Config.Indexer.PubKeyTagsExporter.Enabled {
-			pubkeyTagsUpdater := newPubkeyTagsUpdater(ctx, consDB, statusReporter{})
+			pubkeyTagsUpdater := newPubkeyTagsUpdater(ctx, consDB)
 			go pubkeyTagsUpdater.Update()
 		}
 
@@ -209,23 +210,28 @@ func GetModuleContext() (ModuleContext, error) {
 	return moduleContext, nil
 }
 
-type StatusReporter interface {
+type statusReporter interface {
 	NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) func(status constants.StatusType, metadata map[string]string)
 }
 
-type statusReporter struct{}
-
-func (sr statusReporter) NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) func(status constants.StatusType, metadata map[string]string) {
-	return services.NewStatusReport(id, timeout, checkInterval)
-}
-
-// Stub implementation for testing
 type stubStatusReporter struct{}
 
 func (sr stubStatusReporter) NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) func(status constants.StatusType, metadata map[string]string) {
 	return func(status constants.StatusType, metadata map[string]string) {
 		// No-op implementation
 	}
+}
+
+type actualStatusReporter struct{}
+
+func (sr actualStatusReporter) NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) func(status constants.StatusType, metadata map[string]string) {
+	return services.NewStatusReport(id, timeout, checkInterval)
+}
+
+var StatusReporter statusReporter = stubStatusReporter{}
+
+func InitStatusReport() {
+	StatusReporter = actualStatusReporter{}
 }
 
 type ModuleContext struct {

--- a/backend/pkg/exporter/modules/base.go
+++ b/backend/pkg/exporter/modules/base.go
@@ -41,10 +41,10 @@ var Client *rpc.Client
 
 // Start will start the export of data from rpc into the database
 func StartAll(moduleCtx ModuleContext, modules []ModuleInterface, justV2 bool) {
+	services.InitStatusReport()
 	if !justV2 {
 		ctx := context.Background()
 		consDB := db2.NewConsensusRepository(db.ReaderDb, db.WriterDb)
-		services.InitStatusReport()
 
 		networkLivenessUpdater := newNetworkLivenessUpdater(ctx, moduleCtx.ConsClient, consDB)
 		go networkLivenessUpdater.Export()

--- a/backend/pkg/exporter/modules/base.go
+++ b/backend/pkg/exporter/modules/base.go
@@ -167,7 +167,7 @@ func notifyAllModules(goPool *errgroup.Group, modules []ModuleInterface, f func(
 		module := module
 		goPool.Go(func() error {
 			start := time.Now()
-			r := services.NewStatusReport(module.GetMonitoringEventId(), utils.Config.DeploymentType, 5*time.Minute, constants.Default)
+			r := services.NewStatusReport(module.GetMonitoringEventId(), 5*time.Minute, constants.Default)
 			r(constants.Running, nil)
 			err := f(module)
 			if err != nil {

--- a/backend/pkg/exporter/modules/base.go
+++ b/backend/pkg/exporter/modules/base.go
@@ -168,7 +168,7 @@ func notifyAllModules(goPool *errgroup.Group, modules []ModuleInterface, f func(
 		module := module
 		goPool.Go(func() error {
 			start := time.Now()
-			r := services.NewStatusReport(module.GetMonitoringEventId(), 5*time.Minute, constants.Default)
+			r := services.StatusReporter.NewStatusReport(module.GetMonitoringEventId(), 5*time.Minute, constants.Default)
 			r(constants.Running, nil)
 			err := f(module)
 			if err != nil {

--- a/backend/pkg/exporter/modules/base.go
+++ b/backend/pkg/exporter/modules/base.go
@@ -51,7 +51,7 @@ func StartAll(moduleCtx ModuleContext, modules []ModuleInterface, justV2 bool) {
 		genesisExporter := newGenesisDepositsExporter(ctx, moduleCtx.ConsClient, consDB)
 		go genesisExporter.Export()
 
-		syncCommitteesExporter := NewSyncCommitteesExporter(ctx, moduleCtx.ConsClient, consDB)
+		syncCommitteesExporter := NewSyncCommitteesExporter(ctx, moduleCtx.ConsClient, consDB, statusReporter{})
 		go syncCommitteesExporter.Export()
 
 		syncCommitteesCountExporter := newSyncCommitteesCountExporter(ctx, consDB)
@@ -65,7 +65,7 @@ func StartAll(moduleCtx ModuleContext, modules []ModuleInterface, justV2 bool) {
 		}
 
 		if utils.Config.Indexer.PubKeyTagsExporter.Enabled {
-			pubkeyTagsUpdater := newPubkeyTagsUpdater(ctx, consDB)
+			pubkeyTagsUpdater := newPubkeyTagsUpdater(ctx, consDB, statusReporter{})
 			go pubkeyTagsUpdater.Update()
 		}
 
@@ -207,6 +207,25 @@ func GetModuleContext() (ModuleContext, error) {
 	moduleContext.ConsClient = clClient
 
 	return moduleContext, nil
+}
+
+type StatusReporter interface {
+	NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) func(status constants.StatusType, metadata map[string]string)
+}
+
+type statusReporter struct{}
+
+func (sr statusReporter) NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) func(status constants.StatusType, metadata map[string]string) {
+	return services.NewStatusReport(id, timeout, checkInterval)
+}
+
+// Stub implementation for testing
+type stubStatusReporter struct{}
+
+func (sr stubStatusReporter) NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) func(status constants.StatusType, metadata map[string]string) {
+	return func(status constants.StatusType, metadata map[string]string) {
+		// No-op implementation
+	}
 }
 
 type ModuleContext struct {

--- a/backend/pkg/exporter/modules/base.go
+++ b/backend/pkg/exporter/modules/base.go
@@ -44,7 +44,7 @@ func StartAll(moduleCtx ModuleContext, modules []ModuleInterface, justV2 bool) {
 	if !justV2 {
 		ctx := context.Background()
 		consDB := db2.NewConsensusRepository(db.ReaderDb, db.WriterDb)
-		InitStatusReport()
+		services.InitStatusReport()
 
 		networkLivenessUpdater := newNetworkLivenessUpdater(ctx, moduleCtx.ConsClient, consDB)
 		go networkLivenessUpdater.Export()
@@ -208,30 +208,6 @@ func GetModuleContext() (ModuleContext, error) {
 	moduleContext.ConsClient = clClient
 
 	return moduleContext, nil
-}
-
-type statusReporter interface {
-	NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) func(status constants.StatusType, metadata map[string]string)
-}
-
-type stubStatusReporter struct{}
-
-func (sr stubStatusReporter) NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) func(status constants.StatusType, metadata map[string]string) {
-	return func(status constants.StatusType, metadata map[string]string) {
-		// No-op implementation
-	}
-}
-
-type actualStatusReporter struct{}
-
-func (sr actualStatusReporter) NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) func(status constants.StatusType, metadata map[string]string) {
-	return services.NewStatusReport(id, timeout, checkInterval)
-}
-
-var StatusReporter statusReporter = stubStatusReporter{}
-
-func InitStatusReport() {
-	StatusReporter = actualStatusReporter{}
 }
 
 type ModuleContext struct {

--- a/backend/pkg/exporter/modules/network_liveness.go
+++ b/backend/pkg/exporter/modules/network_liveness.go
@@ -57,7 +57,7 @@ func (n *networkLivenessUpdater) Export() {
 			log.Info("network liveness export loop cancelled")
 			return
 		default:
-			statusReport := services.NewStatusReport(constants.Event_ExporterLegacyNetworkLiveness, utils.Config.DeploymentType, constants.Default, slotDuration)
+			statusReport := services.NewStatusReport(constants.Event_ExporterLegacyNetworkLiveness, constants.Default, slotDuration)
 			statusReport(constants.Running, nil)
 
 			head, err := n.client.GetChainHead()

--- a/backend/pkg/exporter/modules/network_liveness.go
+++ b/backend/pkg/exporter/modules/network_liveness.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gobitfly/beaconchain/pkg/commons/types"
 	"github.com/gobitfly/beaconchain/pkg/commons/utils"
 	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
+	"github.com/gobitfly/beaconchain/pkg/monitoring/services"
 )
 
 type EpochClient interface {
@@ -56,7 +57,7 @@ func (n *networkLivenessUpdater) Export() {
 			log.Info("network liveness export loop cancelled")
 			return
 		default:
-			statusReport := StatusReporter.NewStatusReport(constants.Event_ExporterLegacyNetworkLiveness, constants.Default, slotDuration)
+			statusReport := services.StatusReporter.NewStatusReport(constants.Event_ExporterLegacyNetworkLiveness, constants.Default, slotDuration)
 			statusReport(constants.Running, nil)
 
 			head, err := n.client.GetChainHead()

--- a/backend/pkg/exporter/modules/network_liveness.go
+++ b/backend/pkg/exporter/modules/network_liveness.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gobitfly/beaconchain/pkg/commons/types"
 	"github.com/gobitfly/beaconchain/pkg/commons/utils"
 	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
-	"github.com/gobitfly/beaconchain/pkg/monitoring/services"
 )
 
 type EpochClient interface {
@@ -57,7 +56,7 @@ func (n *networkLivenessUpdater) Export() {
 			log.Info("network liveness export loop cancelled")
 			return
 		default:
-			statusReport := services.NewStatusReport(constants.Event_ExporterLegacyNetworkLiveness, constants.Default, slotDuration)
+			statusReport := StatusReporter.NewStatusReport(constants.Event_ExporterLegacyNetworkLiveness, constants.Default, slotDuration)
 			statusReport(constants.Running, nil)
 
 			head, err := n.client.GetChainHead()

--- a/backend/pkg/exporter/modules/network_liveness_test.go
+++ b/backend/pkg/exporter/modules/network_liveness_test.go
@@ -76,6 +76,7 @@ func TestNetworkLivenessExport(t *testing.T) {
 		ctx:    ctx,
 		cache:  tieredCache,
 	}
+	StatusReporter = stubStatusReporter{}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/backend/pkg/exporter/modules/network_liveness_test.go
+++ b/backend/pkg/exporter/modules/network_liveness_test.go
@@ -61,7 +61,6 @@ func TestNetworkLivenessExport(t *testing.T) {
 				DepositChainID: 1,
 			},
 		},
-		DeploymentType: "development",
 	}
 
 	mockConsDBClient := new(mocks.ConsensusRepository)

--- a/backend/pkg/exporter/modules/network_liveness_test.go
+++ b/backend/pkg/exporter/modules/network_liveness_test.go
@@ -76,7 +76,6 @@ func TestNetworkLivenessExport(t *testing.T) {
 		ctx:    ctx,
 		cache:  tieredCache,
 	}
-	StatusReporter = stubStatusReporter{}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/backend/pkg/exporter/modules/pubkey_tags.go
+++ b/backend/pkg/exporter/modules/pubkey_tags.go
@@ -12,18 +12,16 @@ import (
 )
 
 type pubkeyTagsUpdater struct {
-	db             db2.ConsensusRepository
-	delay          time.Duration
-	ctx            context.Context
-	statusReporter StatusReporter
+	db    db2.ConsensusRepository
+	delay time.Duration
+	ctx   context.Context
 }
 
-func newPubkeyTagsUpdater(ctx context.Context, db db2.ConsensusRepository, reporter StatusReporter) pubkeyTagsUpdater {
+func newPubkeyTagsUpdater(ctx context.Context, db db2.ConsensusRepository) pubkeyTagsUpdater {
 	return pubkeyTagsUpdater{
-		db:             db,
-		delay:          time.Minute * 10,
-		ctx:            ctx,
-		statusReporter: reporter,
+		db:    db,
+		delay: time.Minute * 10,
+		ctx:   ctx,
 	}
 }
 
@@ -36,7 +34,7 @@ func (p *pubkeyTagsUpdater) Update() {
 			return
 		default:
 			startTime := time.Now()
-			statusReport := p.statusReporter.NewStatusReport(constants.Event_ExporterLegacyPubkeyTags, p.delay, time.Second*12)
+			statusReport := StatusReporter.NewStatusReport(constants.Event_ExporterLegacyPubkeyTags, p.delay, time.Second*12)
 			statusReport(constants.Running, nil)
 
 			err := p.db.UpdatePubkeyTags()
@@ -46,7 +44,6 @@ func (p *pubkeyTagsUpdater) Update() {
 			}
 
 			log.Infof("Updating Pubkey Tags took %v sec.", time.Since(startTime).Seconds())
-
 			statusReport(constants.Success, map[string]string{
 				"took":     time.Since(startTime).String(),
 				"took_raw": fmt.Sprintf("%v", time.Since(startTime).Milliseconds()),

--- a/backend/pkg/exporter/modules/pubkey_tags.go
+++ b/backend/pkg/exporter/modules/pubkey_tags.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gobitfly/beaconchain/pkg/commons/log"
 	"github.com/gobitfly/beaconchain/pkg/commons/metrics"
 	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
+	"github.com/gobitfly/beaconchain/pkg/monitoring/services"
 )
 
 type pubkeyTagsUpdater struct {
@@ -34,7 +35,7 @@ func (p *pubkeyTagsUpdater) Update() {
 			return
 		default:
 			startTime := time.Now()
-			statusReport := StatusReporter.NewStatusReport(constants.Event_ExporterLegacyPubkeyTags, p.delay, time.Second*12)
+			statusReport := services.StatusReporter.NewStatusReport(constants.Event_ExporterLegacyPubkeyTags, p.delay, time.Second*12)
 			statusReport(constants.Running, nil)
 
 			err := p.db.UpdatePubkeyTags()

--- a/backend/pkg/exporter/modules/pubkey_tags.go
+++ b/backend/pkg/exporter/modules/pubkey_tags.go
@@ -9,20 +9,21 @@ import (
 	"github.com/gobitfly/beaconchain/pkg/commons/log"
 	"github.com/gobitfly/beaconchain/pkg/commons/metrics"
 	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
-	"github.com/gobitfly/beaconchain/pkg/monitoring/services"
 )
 
 type pubkeyTagsUpdater struct {
-	db    db2.ConsensusRepository
-	delay time.Duration
-	ctx   context.Context
+	db             db2.ConsensusRepository
+	delay          time.Duration
+	ctx            context.Context
+	statusReporter StatusReporter
 }
 
-func newPubkeyTagsUpdater(ctx context.Context, db db2.ConsensusRepository) pubkeyTagsUpdater {
+func newPubkeyTagsUpdater(ctx context.Context, db db2.ConsensusRepository, reporter StatusReporter) pubkeyTagsUpdater {
 	return pubkeyTagsUpdater{
-		db:    db,
-		delay: time.Minute * 10,
-		ctx:   ctx,
+		db:             db,
+		delay:          time.Minute * 10,
+		ctx:            ctx,
+		statusReporter: reporter,
 	}
 }
 
@@ -35,7 +36,7 @@ func (p *pubkeyTagsUpdater) Update() {
 			return
 		default:
 			startTime := time.Now()
-			statusReport := services.NewStatusReport(constants.Event_ExporterLegacyPubkeyTags, p.delay, time.Second*12)
+			statusReport := p.statusReporter.NewStatusReport(constants.Event_ExporterLegacyPubkeyTags, p.delay, time.Second*12)
 			statusReport(constants.Running, nil)
 
 			err := p.db.UpdatePubkeyTags()

--- a/backend/pkg/exporter/modules/pubkey_tags.go
+++ b/backend/pkg/exporter/modules/pubkey_tags.go
@@ -8,7 +8,6 @@ import (
 	db2 "github.com/gobitfly/beaconchain/pkg/commons/db2"
 	"github.com/gobitfly/beaconchain/pkg/commons/log"
 	"github.com/gobitfly/beaconchain/pkg/commons/metrics"
-	"github.com/gobitfly/beaconchain/pkg/commons/utils"
 	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
 	"github.com/gobitfly/beaconchain/pkg/monitoring/services"
 )
@@ -36,7 +35,7 @@ func (p *pubkeyTagsUpdater) Update() {
 			return
 		default:
 			startTime := time.Now()
-			statusReport := services.NewStatusReport(constants.Event_ExporterLegacyPubkeyTags, utils.Config.DeploymentType, p.delay, time.Second*12)
+			statusReport := services.NewStatusReport(constants.Event_ExporterLegacyPubkeyTags, p.delay, time.Second*12)
 			statusReport(constants.Running, nil)
 
 			err := p.db.UpdatePubkeyTags()

--- a/backend/pkg/exporter/modules/pubkey_tags_test.go
+++ b/backend/pkg/exporter/modules/pubkey_tags_test.go
@@ -34,8 +34,6 @@ func TestPubkeyTagsUpdate(t *testing.T) {
 		ctx:   ctx,
 	}
 
-	StatusReporter = stubStatusReporter{}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockConsDBClient.On("UpdatePubkeyTags").Return(tt.mockError)

--- a/backend/pkg/exporter/modules/pubkey_tags_test.go
+++ b/backend/pkg/exporter/modules/pubkey_tags_test.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	dbmocks "github.com/gobitfly/beaconchain/pkg/commons/db2/mocks"
-	"github.com/gobitfly/beaconchain/pkg/commons/types"
-	"github.com/gobitfly/beaconchain/pkg/commons/utils"
 	"github.com/pkg/errors"
 )
 
@@ -31,13 +29,10 @@ func TestPubkeyTagsUpdate(t *testing.T) {
 	defer cancel()
 
 	exporter := pubkeyTagsUpdater{
-		db:    mockConsDBClient,
-		delay: 0,
-		ctx:   ctx,
-	}
-
-	utils.Config = &types.Config{
-		DeploymentType: "development",
+		db:             mockConsDBClient,
+		delay:          0,
+		ctx:            ctx,
+		statusReporter: stubStatusReporter{},
 	}
 
 	for _, tt := range tests {

--- a/backend/pkg/exporter/modules/pubkey_tags_test.go
+++ b/backend/pkg/exporter/modules/pubkey_tags_test.go
@@ -29,11 +29,12 @@ func TestPubkeyTagsUpdate(t *testing.T) {
 	defer cancel()
 
 	exporter := pubkeyTagsUpdater{
-		db:             mockConsDBClient,
-		delay:          0,
-		ctx:            ctx,
-		statusReporter: stubStatusReporter{},
+		db:    mockConsDBClient,
+		delay: 0,
+		ctx:   ctx,
 	}
+
+	StatusReporter = stubStatusReporter{}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/backend/pkg/exporter/modules/sync_committees.go
+++ b/backend/pkg/exporter/modules/sync_committees.go
@@ -23,24 +23,22 @@ type syncCommitteesExporter struct {
 	client SyncCommitteeClient
 	db     db2.ConsensusRepository
 
-	delay          time.Duration
-	ctx            context.Context
-	cache          *cache.TieredCacheBase
-	statusReporter StatusReporter
+	delay time.Duration
+	ctx   context.Context
+	cache *cache.TieredCacheBase
 }
 
-func NewSyncCommitteesExporter(ctx context.Context, client rpc.Client, db db2.ConsensusRepository, reporter StatusReporter) syncCommitteesExporter {
+func NewSyncCommitteesExporter(ctx context.Context, client rpc.Client, db db2.ConsensusRepository) syncCommitteesExporter {
 	if cache.TieredCache == nil {
 		log.Fatal(nil, "TieredCache is not initialised", 0)
 	}
 
 	return syncCommitteesExporter{
-		client:         client,
-		db:             db,
-		delay:          time.Second * 12,
-		ctx:            ctx,
-		cache:          cache.TieredCache,
-		statusReporter: reporter,
+		client: client,
+		db:     db,
+		delay:  time.Second * 12,
+		ctx:    ctx,
+		cache:  cache.TieredCache,
 	}
 }
 
@@ -52,7 +50,7 @@ func (s syncCommitteesExporter) Export() {
 			return
 		default:
 			startTime := time.Now()
-			statusReport := s.statusReporter.NewStatusReport(constants.Event_ExporterLegacySyncCommittees, constants.Default, time.Second*12)
+			statusReport := StatusReporter.NewStatusReport(constants.Event_ExporterLegacySyncCommittees, constants.Default, time.Second*12)
 			statusReport(constants.Running, nil)
 
 			err := s.exportSyncCommittees()

--- a/backend/pkg/exporter/modules/sync_committees.go
+++ b/backend/pkg/exporter/modules/sync_committees.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gobitfly/beaconchain/pkg/commons/utils"
 	constypes "github.com/gobitfly/beaconchain/pkg/consapi/types"
 	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
+	"github.com/gobitfly/beaconchain/pkg/monitoring/services"
 )
 
 type SyncCommitteeClient interface {
@@ -50,7 +51,7 @@ func (s syncCommitteesExporter) Export() {
 			return
 		default:
 			startTime := time.Now()
-			statusReport := StatusReporter.NewStatusReport(constants.Event_ExporterLegacySyncCommittees, constants.Default, time.Second*12)
+			statusReport := services.StatusReporter.NewStatusReport(constants.Event_ExporterLegacySyncCommittees, constants.Default, time.Second*12)
 			statusReport(constants.Running, nil)
 
 			err := s.exportSyncCommittees()

--- a/backend/pkg/exporter/modules/sync_committees.go
+++ b/backend/pkg/exporter/modules/sync_committees.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gobitfly/beaconchain/pkg/commons/utils"
 	constypes "github.com/gobitfly/beaconchain/pkg/consapi/types"
 	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
-	"github.com/gobitfly/beaconchain/pkg/monitoring/services"
 )
 
 type SyncCommitteeClient interface {
@@ -24,22 +23,24 @@ type syncCommitteesExporter struct {
 	client SyncCommitteeClient
 	db     db2.ConsensusRepository
 
-	delay time.Duration
-	ctx   context.Context
-	cache *cache.TieredCacheBase
+	delay          time.Duration
+	ctx            context.Context
+	cache          *cache.TieredCacheBase
+	statusReporter StatusReporter
 }
 
-func NewSyncCommitteesExporter(ctx context.Context, client rpc.Client, db db2.ConsensusRepository) syncCommitteesExporter {
+func NewSyncCommitteesExporter(ctx context.Context, client rpc.Client, db db2.ConsensusRepository, reporter StatusReporter) syncCommitteesExporter {
 	if cache.TieredCache == nil {
 		log.Fatal(nil, "TieredCache is not initialised", 0)
 	}
 
 	return syncCommitteesExporter{
-		client: client,
-		db:     db,
-		delay:  time.Second * 12,
-		ctx:    ctx,
-		cache:  cache.TieredCache,
+		client:         client,
+		db:             db,
+		delay:          time.Second * 12,
+		ctx:            ctx,
+		cache:          cache.TieredCache,
+		statusReporter: reporter,
 	}
 }
 
@@ -51,7 +52,7 @@ func (s syncCommitteesExporter) Export() {
 			return
 		default:
 			startTime := time.Now()
-			statusReport := services.NewStatusReport(constants.Event_ExporterLegacySyncCommittees, constants.Default, time.Second*12)
+			statusReport := s.statusReporter.NewStatusReport(constants.Event_ExporterLegacySyncCommittees, constants.Default, time.Second*12)
 			statusReport(constants.Running, nil)
 
 			err := s.exportSyncCommittees()

--- a/backend/pkg/exporter/modules/sync_committees.go
+++ b/backend/pkg/exporter/modules/sync_committees.go
@@ -51,8 +51,7 @@ func (s syncCommitteesExporter) Export() {
 			return
 		default:
 			startTime := time.Now()
-			deploymentType := utils.Config.DeploymentType
-			statusReport := services.NewStatusReport(constants.Event_ExporterLegacySyncCommittees, deploymentType, constants.Default, time.Second*12)
+			statusReport := services.NewStatusReport(constants.Event_ExporterLegacySyncCommittees, constants.Default, time.Second*12)
 			statusReport(constants.Running, nil)
 
 			err := s.exportSyncCommittees()

--- a/backend/pkg/exporter/modules/sync_committees_count.go
+++ b/backend/pkg/exporter/modules/sync_committees_count.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gobitfly/beaconchain/pkg/commons/log"
 	"github.com/gobitfly/beaconchain/pkg/commons/utils"
 	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
+	"github.com/gobitfly/beaconchain/pkg/monitoring/services"
 )
 
 type syncCommitteesCountExporter struct {
@@ -34,7 +35,7 @@ func (sc syncCommitteesCountExporter) Export() {
 			return
 		default:
 			startTime := time.Now()
-			statusReport := StatusReporter.NewStatusReport(constants.Event_ExporterLegacySyncCommitteesCount, constants.Default, time.Second*12)
+			statusReport := services.StatusReporter.NewStatusReport(constants.Event_ExporterLegacySyncCommitteesCount, constants.Default, time.Second*12)
 			statusReport(constants.Running, nil)
 
 			err := sc.processSyncCommitteesCount()

--- a/backend/pkg/exporter/modules/sync_committees_count.go
+++ b/backend/pkg/exporter/modules/sync_committees_count.go
@@ -35,7 +35,7 @@ func (sc syncCommitteesCountExporter) Export() {
 			return
 		default:
 			startTime := time.Now()
-			statusReport := services.NewStatusReport(constants.Event_ExporterLegacySyncCommitteesCount, utils.Config.DeploymentType, constants.Default, time.Second*12)
+			statusReport := services.NewStatusReport(constants.Event_ExporterLegacySyncCommitteesCount, constants.Default, time.Second*12)
 			statusReport(constants.Running, nil)
 
 			err := sc.processSyncCommitteesCount()

--- a/backend/pkg/exporter/modules/sync_committees_count.go
+++ b/backend/pkg/exporter/modules/sync_committees_count.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gobitfly/beaconchain/pkg/commons/log"
 	"github.com/gobitfly/beaconchain/pkg/commons/utils"
 	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
-	"github.com/gobitfly/beaconchain/pkg/monitoring/services"
 )
 
 type syncCommitteesCountExporter struct {
@@ -35,7 +34,7 @@ func (sc syncCommitteesCountExporter) Export() {
 			return
 		default:
 			startTime := time.Now()
-			statusReport := services.NewStatusReport(constants.Event_ExporterLegacySyncCommitteesCount, constants.Default, time.Second*12)
+			statusReport := StatusReporter.NewStatusReport(constants.Event_ExporterLegacySyncCommitteesCount, constants.Default, time.Second*12)
 			statusReport(constants.Running, nil)
 
 			err := sc.processSyncCommitteesCount()

--- a/backend/pkg/exporter/modules/sync_committees_count_test.go
+++ b/backend/pkg/exporter/modules/sync_committees_count_test.go
@@ -19,6 +19,7 @@ func TestSyncCommitteesCountExport(t *testing.T) {
 			},
 		},
 	}
+	StatusReporter = stubStatusReporter{}
 
 	t.Run("records exist in db", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)

--- a/backend/pkg/exporter/modules/sync_committees_count_test.go
+++ b/backend/pkg/exporter/modules/sync_committees_count_test.go
@@ -19,7 +19,6 @@ func TestSyncCommitteesCountExport(t *testing.T) {
 			},
 		},
 	}
-	StatusReporter = stubStatusReporter{}
 
 	t.Run("records exist in db", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)

--- a/backend/pkg/exporter/modules/sync_committees_count_test.go
+++ b/backend/pkg/exporter/modules/sync_committees_count_test.go
@@ -18,7 +18,6 @@ func TestSyncCommitteesCountExport(t *testing.T) {
 				EpochsPerSyncCommitteePeriod: 32,
 			},
 		},
-		DeploymentType: "development",
 	}
 
 	t.Run("records exist in db", func(t *testing.T) {

--- a/backend/pkg/exporter/modules/sync_committees_test.go
+++ b/backend/pkg/exporter/modules/sync_committees_test.go
@@ -83,11 +83,12 @@ func TestSyncCommitteesExport(t *testing.T) {
 	defer cancel()
 
 	exporter := syncCommitteesExporter{
-		client: mockClient,
-		db:     mockConsDBClient,
-		delay:  0,
-		ctx:    ctx,
-		cache:  tieredCache,
+		client:         mockClient,
+		db:             mockConsDBClient,
+		delay:          0,
+		ctx:            ctx,
+		cache:          tieredCache,
+		statusReporter: stubStatusReporter{},
 	}
 
 	utils.Config = &types.Config{
@@ -99,7 +100,6 @@ func TestSyncCommitteesExport(t *testing.T) {
 				DepositChainID:               1,
 			},
 		},
-		DeploymentType: "development",
 	}
 
 	for _, tt := range tests {

--- a/backend/pkg/exporter/modules/sync_committees_test.go
+++ b/backend/pkg/exporter/modules/sync_committees_test.go
@@ -101,8 +101,6 @@ func TestSyncCommitteesExport(t *testing.T) {
 		},
 	}
 
-	StatusReporter = stubStatusReporter{}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			latestNodeFinalizedEpochKey := fmt.Sprintf("%d:frontend:latestFinalized", tt.mockDepositChainID)

--- a/backend/pkg/exporter/modules/sync_committees_test.go
+++ b/backend/pkg/exporter/modules/sync_committees_test.go
@@ -83,12 +83,11 @@ func TestSyncCommitteesExport(t *testing.T) {
 	defer cancel()
 
 	exporter := syncCommitteesExporter{
-		client:         mockClient,
-		db:             mockConsDBClient,
-		delay:          0,
-		ctx:            ctx,
-		cache:          tieredCache,
-		statusReporter: stubStatusReporter{},
+		client: mockClient,
+		db:     mockConsDBClient,
+		delay:  0,
+		ctx:    ctx,
+		cache:  tieredCache,
 	}
 
 	utils.Config = &types.Config{
@@ -101,6 +100,8 @@ func TestSyncCommitteesExport(t *testing.T) {
 			},
 		},
 	}
+
+	StatusReporter = stubStatusReporter{}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/backend/pkg/monitoring/monitoring.go
+++ b/backend/pkg/monitoring/monitoring.go
@@ -45,6 +45,7 @@ func Init(full bool) {
 
 func Start() {
 	log.Infof("starting monitoring services")
+	services.InitStatusReport()
 	for _, service := range monitoredServices {
 		service.Start()
 	}
@@ -56,7 +57,7 @@ func Stop() {
 		service.Stop()
 	}
 	// this prevents status reports that werent shut down cleanly from triggering alerts
-	services.NewStatusReport(constants.Event_MonitoringCleanShutdown, constants.Default, constants.Default)(constants.Success, nil)
+	services.StatusReporter.NewStatusReport(constants.Event_MonitoringCleanShutdown, constants.Default, constants.Default)(constants.Success, nil)
 	if startedClickhouse.Load() {
 		db.ClickHouseNativeWriter.Close()
 	}

--- a/backend/pkg/monitoring/monitoring.go
+++ b/backend/pkg/monitoring/monitoring.go
@@ -56,7 +56,7 @@ func Stop() {
 		service.Stop()
 	}
 	// this prevents status reports that werent shut down cleanly from triggering alerts
-	services.NewStatusReport(constants.Event_MonitoringCleanShutdown, utils.Config.DeploymentType, constants.Default, constants.Default)(constants.Success, nil)
+	services.NewStatusReport(constants.Event_MonitoringCleanShutdown, constants.Default, constants.Default)(constants.Success, nil)
 	if startedClickhouse.Load() {
 		db.ClickHouseNativeWriter.Close()
 	}

--- a/backend/pkg/monitoring/services/base.go
+++ b/backend/pkg/monitoring/services/base.go
@@ -45,7 +45,7 @@ func (s *ServiceBase) Stop() {
 	s.wg.Wait()
 }
 
-func NewStatusReport(id constants.Event, timeout time.Duration, check_interval time.Duration) func(status constants.StatusType, metadata map[string]string) {
+func newStatusReport(id constants.Event, timeout time.Duration, check_interval time.Duration) func(status constants.StatusType, metadata map[string]string) {
 	runId := uuid.New().String()
 	return func(status constants.StatusType, metadata map[string]string) {
 		// acquire snowflake synchronously
@@ -149,7 +149,7 @@ func (sr stubStatusReporter) NewStatusReport(id constants.Event, timeout time.Du
 type statusReporter struct{}
 
 func (sr statusReporter) NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) func(status constants.StatusType, metadata map[string]string) {
-	return NewStatusReport(id, timeout, checkInterval)
+	return newStatusReport(id, timeout, checkInterval)
 }
 
 var StatusReporter statusReport = stubStatusReporter{}

--- a/backend/pkg/monitoring/services/base.go
+++ b/backend/pkg/monitoring/services/base.go
@@ -133,3 +133,27 @@ func GetRequiredEvents() []constants.Event {
 	}
 	return requiredEvents
 }
+
+type statusReport interface {
+	NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) func(status constants.StatusType, metadata map[string]string)
+}
+
+type stubStatusReporter struct{}
+
+func (sr stubStatusReporter) NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) func(status constants.StatusType, metadata map[string]string) {
+	return func(status constants.StatusType, metadata map[string]string) {
+		// No-op implementation
+	}
+}
+
+type statusReporter struct{}
+
+func (sr statusReporter) NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) func(status constants.StatusType, metadata map[string]string) {
+	return NewStatusReport(id, timeout, checkInterval)
+}
+
+var StatusReporter statusReport = stubStatusReporter{}
+
+func InitStatusReport() {
+	StatusReporter = statusReporter{}
+}

--- a/backend/pkg/monitoring/services/base.go
+++ b/backend/pkg/monitoring/services/base.go
@@ -142,7 +142,16 @@ type stubStatusReporter struct{}
 
 func (sr stubStatusReporter) NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) func(status constants.StatusType, metadata map[string]string) {
 	return func(status constants.StatusType, metadata map[string]string) {
-		// No-op implementation
+		// no-op implementation
+		// only warn if utils.Config is initialized and we're not in development environment
+		if utils.Config != nil && utils.Config.DeploymentType != "development" {
+			log.Warnf("STUB STATUS REPORTER IN USE IN %s ENVIRONMENT! Event: %s, Status: %s, Metadata: %v",
+				utils.Config.DeploymentType,
+				id,
+				status,
+				metadata,
+			)
+		}
 	}
 }
 

--- a/backend/pkg/monitoring/services/base.go
+++ b/backend/pkg/monitoring/services/base.go
@@ -45,7 +45,7 @@ func (s *ServiceBase) Stop() {
 	s.wg.Wait()
 }
 
-func NewStatusReport(id constants.Event, deploymentType string, timeout time.Duration, check_interval time.Duration) func(status constants.StatusType, metadata map[string]string) {
+func NewStatusReport(id constants.Event, timeout time.Duration, check_interval time.Duration) func(status constants.StatusType, metadata map[string]string) {
 	runId := uuid.New().String()
 	return func(status constants.StatusType, metadata map[string]string) {
 		// acquire snowflake synchronously
@@ -88,7 +88,7 @@ func NewStatusReport(id constants.Event, deploymentType string, timeout time.Dur
 			log.TraceWithFields(log.Fields{
 				"emitter":         id,
 				"event_id":        utils.GetUUID(),
-				"deployment_type": deploymentType,
+				"deployment_type": utils.Config.DeploymentType,
 				"insert_id":       flake,
 				"expires_at":      expires_at,
 				"timeouts_at":     timeouts_at,
@@ -102,16 +102,16 @@ func NewStatusReport(id constants.Event, deploymentType string, timeout time.Dur
 					false, // true means wait for settlement, but we want to shoot and forget. false does mean we cant log any errors that occur during settlement
 					utils.GetUUID(),
 					id,
-					deploymentType,
+					utils.Config.DeploymentType,
 					flake,
 					expires_at,
 					timeouts_at,
 					metadata,
 				)
-			} else if deploymentType != "development" {
+			} else if utils.Config.DeploymentType != "development" {
 				log.Error(nil, "clickhouse native writer is nil", 0)
 			}
-			if err != nil && deploymentType != "development" {
+			if err != nil && utils.Config.DeploymentType != "development" {
 				log.Error(err, "error inserting status report", 0)
 			}
 		}()

--- a/backend/pkg/monitoring/services/clean_shutdown_spam.go
+++ b/backend/pkg/monitoring/services/clean_shutdown_spam.go
@@ -39,7 +39,7 @@ func (s *CleanShutdownSpamDetector) internalProcess() {
 }
 
 func (s *CleanShutdownSpamDetector) runChecks() {
-	r := NewStatusReport(constants.Event_MonitoringCleanShutdownSpam, utils.Config.DeploymentType, constants.Default, 30*time.Second)
+	r := NewStatusReport(constants.Event_MonitoringCleanShutdownSpam, constants.Default, 30*time.Second)
 	r(constants.Running, nil)
 	if db.ClickHouseReader == nil {
 		r(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})

--- a/backend/pkg/monitoring/services/clean_shutdown_spam.go
+++ b/backend/pkg/monitoring/services/clean_shutdown_spam.go
@@ -39,7 +39,7 @@ func (s *CleanShutdownSpamDetector) internalProcess() {
 }
 
 func (s *CleanShutdownSpamDetector) runChecks() {
-	r := NewStatusReport(constants.Event_MonitoringCleanShutdownSpam, constants.Default, 30*time.Second)
+	r := StatusReporter.NewStatusReport(constants.Event_MonitoringCleanShutdownSpam, constants.Default, 30*time.Second)
 	r(constants.Running, nil)
 	if db.ClickHouseReader == nil {
 		r(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})

--- a/backend/pkg/monitoring/services/clickhouse_epoch.go
+++ b/backend/pkg/monitoring/services/clickhouse_epoch.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gobitfly/beaconchain/pkg/commons/db"
 	"github.com/gobitfly/beaconchain/pkg/commons/log"
-	"github.com/gobitfly/beaconchain/pkg/commons/utils"
 	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
 )
 
@@ -37,7 +36,7 @@ func (s *ServiceClickhouseEpoch) internalProcess() {
 }
 
 func (s *ServiceClickhouseEpoch) runChecks() {
-	r := NewStatusReport(constants.Event_ClickhouseDashboardEpoch, utils.Config.DeploymentType, constants.Default, 30*time.Second)
+	r := NewStatusReport(constants.Event_ClickhouseDashboardEpoch, constants.Default, 30*time.Second)
 	r(constants.Running, nil)
 	if db.ClickHouseReader == nil {
 		r(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})

--- a/backend/pkg/monitoring/services/clickhouse_epoch.go
+++ b/backend/pkg/monitoring/services/clickhouse_epoch.go
@@ -36,7 +36,7 @@ func (s *ServiceClickhouseEpoch) internalProcess() {
 }
 
 func (s *ServiceClickhouseEpoch) runChecks() {
-	r := NewStatusReport(constants.Event_ClickhouseDashboardEpoch, constants.Default, 30*time.Second)
+	r := StatusReporter.NewStatusReport(constants.Event_ClickhouseDashboardEpoch, constants.Default, 30*time.Second)
 	r(constants.Running, nil)
 	if db.ClickHouseReader == nil {
 		r(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})

--- a/backend/pkg/monitoring/services/clickhouse_rollings.go
+++ b/backend/pkg/monitoring/services/clickhouse_rollings.go
@@ -56,7 +56,7 @@ func (s *ServiceClickhouseRollings) runChecks() {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			r := NewStatusReport(rollings[rolling], utils.Config.DeploymentType, constants.Default, 30*time.Second)
+			r := NewStatusReport(rollings[rolling], constants.Default, 30*time.Second)
 			r(constants.Running, nil)
 			if db.ClickHouseReader == nil {
 				r(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})

--- a/backend/pkg/monitoring/services/clickhouse_rollings.go
+++ b/backend/pkg/monitoring/services/clickhouse_rollings.go
@@ -56,7 +56,7 @@ func (s *ServiceClickhouseRollings) runChecks() {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			r := NewStatusReport(rollings[rolling], constants.Default, 30*time.Second)
+			r := StatusReporter.NewStatusReport(rollings[rolling], constants.Default, 30*time.Second)
 			r(constants.Running, nil)
 			if db.ClickHouseReader == nil {
 				r(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})

--- a/backend/pkg/monitoring/services/db_connections.go
+++ b/backend/pkg/monitoring/services/db_connections.go
@@ -89,7 +89,7 @@ func (s *ServerDbConnections) checkDBConnections() {
 			// context with deadline
 			ctx, cancel := context.WithTimeout(s.ctx, 15*time.Second)
 			defer cancel()
-			r := NewStatusReport(entry.ID, constants.Default, 10*time.Second)
+			r := StatusReporter.NewStatusReport(entry.ID, constants.Default, 10*time.Second)
 			switch edb := entry.DB.(type) {
 			case *sqlx.DB:
 				err := edb.PingContext(ctx)

--- a/backend/pkg/monitoring/services/db_connections.go
+++ b/backend/pkg/monitoring/services/db_connections.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gobitfly/beaconchain/pkg/commons/cache"
 	"github.com/gobitfly/beaconchain/pkg/commons/db"
 	"github.com/gobitfly/beaconchain/pkg/commons/log"
-	"github.com/gobitfly/beaconchain/pkg/commons/utils"
 	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
 	"github.com/jmoiron/sqlx"
 )
@@ -90,7 +89,7 @@ func (s *ServerDbConnections) checkDBConnections() {
 			// context with deadline
 			ctx, cancel := context.WithTimeout(s.ctx, 15*time.Second)
 			defer cancel()
-			r := NewStatusReport(entry.ID, utils.Config.DeploymentType, constants.Default, 10*time.Second)
+			r := NewStatusReport(entry.ID, constants.Default, 10*time.Second)
 			switch edb := entry.DB.(type) {
 			case *sqlx.DB:
 				err := edb.PingContext(ctx)

--- a/backend/pkg/monitoring/services/flaky_test_service.go
+++ b/backend/pkg/monitoring/services/flaky_test_service.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gobitfly/beaconchain/pkg/commons/utils"
 	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
 )
 
@@ -29,7 +28,7 @@ func (s *FlakyTestService) internalProcess() {
 			return
 		case <-time.After(10 * time.Second):
 			err := fmt.Errorf("random error")
-			NewStatusReport("flaky_test", utils.Config.DeploymentType, constants.Default, constants.Default)(constants.Failure, map[string]string{"error": err.Error()})
+			NewStatusReport("flaky_test", constants.Default, constants.Default)(constants.Failure, map[string]string{"error": err.Error()})
 		}
 	}
 }

--- a/backend/pkg/monitoring/services/flaky_test_service.go
+++ b/backend/pkg/monitoring/services/flaky_test_service.go
@@ -28,7 +28,7 @@ func (s *FlakyTestService) internalProcess() {
 			return
 		case <-time.After(10 * time.Second):
 			err := fmt.Errorf("random error")
-			NewStatusReport("flaky_test", constants.Default, constants.Default)(constants.Failure, map[string]string{"error": err.Error()})
+			StatusReporter.NewStatusReport("flaky_test", constants.Default, constants.Default)(constants.Failure, map[string]string{"error": err.Error()})
 		}
 	}
 }

--- a/backend/pkg/monitoring/services/timeout_detector.go
+++ b/backend/pkg/monitoring/services/timeout_detector.go
@@ -38,7 +38,7 @@ func (s *ServiceTimeoutDetector) internalProcess() {
 }
 
 func (s *ServiceTimeoutDetector) runChecks() {
-	r := NewStatusReport(constants.Event_MonitoringTimeouts, constants.Default, 30*time.Second)
+	r := StatusReporter.NewStatusReport(constants.Event_MonitoringTimeouts, constants.Default, 30*time.Second)
 	r(constants.Running, nil)
 	if db.ClickHouseReader == nil {
 		r(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})

--- a/backend/pkg/monitoring/services/timeout_detector.go
+++ b/backend/pkg/monitoring/services/timeout_detector.go
@@ -38,7 +38,7 @@ func (s *ServiceTimeoutDetector) internalProcess() {
 }
 
 func (s *ServiceTimeoutDetector) runChecks() {
-	r := NewStatusReport(constants.Event_MonitoringTimeouts, utils.Config.DeploymentType, constants.Default, 30*time.Second)
+	r := NewStatusReport(constants.Event_MonitoringTimeouts, constants.Default, 30*time.Second)
 	r(constants.Running, nil)
 	if db.ClickHouseReader == nil {
 		r(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})


### PR DESCRIPTION
Changes:
- Replace direct `services.NewStatusReport` usage with injectable `statusReport` interface
- Add `stubStatusReporter` for testing and `statusReporter` for production
- Make `newStatusReport` function internal
- Eliminate race condition in tests by removing global config access

Testing:
- Update unit tests to use mock status reporter
- Verify no more race detector warnings