### PR TITLE
fix(execution layer): make v2 iso with v1

### DIFF
--- a/backend/pkg/commons/erc1155/erc1155.go
+++ b/backend/pkg/commons/erc1155/erc1155.go
@@ -6,5 +6,5 @@ import (
 
 var abi, _ = contracts.ERC1155MetaData.GetAbi()
 
-var TransferBulkTopic = abi.Events["TransferBulk"].ID
+var TransferBatchTopic = abi.Events["TransferBatch"].ID
 var TransferSingleTopic = abi.Events["TransferSingle"].ID

--- a/backend/pkg/commons/rpc/erigon.go
+++ b/backend/pkg/commons/rpc/erigon.go
@@ -167,7 +167,7 @@ func (client *ErigonClient) GetBlock(number uint64, traceMode string) (*types.Et
 			LogsBloom:            receipt.Bloom[:],
 			Status:               receipt.Status,
 			Logs:                 getLogsFromReceipts(receipt.Logs),
-			Itx:                  getInternalTxs(traceIndex, traces, txPosition),
+			Itx:                  getInternalTxs(&traceIndex, traces, txPosition),
 			MaxFeePerBlobGas:     getMaxFeePerBlobGas(tx),
 			BlobVersionedHashes:  getBlobVersionedHashes(tx),
 			BlobGasPrice:         getBlobGasPrice(receipt),
@@ -517,10 +517,10 @@ func (client *ErigonClient) getSender(tx *gethtypes.Transaction, blockHash commo
 	return sender.Bytes()
 }
 
-func getInternalTxs(traceIndex int, traces []*Eth1InternalTransactionWithPosition, txPosition int) []*types.Eth1InternalTransaction {
+func getInternalTxs(traceIndex *int, traces []*Eth1InternalTransactionWithPosition, txPosition int) []*types.Eth1InternalTransaction {
 	var internals []*types.Eth1InternalTransaction
-	for ; traceIndex < len(traces) && traces[traceIndex].txPosition == txPosition; traceIndex++ {
-		internals = append(internals, &traces[traceIndex].Eth1InternalTransaction)
+	for ; *traceIndex < len(traces) && traces[*traceIndex].txPosition == txPosition; *traceIndex++ {
+		internals = append(internals, &traces[*traceIndex].Eth1InternalTransaction)
 	}
 	return internals
 }

--- a/backend/pkg/commons/rpc/erigon_test.go
+++ b/backend/pkg/commons/rpc/erigon_test.go
@@ -85,9 +85,13 @@ func TestGetInternalTxs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := getInternalTxs(tt.traceIndex, tt.traces, tt.txPosition)
+			currentTrace := tt.traceIndex
+			result := getInternalTxs(&currentTrace, tt.traces, tt.txPosition)
 			if len(result) != len(tt.expected) {
 				t.Fatalf("got %v internal transactions, want %v internal transactions", len(result), len(tt.expected))
+			}
+			if currentTrace == tt.traceIndex {
+				t.Errorf("trace index not increased")
 			}
 			for i, itx := range result {
 				if !bytes.Equal(itx.From, tt.expected[i].From) {

--- a/backend/pkg/executionlayer/blockindexer.go
+++ b/backend/pkg/executionlayer/blockindexer.go
@@ -219,7 +219,7 @@ func (r *reporter) report(total uint64, block *types.Eth1Block, timings *types.G
 		}
 		perc := float64(count) * 100 / float64(total)
 		log.Infof("retrieved & saved block %v (0x%x) in %v (header: %v, receipts: %v, traces: %v, db: %v)", block.Number, block.Hash, time.Since(blockStartTs), timings.Headers, timings.Receipts, timings.Traces, time.Since(dbStart))
-		log.Infof("processed %v blocks in %v (%.1f blocks / sec); sync is %.1f%% complete", block.Number, time.Since(startTs), float64(block.Number)/time.Since(*lastTickTs).Seconds(), perc)
+		log.Infof("processed %v blocks in %v (%.1f blocks / sec); sync is %.1f%% complete", count, time.Since(startTs), float64(count)/time.Since(*lastTickTs).Seconds(), perc)
 
 		*lastTickTs = time.Now()
 	}

--- a/backend/pkg/executionlayer/transformer.go
+++ b/backend/pkg/executionlayer/transformer.go
@@ -345,6 +345,9 @@ func transformITx(chainID string, block *types.Eth1Block, res *db2.IndexedBlock)
 			if !isValidItx(itx) {
 				continue
 			}
+			if itx.GetType() == "delegatecall" {
+				continue
+			}
 
 			indexed := &types.Eth1InternalTransactionIndexed{
 				ParentHash:  tx.GetHash(),
@@ -355,9 +358,6 @@ func transformITx(chainID string, block *types.Eth1Block, res *db2.IndexedBlock)
 				To:          itx.GetTo(),
 				Value:       itx.GetValue(),
 				Reverted:    reverted,
-			}
-			if itx.GetType() == "delegatecall" {
-				continue
 			}
 			transactions = append(transactions, db2.InternalWithIndexes{
 				Indexed:       indexed,
@@ -717,10 +717,10 @@ func isValidERC1155Log(log *types.Eth1Log) bool {
 
 	// check if first topic matches TransferSingle or TransferBatch topic
 	firstTopic := log.GetTopics()[0]
-	isTransferBulk := bytes.Equal(firstTopic, erc1155.TransferBulkTopic.Bytes())
+	isTransferBatch := bytes.Equal(firstTopic, erc1155.TransferBatchTopic.Bytes())
 	isTransferSingle := bytes.Equal(firstTopic, erc1155.TransferSingleTopic.Bytes())
 
-	return isTransferBulk || isTransferSingle
+	return isTransferBatch || isTransferSingle
 }
 
 func isBlobTx(txType uint32) bool {

--- a/backend/pkg/executionlayer/transformer_test.go
+++ b/backend/pkg/executionlayer/transformer_test.go
@@ -319,7 +319,7 @@ func TestTransformERC1155(t *testing.T) {
 				},
 			},
 		},
-		// TODO add transfer bulk when bug fixed
+		// TODO add transfer Batch when bug fixed
 	}
 
 	for _, tt := range tests {
@@ -1458,10 +1458,10 @@ func TestIsValidERC1155Log(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "valid TransferBulkTopic log",
+			name: "valid TransferBatchTopic log",
 			log: &types.Eth1Log{
 				Topics: [][]byte{
-					erc1155.TransferBulkTopic.Bytes(),
+					erc1155.TransferBatchTopic.Bytes(),
 					alice,
 					bob,
 					john,
@@ -1493,10 +1493,10 @@ func TestIsValidERC1155Log(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "invalid TransferBulkTopic log with too little topics",
+			name: "invalid TransferBatchTopic log with too little topics",
 			log: &types.Eth1Log{
 				Topics: [][]byte{
-					erc1155.TransferBulkTopic.Bytes(),
+					erc1155.TransferBatchTopic.Bytes(),
 					alice,
 					bob,
 				},
@@ -1517,10 +1517,10 @@ func TestIsValidERC1155Log(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "invalid TransferBulkTopic log with too many topics",
+			name: "invalid TransferBatchTopic log with too many topics",
 			log: &types.Eth1Log{
 				Topics: [][]byte{
-					erc1155.TransferBulkTopic.Bytes(),
+					erc1155.TransferBatchTopic.Bytes(),
 					alice,
 					bob,
 					john,


### PR DESCRIPTION
Fix multiple little issues
* TransferBatch log topic for erc1155
* internal tx parser properly increase current trace index
* fix execution layer reporter log

**Tested on**: mainnet with live indexing for 7k blocks (1 day)