### PR TITLE
refactor(monitoring): update Status Reporter and clean up db functions

### DIFF
--- a/backend/pkg/api/data_access/healthz.go
+++ b/backend/pkg/api/data_access/healthz.go
@@ -117,7 +117,11 @@ func (d *DataAccessService) GetHealthz(ctx context.Context, showAll bool) types.
 	for _, result := range results {
 		response.Reports[result.EventId] = append(response.Reports[result.EventId], result)
 	}
-	requiredEvents := monitoringServices.GetRequiredEvents()
+	requiredEvents := monitoringServices.GetRequiredEvents(
+		utils.Config.DeploymentType,
+		utils.Config.RocketpoolExporter.Enabled,
+		utils.Config.Indexer.PubKeyTagsExporter.Enabled,
+	)
 	for _, id := range requiredEvents {
 		if _, ok := response.Reports[string(id)]; !ok {
 			response.Reports[string(id)] = []types.HealthzResult{

--- a/backend/pkg/api/services/service.go
+++ b/backend/pkg/api/services/service.go
@@ -40,7 +40,7 @@ func NewServices(readerDb, writerDb, alloyReader, alloyWriter, clickhouseReader 
 func (s *Services) InitServices() {
 	wg := &sync.WaitGroup{}
 	log.Infof("initializing services...")
-	services.InitStatusReport()
+	services.InitStatusReporter(utils.Config.DeploymentType)
 	wg.Add(4)
 	go s.startSlotVizDataService(wg)
 	go s.startIndexMappingService(wg)

--- a/backend/pkg/api/services/service_average_network_efficiency.go
+++ b/backend/pkg/api/services/service_average_network_efficiency.go
@@ -26,16 +26,16 @@ func (s *Services) startEfficiencyDataService(wg *sync.WaitGroup) {
 	for {
 		startTime := time.Now()
 		delay := time.Duration(utils.Config.Chain.ClConfig.SlotsPerEpoch*utils.Config.Chain.ClConfig.SecondsPerSlot) * time.Second
-		r := services.StatusReporter().NewStatusReport(constants.Event_ApiServiceAvgEfficiency, constants.Default, delay)
-		r(constants.Running, nil)
+		statusReporter := services.NewStatusReporter(constants.Event_ApiServiceAvgEfficiency, constants.Default, delay)
+		statusReporter.Report(constants.Running, nil)
 		err := s.updateEfficiencyData() // TODO: only update data if something has changed (new head epoch)
 		if err != nil {
 			log.Error(err, "error updating average network efficiency data", 0)
-			r(constants.Failure, map[string]string{"error": err.Error()})
+			statusReporter.Report(constants.Failure, map[string]string{"error": err.Error()})
 			delay = 10 * time.Second
 		} else {
 			log.Infof("=== average network efficiency data updated in %s", time.Since(startTime))
-			r(constants.Success, map[string]string{"took": time.Since(startTime).String(), "took_raw": fmt.Sprintf("%v", time.Since(startTime).Milliseconds())})
+			statusReporter.Report(constants.Success, map[string]string{"took": time.Since(startTime).String(), "took_raw": fmt.Sprintf("%v", time.Since(startTime).Milliseconds())})
 			o.Do(func() {
 				wg.Done()
 			})

--- a/backend/pkg/api/services/service_average_network_efficiency.go
+++ b/backend/pkg/api/services/service_average_network_efficiency.go
@@ -26,7 +26,7 @@ func (s *Services) startEfficiencyDataService(wg *sync.WaitGroup) {
 	for {
 		startTime := time.Now()
 		delay := time.Duration(utils.Config.Chain.ClConfig.SlotsPerEpoch*utils.Config.Chain.ClConfig.SecondsPerSlot) * time.Second
-		r := services.StatusReporter.NewStatusReport(constants.Event_ApiServiceAvgEfficiency, constants.Default, delay)
+		r := services.StatusReporter().NewStatusReport(constants.Event_ApiServiceAvgEfficiency, constants.Default, delay)
 		r(constants.Running, nil)
 		err := s.updateEfficiencyData() // TODO: only update data if something has changed (new head epoch)
 		if err != nil {

--- a/backend/pkg/api/services/service_slot_viz.go
+++ b/backend/pkg/api/services/service_slot_viz.go
@@ -32,15 +32,15 @@ func (s *Services) startSlotVizDataService(wg *sync.WaitGroup) {
 	for {
 		startTime := time.Now()
 		delay := time.Duration(utils.Config.Chain.ClConfig.SecondsPerSlot) * time.Second
-		r := services.StatusReporter().NewStatusReport(constants.Event_ApiServiceSlotViz, constants.Default, delay)
-		r(constants.Running, nil)
+		statusReporter := services.NewStatusReporter(constants.Event_ApiServiceSlotViz, constants.Default, delay)
+		statusReporter.Report(constants.Running, nil)
 		err := s.updateSlotVizData() // TODO: only update data if something has changed (new head slot or new head epoch)
 		if err != nil {
 			log.Error(err, "error updating slotviz data", 0)
-			r(constants.Failure, map[string]string{"error": err.Error()})
+			statusReporter.Report(constants.Failure, map[string]string{"error": err.Error()})
 		}
 		log.Infof("=== slotviz data updated in %s", time.Since(startTime))
-		r(constants.Success, map[string]string{"took": time.Since(startTime).String(), "took_raw": fmt.Sprintf("%v", time.Since(startTime).Milliseconds())})
+		statusReporter.Report(constants.Success, map[string]string{"took": time.Since(startTime).String(), "took_raw": fmt.Sprintf("%v", time.Since(startTime).Milliseconds())})
 		o.Do(func() {
 			wg.Done()
 		})

--- a/backend/pkg/api/services/service_slot_viz.go
+++ b/backend/pkg/api/services/service_slot_viz.go
@@ -32,7 +32,7 @@ func (s *Services) startSlotVizDataService(wg *sync.WaitGroup) {
 	for {
 		startTime := time.Now()
 		delay := time.Duration(utils.Config.Chain.ClConfig.SecondsPerSlot) * time.Second
-		r := services.StatusReporter.NewStatusReport(constants.Event_ApiServiceSlotViz, constants.Default, delay)
+		r := services.StatusReporter().NewStatusReport(constants.Event_ApiServiceSlotViz, constants.Default, delay)
 		r(constants.Running, nil)
 		err := s.updateSlotVizData() // TODO: only update data if something has changed (new head slot or new head epoch)
 		if err != nil {

--- a/backend/pkg/api/services/service_validator_mapping.go
+++ b/backend/pkg/api/services/service_validator_mapping.go
@@ -41,7 +41,7 @@ func (s *Services) startIndexMappingService(wg *sync.WaitGroup) {
 		startTime := time.Now()
 		delay := time.Duration(utils.Config.Chain.ClConfig.SecondsPerSlot) * time.Second
 		err = nil // clear error
-		r := services.StatusReporter.NewStatusReport(constants.Event_ApiServiceValidatorMapping, constants.Default, delay)
+		r := services.StatusReporter().NewStatusReport(constants.Event_ApiServiceValidatorMapping, constants.Default, delay)
 		r(constants.Running, nil)
 		latestEpoch := cache.LatestEpoch.Get()
 		if currentValidatorMapping.Load() == nil || latestEpoch != lastEpochUpdate {

--- a/backend/pkg/api/services/service_validator_mapping.go
+++ b/backend/pkg/api/services/service_validator_mapping.go
@@ -41,19 +41,19 @@ func (s *Services) startIndexMappingService(wg *sync.WaitGroup) {
 		startTime := time.Now()
 		delay := time.Duration(utils.Config.Chain.ClConfig.SecondsPerSlot) * time.Second
 		err = nil // clear error
-		r := services.StatusReporter().NewStatusReport(constants.Event_ApiServiceValidatorMapping, constants.Default, delay)
-		r(constants.Running, nil)
+		statusReporter := services.NewStatusReporter(constants.Event_ApiServiceValidatorMapping, constants.Default, delay)
+		statusReporter.Report(constants.Running, nil)
 		latestEpoch := cache.LatestEpoch.Get()
 		if currentValidatorMapping.Load() == nil || latestEpoch != lastEpochUpdate {
 			err = s.updateValidatorMapping()
 		}
 		if err != nil {
 			log.Error(err, "error updating validator mapping", 0)
-			r(constants.Failure, map[string]string{"error": err.Error()})
+			statusReporter.Report(constants.Failure, map[string]string{"error": err.Error()})
 			delay = 10 * time.Second
 		} else {
 			log.Infof("=== validator mapping updated in %s", time.Since(startTime))
-			r(constants.Success, map[string]string{"took": time.Since(startTime).String(), "took_raw": fmt.Sprintf("%v", time.Since(startTime).Milliseconds()), "latest_epoch": fmt.Sprintf("%d", lastEpochUpdate)})
+			statusReporter.Report(constants.Success, map[string]string{"took": time.Since(startTime).String(), "took_raw": fmt.Sprintf("%v", time.Since(startTime).Milliseconds()), "latest_epoch": fmt.Sprintf("%d", lastEpochUpdate)})
 			lastEpochUpdate = latestEpoch
 			o.Do(func() {
 				wg.Done()

--- a/backend/pkg/commons/db2/db.go
+++ b/backend/pkg/commons/db2/db.go
@@ -45,4 +45,5 @@ type Monitoring interface {
 	SaveNewStatusReport(status StatusReport) error
 	GetEmitters() ([]string, error)
 	GetVDLatestEpochTs() (time.Time, error)
+	GetVDRollingEpochEnd(rolling string) (uint64, error)
 }

--- a/backend/pkg/commons/db2/db.go
+++ b/backend/pkg/commons/db2/db.go
@@ -43,6 +43,7 @@ type LastBlocksStoreWriter interface {
 
 type Monitoring interface {
 	SaveNewStatusReport(status StatusReport) error
+	GetLatestStatusReport() ([]Victims, error)
 	GetEmitters() ([]string, error)
 	GetVDLatestEpochTs() (time.Time, error)
 	GetVDRollingEpochEnd(rolling string) (uint64, error)

--- a/backend/pkg/commons/db2/db.go
+++ b/backend/pkg/commons/db2/db.go
@@ -45,6 +45,6 @@ type Monitoring interface {
 	SaveNewStatusReport(status StatusReport) error
 	GetLatestStatusReport() ([]Victims, error)
 	GetEmitters() ([]string, error)
-	GetVDLatestEpochTs() (time.Time, error)
-	GetVDRollingEpochEnd(rolling string) (uint64, error)
+	GetLatestEpoch() (time.Time, error)
+	GetEpochEnd(rolling string) (uint64, error)
 }

--- a/backend/pkg/commons/db2/db.go
+++ b/backend/pkg/commons/db2/db.go
@@ -38,3 +38,7 @@ type LastBlocksStoreWriter interface {
 	SetInBlocksTable(chainID string, number uint64) error
 	SetInDataTable(chainID string, number uint64) error
 }
+
+type Monitoring interface {
+	SaveNewStatusReport(status StatusReport) error
+}

--- a/backend/pkg/commons/db2/db.go
+++ b/backend/pkg/commons/db2/db.go
@@ -1,6 +1,8 @@
 package db2
 
 import (
+	"time"
+
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/gobitfly/beaconchain/pkg/commons/types"
@@ -42,4 +44,5 @@ type LastBlocksStoreWriter interface {
 type Monitoring interface {
 	SaveNewStatusReport(status StatusReport) error
 	GetEmitters() ([]string, error)
+	GetVDLatestEpochTs() (time.Time, error)
 }

--- a/backend/pkg/commons/db2/db.go
+++ b/backend/pkg/commons/db2/db.go
@@ -41,4 +41,5 @@ type LastBlocksStoreWriter interface {
 
 type Monitoring interface {
 	SaveNewStatusReport(status StatusReport) error
+	GetEmitters() ([]string, error)
 }

--- a/backend/pkg/commons/db2/monitoring.go
+++ b/backend/pkg/commons/db2/monitoring.go
@@ -73,6 +73,80 @@ func (m *MonitoringDB) SaveNewStatusReport(status StatusReport) error {
 	return err
 }
 
+type Victims struct {
+	EventID    string            `db:"event_id"`
+	Emitter    string            `db:"emitter"`
+	Status     string            `db:"status"`
+	InsertedAt time.Time         `db:"inserted_at"`
+	ExpiresAt  time.Time         `db:"expires_at"`
+	TimeoutsAt time.Time         `db:"timeouts_at"`
+	Metadata   map[string]string `db:"metadata"`
+}
+
+func (m *MonitoringDB) GetLatestStatusReport() ([]Victims, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	query := `
+		with active_reports as (
+			SELECT
+				event_id,
+				emitter,
+				run_id,
+				inserted_at,
+				insert_id,
+				expires_at,
+				timeouts_at,
+				status,
+				metadata
+			FROM status_reports
+			WHERE expires_at > now() and deployment_type = ? and emitter not in (select distinct emitter from status_reports where event_id = ? and inserted_at > now() - interval 1 days)
+			ORDER BY
+				event_id ASC,
+				emitter ASC,
+				run_id ASC,
+				insert_id DESC
+		), latest_report_per_run as (
+			SELECT
+				event_id,
+				emitter,
+				any(inserted_at) as inserted_at, 
+				any(insert_id) as insert_id, 
+				any(expires_at) as expires_at,
+				any(timeouts_at) as timeouts_at,
+				any(status) AS status,
+				any(metadata) AS metadata
+			FROM
+				active_reports
+			GROUP BY
+				event_id,
+				emitter,
+				run_id
+			order by insert_id desc
+		)
+		SELECT
+			event_id,
+			emitter,
+			status,
+			inserted_at,
+			expires_at,
+			timeouts_at,
+			metadata
+		FROM
+			latest_report_per_run
+		WHERE status = 'running' and timeouts_at < now()
+		ORDER BY event_id ASC, inserted_at DESC
+		`
+
+	var victims []Victims
+	err := m.ClickHouseReader.SelectContext(ctx, &victims, query, utils.Config.DeploymentType, constants.Event_MonitoringCleanShutdown)
+	if err != nil {
+		return nil, err
+	}
+
+	return victims, nil
+}
+
 func (m *MonitoringDB) GetEmitters() ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()

--- a/backend/pkg/commons/db2/monitoring.go
+++ b/backend/pkg/commons/db2/monitoring.go
@@ -1,0 +1,73 @@
+package db2
+
+import (
+	"context"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/gobitfly/beaconchain/pkg/commons/db"
+	"github.com/gobitfly/beaconchain/pkg/commons/utils"
+	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
+	"github.com/jmoiron/sqlx"
+)
+
+type MonitoringDB struct {
+	ClickHouseReader       *sqlx.DB
+	ClickHouseNativeWriter driver.Conn
+}
+
+func NewMonitoringDB() *MonitoringDB {
+	return &MonitoringDB{
+		ClickHouseReader:       db.ClickHouseReader,
+		ClickHouseNativeWriter: db.ClickHouseNativeWriter,
+	}
+}
+
+type StatusReport struct {
+	ID         constants.Event
+	Flake      int64
+	ExpiresAt  time.Time
+	TimeoutsAt time.Time
+	Metadata   map[string]string
+}
+
+func (m *MonitoringDB) SaveNewStatusReport(status StatusReport) error {
+	timeoutContext, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// wrap in clickhouse context so we can set the setting throw_if_deduplication_in_dependent_materialized_views_enabled_with_async_insert to 0
+	// we have no materialized views on the status_reports table, but it triggers as we need the deduplication setting for the other tables
+	ctx := clickhouse.Context(timeoutContext, clickhouse.WithSettings(
+		clickhouse.Settings{
+			"throw_if_deduplication_in_dependent_materialized_views_enabled_with_async_insert": 0,
+		},
+	))
+
+	stmt := `INSERT INTO status_reports (
+		emitter, 
+		event_id, 
+		deployment_type, 
+		insert_id, 
+		expires_at, 
+		timeouts_at, 
+		metadata
+	) 
+	VALUES 
+		(?, ?, ?, ?, ?, ?, ?)`
+
+	err := m.ClickHouseNativeWriter.AsyncInsert(
+		ctx,
+		stmt,
+		false, // true means wait for settlement, but we want to shoot and forget. false does mean we cant log any errors that occur during settlement
+		utils.GetUUID(),
+		status.ID,
+		utils.Config.DeploymentType,
+		status.Flake,
+		status.ExpiresAt,
+		status.TimeoutsAt,
+		status.Metadata,
+	)
+
+	return err
+}

--- a/backend/pkg/commons/db2/monitoring.go
+++ b/backend/pkg/commons/db2/monitoring.go
@@ -71,3 +71,27 @@ func (m *MonitoringDB) SaveNewStatusReport(status StatusReport) error {
 
 	return err
 }
+
+func (m *MonitoringDB) GetEmitters() ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	query := `
+		SELECT
+			emitter
+		FROM
+			status_reports
+		WHERE
+			deployment_type = ?
+			AND inserted_at >= now() - interval 5 minutes
+			AND event_id = ?
+		`
+
+	var emitters []string
+	err := m.ClickHouseReader.SelectContext(ctx, &emitters, query, utils.Config.DeploymentType, constants.Event_MonitoringCleanShutdown)
+	if err != nil {
+		return nil, err
+	}
+
+	return emitters, nil
+}

--- a/backend/pkg/commons/db2/monitoring.go
+++ b/backend/pkg/commons/db2/monitoring.go
@@ -2,6 +2,7 @@ package db2
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -111,4 +112,23 @@ func (m *MonitoringDB) GetVDLatestEpochTs() (time.Time, error) {
 	}
 
 	return ts, err
+}
+
+func (m *MonitoringDB) GetVDRollingEpochEnd(rolling string) (uint64, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	var epochEnd uint64
+	err := m.ClickHouseReader.GetContext(ctx, &epochEnd, fmt.Sprintf(`
+			SELECT
+				max(epoch_end)
+			FROM validator_dashboard_data_rolling_%s`,
+		rolling,
+	),
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	return epochEnd, err
 }

--- a/backend/pkg/commons/db2/monitoring.go
+++ b/backend/pkg/commons/db2/monitoring.go
@@ -95,3 +95,20 @@ func (m *MonitoringDB) GetEmitters() ([]string, error) {
 
 	return emitters, nil
 }
+
+func (m *MonitoringDB) GetVDLatestEpochTs() (time.Time, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	var ts time.Time
+	err := m.ClickHouseReader.GetContext(
+		ctx,
+		&ts,
+		"SELECT MAX(t) FROM view_validator_dashboard_data_epoch_max_ts",
+	)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	return ts, err
+}

--- a/backend/pkg/commons/db2/monitoring.go
+++ b/backend/pkg/commons/db2/monitoring.go
@@ -7,21 +7,20 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/gobitfly/beaconchain/pkg/commons/db"
 	"github.com/gobitfly/beaconchain/pkg/commons/utils"
 	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
 	"github.com/jmoiron/sqlx"
 )
 
-type MonitoringDB struct {
+type MonitoringClickhouse struct {
 	ClickHouseReader       *sqlx.DB
 	ClickHouseNativeWriter driver.Conn
 }
 
-func NewMonitoringDB() *MonitoringDB {
-	return &MonitoringDB{
-		ClickHouseReader:       db.ClickHouseReader,
-		ClickHouseNativeWriter: db.ClickHouseNativeWriter,
+func NewMonitoringClickhouse(chReader *sqlx.DB, chNativeWriter driver.Conn) *MonitoringClickhouse {
+	return &MonitoringClickhouse{
+		ClickHouseReader:       chReader,
+		ClickHouseNativeWriter: chNativeWriter,
 	}
 }
 
@@ -33,7 +32,7 @@ type StatusReport struct {
 	Metadata   map[string]string
 }
 
-func (m *MonitoringDB) SaveNewStatusReport(status StatusReport) error {
+func (m *MonitoringClickhouse) SaveNewStatusReport(status StatusReport) error {
 	timeoutContext, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -83,7 +82,7 @@ type Victims struct {
 	Metadata   map[string]string `db:"metadata"`
 }
 
-func (m *MonitoringDB) GetLatestStatusReport() ([]Victims, error) {
+func (m *MonitoringClickhouse) GetLatestStatusReport() ([]Victims, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
@@ -147,7 +146,7 @@ func (m *MonitoringDB) GetLatestStatusReport() ([]Victims, error) {
 	return victims, nil
 }
 
-func (m *MonitoringDB) GetEmitters() ([]string, error) {
+func (m *MonitoringClickhouse) GetEmitters() ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
@@ -171,7 +170,7 @@ func (m *MonitoringDB) GetEmitters() ([]string, error) {
 	return emitters, nil
 }
 
-func (m *MonitoringDB) GetVDLatestEpochTs() (time.Time, error) {
+func (m *MonitoringClickhouse) GetLatestEpoch() (time.Time, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
@@ -185,10 +184,10 @@ func (m *MonitoringDB) GetVDLatestEpochTs() (time.Time, error) {
 		return time.Time{}, err
 	}
 
-	return ts, err
+	return ts, nil
 }
 
-func (m *MonitoringDB) GetVDRollingEpochEnd(rolling string) (uint64, error) {
+func (m *MonitoringClickhouse) GetEpochEnd(rolling string) (uint64, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
@@ -204,5 +203,5 @@ func (m *MonitoringDB) GetVDRollingEpochEnd(rolling string) (uint64, error) {
 		return 0, err
 	}
 
-	return epochEnd, err
+	return epochEnd, nil
 }

--- a/backend/pkg/exporter/modules/base.go
+++ b/backend/pkg/exporter/modules/base.go
@@ -168,15 +168,15 @@ func notifyAllModules(goPool *errgroup.Group, modules []ModuleInterface, f func(
 		module := module
 		goPool.Go(func() error {
 			start := time.Now()
-			r := services.StatusReporter().NewStatusReport(module.GetMonitoringEventId(), 5*time.Minute, constants.Default)
-			r(constants.Running, nil)
+			statusReporter := services.NewStatusReporter(module.GetMonitoringEventId(), 5*time.Minute, constants.Default)
+			statusReporter.Report(constants.Running, nil)
 			err := f(module)
 			if err != nil {
 				log.Error(err, fmt.Sprintf("error in module %s", module.GetName()), 0)
-				r(constants.Failure, map[string]string{"error": err.Error()})
+				statusReporter.Report(constants.Failure, map[string]string{"error": err.Error()})
 				return nil // return never gets caught anywhere? lets not risk a memory leak and instead return nil
 			}
-			r(constants.Success, map[string]string{"took_raw": fmt.Sprintf("%v", time.Since(start).Milliseconds())})
+			statusReporter.Report(constants.Success, map[string]string{"took_raw": fmt.Sprintf("%v", time.Since(start).Milliseconds())})
 			return nil
 		})
 	}

--- a/backend/pkg/exporter/modules/base.go
+++ b/backend/pkg/exporter/modules/base.go
@@ -41,7 +41,7 @@ var Client *rpc.Client
 
 // Start will start the export of data from rpc into the database
 func StartAll(moduleCtx ModuleContext, modules []ModuleInterface, justV2 bool) {
-	services.InitStatusReport()
+	services.InitStatusReporter(utils.Config.DeploymentType)
 	if !justV2 {
 		ctx := context.Background()
 		consDB := db2.NewConsensusRepository(db.ReaderDb, db.WriterDb)
@@ -168,7 +168,7 @@ func notifyAllModules(goPool *errgroup.Group, modules []ModuleInterface, f func(
 		module := module
 		goPool.Go(func() error {
 			start := time.Now()
-			r := services.StatusReporter.NewStatusReport(module.GetMonitoringEventId(), 5*time.Minute, constants.Default)
+			r := services.StatusReporter().NewStatusReport(module.GetMonitoringEventId(), 5*time.Minute, constants.Default)
 			r(constants.Running, nil)
 			err := f(module)
 			if err != nil {

--- a/backend/pkg/exporter/modules/network_liveness.go
+++ b/backend/pkg/exporter/modules/network_liveness.go
@@ -57,7 +57,7 @@ func (n *networkLivenessUpdater) Export() {
 			log.Info("network liveness export loop cancelled")
 			return
 		default:
-			statusReport := services.StatusReporter.NewStatusReport(constants.Event_ExporterLegacyNetworkLiveness, constants.Default, slotDuration)
+			statusReport := services.StatusReporter().NewStatusReport(constants.Event_ExporterLegacyNetworkLiveness, constants.Default, slotDuration)
 			statusReport(constants.Running, nil)
 
 			head, err := n.client.GetChainHead()

--- a/backend/pkg/exporter/modules/network_liveness.go
+++ b/backend/pkg/exporter/modules/network_liveness.go
@@ -57,26 +57,26 @@ func (n *networkLivenessUpdater) Export() {
 			log.Info("network liveness export loop cancelled")
 			return
 		default:
-			statusReport := services.StatusReporter().NewStatusReport(constants.Event_ExporterLegacyNetworkLiveness, constants.Default, slotDuration)
-			statusReport(constants.Running, nil)
+			statusReporter := services.NewStatusReporter(constants.Event_ExporterLegacyNetworkLiveness, constants.Default, slotDuration)
+			statusReporter.Report(constants.Running, nil)
 
 			head, err := n.client.GetChainHead()
 			if err != nil {
 				log.Error(err, "error getting chainhead when exporting network liveness", 0)
-				statusReport(constants.Failure, map[string]string{"error": err.Error()})
+				statusReporter.Report(constants.Failure, map[string]string{"error": err.Error()})
 				time.Sleep(slotDuration)
 				continue
 			}
 
 			if prevHeadEpoch == head.HeadEpoch {
-				statusReport(constants.Success, nil)
+				statusReporter.Report(constants.Success, nil)
 				time.Sleep(slotDuration)
 				continue
 			}
 
 			// wait for node to be synced
 			if nodeNotSynced(head.HeadEpoch, epochDuration) {
-				statusReport(constants.Failure, map[string]string{"error": "node not synced"})
+				statusReporter.Report(constants.Failure, map[string]string{"error": "node not synced"})
 				time.Sleep(slotDuration)
 				continue
 			}
@@ -84,7 +84,7 @@ func (n *networkLivenessUpdater) Export() {
 			err = n.db.SaveNetworkLivenessData(head)
 			if err != nil {
 				log.Error(err, "error saving network liveness in db", 0)
-				statusReport(constants.Failure, map[string]string{"error": err.Error()})
+				statusReporter.Report(constants.Failure, map[string]string{"error": err.Error()})
 			} else {
 				log.Infof("updated network liveness for epoch %v", head.HeadEpoch)
 				prevHeadEpoch = head.HeadEpoch
@@ -93,10 +93,10 @@ func (n *networkLivenessUpdater) Export() {
 			err = n.updateCache(head)
 			if err != nil {
 				log.Error(err, "error updating cache", 0)
-				statusReport(constants.Failure, map[string]string{"error": err.Error()})
+				statusReporter.Report(constants.Failure, map[string]string{"error": err.Error()})
 			}
 
-			statusReport(constants.Success, nil)
+			statusReporter.Report(constants.Success, nil)
 
 			time.Sleep(slotDuration)
 		}

--- a/backend/pkg/exporter/modules/pubkey_tags.go
+++ b/backend/pkg/exporter/modules/pubkey_tags.go
@@ -35,17 +35,17 @@ func (p *pubkeyTagsUpdater) Update() {
 			return
 		default:
 			startTime := time.Now()
-			statusReport := services.StatusReporter().NewStatusReport(constants.Event_ExporterLegacyPubkeyTags, p.delay, time.Second*12)
-			statusReport(constants.Running, nil)
+			statusReporter := services.NewStatusReporter(constants.Event_ExporterLegacyPubkeyTags, p.delay, time.Second*12)
+			statusReporter.Report(constants.Running, nil)
 
 			err := p.db.UpdatePubkeyTags()
 			if err != nil {
 				log.Error(err, "error updating validator_tags", 0)
-				statusReport(constants.Failure, map[string]string{"error": err.Error()})
+				statusReporter.Report(constants.Failure, map[string]string{"error": err.Error()})
 			}
 
 			log.Infof("Updating Pubkey Tags took %v sec.", time.Since(startTime).Seconds())
-			statusReport(constants.Success, map[string]string{
+			statusReporter.Report(constants.Success, map[string]string{
 				"took":     time.Since(startTime).String(),
 				"took_raw": fmt.Sprintf("%v", time.Since(startTime).Milliseconds()),
 			})

--- a/backend/pkg/exporter/modules/pubkey_tags.go
+++ b/backend/pkg/exporter/modules/pubkey_tags.go
@@ -35,7 +35,7 @@ func (p *pubkeyTagsUpdater) Update() {
 			return
 		default:
 			startTime := time.Now()
-			statusReport := services.StatusReporter.NewStatusReport(constants.Event_ExporterLegacyPubkeyTags, p.delay, time.Second*12)
+			statusReport := services.StatusReporter().NewStatusReport(constants.Event_ExporterLegacyPubkeyTags, p.delay, time.Second*12)
 			statusReport(constants.Running, nil)
 
 			err := p.db.UpdatePubkeyTags()

--- a/backend/pkg/exporter/modules/sync_committees.go
+++ b/backend/pkg/exporter/modules/sync_committees.go
@@ -51,7 +51,7 @@ func (s syncCommitteesExporter) Export() {
 			return
 		default:
 			startTime := time.Now()
-			statusReport := services.StatusReporter.NewStatusReport(constants.Event_ExporterLegacySyncCommittees, constants.Default, time.Second*12)
+			statusReport := services.StatusReporter().NewStatusReport(constants.Event_ExporterLegacySyncCommittees, constants.Default, time.Second*12)
 			statusReport(constants.Running, nil)
 
 			err := s.exportSyncCommittees()

--- a/backend/pkg/exporter/modules/sync_committees.go
+++ b/backend/pkg/exporter/modules/sync_committees.go
@@ -51,15 +51,15 @@ func (s syncCommitteesExporter) Export() {
 			return
 		default:
 			startTime := time.Now()
-			statusReport := services.StatusReporter().NewStatusReport(constants.Event_ExporterLegacySyncCommittees, constants.Default, time.Second*12)
-			statusReport(constants.Running, nil)
+			statusReporter := services.NewStatusReporter(constants.Event_ExporterLegacySyncCommittees, constants.Default, time.Second*12)
+			statusReporter.Report(constants.Running, nil)
 
 			err := s.exportSyncCommittees()
 			if err != nil {
 				log.Error(err, "error exporting sync_committees", 0, map[string]interface{}{"duration": time.Since(startTime)})
-				statusReport(constants.Failure, map[string]string{"error": err.Error()})
+				statusReporter.Report(constants.Failure, map[string]string{"error": err.Error()})
 			}
-			statusReport(constants.Success, map[string]string{
+			statusReporter.Report(constants.Success, map[string]string{
 				"took":     time.Since(startTime).String(),
 				"took_raw": fmt.Sprintf("%v", time.Since(startTime).Milliseconds()),
 			})

--- a/backend/pkg/exporter/modules/sync_committees_count.go
+++ b/backend/pkg/exporter/modules/sync_committees_count.go
@@ -35,15 +35,15 @@ func (sc syncCommitteesCountExporter) Export() {
 			return
 		default:
 			startTime := time.Now()
-			statusReport := services.StatusReporter().NewStatusReport(constants.Event_ExporterLegacySyncCommitteesCount, constants.Default, time.Second*12)
-			statusReport(constants.Running, nil)
+			statusReporter := services.NewStatusReporter(constants.Event_ExporterLegacySyncCommitteesCount, constants.Default, time.Second*12)
+			statusReporter.Report(constants.Running, nil)
 
 			err := sc.processSyncCommitteesCount()
 			if err != nil {
 				log.Error(err, "error exporting sync_committees_count_per_validator", 0)
-				statusReport(constants.Failure, map[string]string{"error": err.Error()})
+				statusReporter.Report(constants.Failure, map[string]string{"error": err.Error()})
 			} else {
-				statusReport(constants.Success, map[string]string{
+				statusReporter.Report(constants.Success, map[string]string{
 					"took":     time.Since(startTime).String(),
 					"took_raw": fmt.Sprintf("%v", time.Since(startTime).Milliseconds()),
 				})

--- a/backend/pkg/exporter/modules/sync_committees_count.go
+++ b/backend/pkg/exporter/modules/sync_committees_count.go
@@ -35,7 +35,7 @@ func (sc syncCommitteesCountExporter) Export() {
 			return
 		default:
 			startTime := time.Now()
-			statusReport := services.StatusReporter.NewStatusReport(constants.Event_ExporterLegacySyncCommitteesCount, constants.Default, time.Second*12)
+			statusReport := services.StatusReporter().NewStatusReport(constants.Event_ExporterLegacySyncCommitteesCount, constants.Default, time.Second*12)
 			statusReport(constants.Running, nil)
 
 			err := sc.processSyncCommitteesCount()

--- a/backend/pkg/monitoring/monitoring.go
+++ b/backend/pkg/monitoring/monitoring.go
@@ -41,11 +41,12 @@ func Init(full bool) {
 	for _, service := range monitoredServices {
 		service.InitServices()
 	}
+
+	services.InitStatusReport()
 }
 
 func Start() {
 	log.Infof("starting monitoring services")
-	services.InitStatusReport()
 	for _, service := range monitoredServices {
 		service.Start()
 	}

--- a/backend/pkg/monitoring/monitoring.go
+++ b/backend/pkg/monitoring/monitoring.go
@@ -58,7 +58,7 @@ func Stop() {
 		service.Stop()
 	}
 	// this prevents status reports that werent shut down cleanly from triggering alerts
-	services.StatusReporter().NewStatusReport(constants.Event_MonitoringCleanShutdown, constants.Default, constants.Default)(constants.Success, nil)
+	services.NewStatusReporter(constants.Event_MonitoringCleanShutdown, constants.Default, constants.Default).Report(constants.Success, nil)
 	if startedClickhouse.Load() {
 		db.ClickHouseNativeWriter.Close()
 	}

--- a/backend/pkg/monitoring/monitoring.go
+++ b/backend/pkg/monitoring/monitoring.go
@@ -42,7 +42,7 @@ func Init(full bool) {
 		service.InitServices()
 	}
 
-	services.InitStatusReport()
+	services.InitStatusReporter(utils.Config.DeploymentType)
 }
 
 func Start() {
@@ -58,7 +58,7 @@ func Stop() {
 		service.Stop()
 	}
 	// this prevents status reports that werent shut down cleanly from triggering alerts
-	services.StatusReporter.NewStatusReport(constants.Event_MonitoringCleanShutdown, constants.Default, constants.Default)(constants.Success, nil)
+	services.StatusReporter().NewStatusReport(constants.Event_MonitoringCleanShutdown, constants.Default, constants.Default)(constants.Success, nil)
 	if startedClickhouse.Load() {
 		db.ClickHouseNativeWriter.Close()
 	}

--- a/backend/pkg/monitoring/services/base.go
+++ b/backend/pkg/monitoring/services/base.go
@@ -36,7 +36,7 @@ type ServiceBase struct {
 
 func (s *ServiceBase) InitServices() {
 	s.ctx, s.cancel = context.WithCancel(context.Background())
-	s.db = db2.NewMonitoringDB()
+	s.db = db2.NewMonitoringClickhouse(db.ClickHouseReader, db.ClickHouseNativeWriter)
 }
 
 func (s *ServiceBase) Stop() {
@@ -87,8 +87,8 @@ func newStatusReport(id constants.Event, timeout time.Duration, check_interval t
 			}, "sending status report")
 			var err error
 			if db.ClickHouseNativeWriter != nil {
-				monitoringDB := db2.NewMonitoringDB()
-				err = monitoringDB.SaveNewStatusReport(db2.StatusReport{
+				monitoringCH := db2.NewMonitoringClickhouse(nil, db.ClickHouseNativeWriter)
+				err = monitoringCH.SaveNewStatusReport(db2.StatusReport{
 					ID:         id,
 					Flake:      flake,
 					ExpiresAt:  expires_at,

--- a/backend/pkg/monitoring/services/base.go
+++ b/backend/pkg/monitoring/services/base.go
@@ -9,8 +9,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/gobitfly/beaconchain/pkg/commons/db"
+	"github.com/gobitfly/beaconchain/pkg/commons/db2"
 	"github.com/gobitfly/beaconchain/pkg/commons/log"
 	"github.com/gobitfly/beaconchain/pkg/commons/utils"
 	"github.com/gobitfly/beaconchain/pkg/commons/version"
@@ -31,10 +31,12 @@ type ServiceBase struct {
 	cancel  context.CancelFunc
 	running atomic.Bool
 	wg      sync.WaitGroup
+	db      db2.Monitoring
 }
 
 func (s *ServiceBase) InitServices() {
 	s.ctx, s.cancel = context.WithCancel(context.Background())
+	s.db = db2.NewMonitoringDB()
 }
 
 func (s *ServiceBase) Stop() {
@@ -66,17 +68,6 @@ func newStatusReport(id constants.Event, timeout time.Duration, check_interval t
 				metadata["caller"] = fmt.Sprintf("%s %s:%d", callerFunction, callerFile, callerLine)
 			}
 
-			// report status to monitoring
-			timeoutContext, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
-			// wrap in clickhouse context so we can set the setting throw_if_deduplication_in_dependent_materialized_views_enabled_with_async_insert to 0
-			// we have no materialized views on the status_reports table, but it triggers as we need the deduplication setting for the other tables
-			ctx := clickhouse.Context(timeoutContext, clickhouse.WithSettings(
-				clickhouse.Settings{
-					"throw_if_deduplication_in_dependent_materialized_views_enabled_with_async_insert": 0,
-				},
-			))
-
 			timeouts_at := now.Add(1 * time.Minute)
 			if timeout != constants.Default {
 				timeouts_at = now.Add(timeout)
@@ -96,18 +87,14 @@ func newStatusReport(id constants.Event, timeout time.Duration, check_interval t
 			}, "sending status report")
 			var err error
 			if db.ClickHouseNativeWriter != nil {
-				err = db.ClickHouseNativeWriter.AsyncInsert(
-					ctx,
-					"INSERT INTO status_reports (emitter, event_id, deployment_type, insert_id, expires_at, timeouts_at, metadata) VALUES (?, ?, ?, ?, ?, ?, ?)",
-					false, // true means wait for settlement, but we want to shoot and forget. false does mean we cant log any errors that occur during settlement
-					utils.GetUUID(),
-					id,
-					utils.Config.DeploymentType,
-					flake,
-					expires_at,
-					timeouts_at,
-					metadata,
-				)
+				monitoringDB := db2.NewMonitoringDB()
+				err = monitoringDB.SaveNewStatusReport(db2.StatusReport{
+					ID:         id,
+					Flake:      flake,
+					ExpiresAt:  expires_at,
+					TimeoutsAt: timeouts_at,
+					Metadata:   metadata,
+				})
 			} else if utils.Config.DeploymentType != "development" {
 				log.Error(nil, "clickhouse native writer is nil", 0)
 			}

--- a/backend/pkg/monitoring/services/base.go
+++ b/backend/pkg/monitoring/services/base.go
@@ -47,7 +47,7 @@ func (s *ServiceBase) Stop() {
 	s.wg.Wait()
 }
 
-func newStatusReport(id constants.Event, timeout time.Duration, check_interval time.Duration) func(status constants.StatusType, metadata map[string]string) {
+func newStatusReport(id constants.Event, timeout time.Duration, check_interval time.Duration, deploymentType string) func(status constants.StatusType, metadata map[string]string) {
 	runId := uuid.New().String()
 	return func(status constants.StatusType, metadata map[string]string) {
 		// acquire snowflake synchronously
@@ -79,7 +79,7 @@ func newStatusReport(id constants.Event, timeout time.Duration, check_interval t
 			log.TraceWithFields(log.Fields{
 				"emitter":         id,
 				"event_id":        utils.GetUUID(),
-				"deployment_type": utils.Config.DeploymentType,
+				"deployment_type": deploymentType,
 				"insert_id":       flake,
 				"expires_at":      expires_at,
 				"timeouts_at":     timeouts_at,
@@ -95,10 +95,10 @@ func newStatusReport(id constants.Event, timeout time.Duration, check_interval t
 					TimeoutsAt: timeouts_at,
 					Metadata:   metadata,
 				})
-			} else if utils.Config.DeploymentType != "development" {
+			} else if deploymentType != "development" {
 				log.Error(nil, "clickhouse native writer is nil", 0)
 			}
-			if err != nil && utils.Config.DeploymentType != "development" {
+			if err != nil && deploymentType != "development" {
 				log.Error(err, "error inserting status report", 0)
 			}
 		}()
@@ -121,19 +121,24 @@ func GetRequiredEvents() []constants.Event {
 	return requiredEvents
 }
 
-type statusReport interface {
-	NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) func(status constants.StatusType, metadata map[string]string)
+type StatusReporterFunc func(status constants.StatusType, metadata map[string]string)
+
+type StatusReport interface {
+	NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) StatusReporterFunc
 }
 
-type stubStatusReporter struct{}
+type stubStatusReporter struct {
+	initialized    bool
+	deploymentType string
+}
 
-func (sr stubStatusReporter) NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) func(status constants.StatusType, metadata map[string]string) {
+func (sr stubStatusReporter) NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) StatusReporterFunc {
 	return func(status constants.StatusType, metadata map[string]string) {
 		// no-op implementation
-		// only warn if utils.Config is initialized and we're not in development environment
-		if utils.Config != nil && utils.Config.DeploymentType != "development" {
+		// only warn if we're not in development environment
+		if sr.initialized && sr.deploymentType != "development" {
 			log.Warnf("STUB STATUS REPORTER IN USE IN %s ENVIRONMENT! Event: %s, Status: %s, Metadata: %v",
-				utils.Config.DeploymentType,
+				sr.deploymentType,
 				id,
 				status,
 				metadata,
@@ -142,14 +147,29 @@ func (sr stubStatusReporter) NewStatusReport(id constants.Event, timeout time.Du
 	}
 }
 
-type statusReporter struct{}
-
-func (sr statusReporter) NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) func(status constants.StatusType, metadata map[string]string) {
-	return newStatusReport(id, timeout, checkInterval)
+type statusReporter struct {
+	initialized    bool
+	deploymentType string
 }
 
-var StatusReporter statusReport = stubStatusReporter{}
+func (sr statusReporter) NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) StatusReporterFunc {
+	if !sr.initialized {
+		log.Warn("status reporter not initialized, using stub implementation")
+		return stubStatusReporter{initialized: false}.NewStatusReport(id, timeout, checkInterval)
+	}
+	return newStatusReport(id, timeout, checkInterval, sr.deploymentType)
+}
 
-func InitStatusReport() {
-	StatusReporter = statusReporter{}
+// default to stub implementation
+var globalStatusReporter StatusReport = stubStatusReporter{initialized: false}
+
+func InitStatusReporter(deploymentType string) {
+	globalStatusReporter = statusReporter{
+		initialized:    true,
+		deploymentType: deploymentType,
+	}
+}
+
+func StatusReporter() StatusReport {
+	return globalStatusReporter
 }

--- a/backend/pkg/monitoring/services/base.go
+++ b/backend/pkg/monitoring/services/base.go
@@ -58,6 +58,11 @@ var (
 )
 
 func InitStatusReporter(deploymentType string) {
+	if deploymentType == "" {
+		log.Warn("deployment type is empty, defaulting to 'development'")
+		deploymentType = "development"
+	}
+
 	configOnce.Do(func() {
 		config = statusConfig{
 			initialized:    true,

--- a/backend/pkg/monitoring/services/base.go
+++ b/backend/pkg/monitoring/services/base.go
@@ -47,129 +47,135 @@ func (s *ServiceBase) Stop() {
 	s.wg.Wait()
 }
 
-func newStatusReport(id constants.Event, timeout time.Duration, check_interval time.Duration, deploymentType string) func(status constants.StatusType, metadata map[string]string) {
-	runId := uuid.New().String()
-	return func(status constants.StatusType, metadata map[string]string) {
-		// acquire snowflake synchronously
-		flake := utils.GetSnowflake()
-		callerProgramCounter, callerFullFilePath, callerLine, callerOK := runtime.Caller(1)
-		now := time.Now()
-		go func() {
-			if metadata == nil {
-				metadata = make(map[string]string)
-			}
-
-			metadata["run_id"] = runId
-			metadata["status"] = string(status)
-			metadata["executable_version"] = fmt.Sprintf("%s (%s)", version.Version, version.GoVersion)
-			if callerOK {
-				callerFunction := runtime.FuncForPC(callerProgramCounter).Name()
-				callerFile := filepath.Base(callerFullFilePath)
-				metadata["caller"] = fmt.Sprintf("%s %s:%d", callerFunction, callerFile, callerLine)
-			}
-
-			timeouts_at := now.Add(1 * time.Minute)
-			if timeout != constants.Default {
-				timeouts_at = now.Add(timeout)
-			}
-			expires_at := timeouts_at.Add(1 * time.Minute)
-			if check_interval >= 1*time.Minute {
-				expires_at = timeouts_at.Add(check_interval)
-			}
-			log.TraceWithFields(log.Fields{
-				"emitter":         id,
-				"event_id":        utils.GetUUID(),
-				"deployment_type": deploymentType,
-				"insert_id":       flake,
-				"expires_at":      expires_at,
-				"timeouts_at":     timeouts_at,
-				"metadata":        metadata,
-			}, "sending status report")
-			var err error
-			if db.ClickHouseNativeWriter != nil {
-				monitoringCH := db2.NewMonitoringClickhouse(nil, db.ClickHouseNativeWriter)
-				err = monitoringCH.SaveNewStatusReport(db2.StatusReport{
-					ID:         id,
-					Flake:      flake,
-					ExpiresAt:  expires_at,
-					TimeoutsAt: timeouts_at,
-					Metadata:   metadata,
-				})
-			} else if deploymentType != "development" {
-				log.Error(nil, "clickhouse native writer is nil", 0)
-			}
-			if err != nil && deploymentType != "development" {
-				log.Error(err, "error inserting status report", 0)
-			}
-		}()
-	}
-}
-
-func GetRequiredEvents() []constants.Event {
-	// i would hope this simple of a function doesnt need caching
-	requiredEvents := constants.RequiredEvents
-	if utils.Config.DeploymentType != "production" {
-		return requiredEvents
-	}
-	requiredEvents = append(requiredEvents, constants.ProductionRequiredEvents...)
-	if utils.Config.RocketpoolExporter.Enabled {
-		requiredEvents = append(requiredEvents, constants.Event_ExporterLegacyRocketPool)
-	}
-	if utils.Config.Indexer.PubKeyTagsExporter.Enabled {
-		requiredEvents = append(requiredEvents, constants.Event_ExporterLegacyPubkeyTags)
-	}
-	return requiredEvents
-}
-
-type StatusReporterFunc func(status constants.StatusType, metadata map[string]string)
-
-type StatusReport interface {
-	NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) StatusReporterFunc
-}
-
-type stubStatusReporter struct {
+type statusConfig struct {
 	initialized    bool
 	deploymentType string
 }
 
-func (sr stubStatusReporter) NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) StatusReporterFunc {
-	return func(status constants.StatusType, metadata map[string]string) {
-		// no-op implementation
-		// only warn if we're not in development environment
-		if sr.initialized && sr.deploymentType != "development" {
-			log.Warnf("STUB STATUS REPORTER IN USE IN %s ENVIRONMENT! Event: %s, Status: %s, Metadata: %v",
-				sr.deploymentType,
-				id,
-				status,
-				metadata,
-			)
+var (
+	config     statusConfig
+	configOnce sync.Once
+)
+
+func InitStatusReporter(deploymentType string) {
+	configOnce.Do(func() {
+		config = statusConfig{
+			initialized:    true,
+			deploymentType: deploymentType,
 		}
+	})
+}
+
+func NewStatusReporter(event constants.Event, defaultTimeout, defaultInterval time.Duration) StatusReporter {
+	if !config.initialized {
+		return &stubStatusReporter{}
 	}
+
+	return &statusReporter{
+		id:            event,
+		timeout:       defaultTimeout,
+		checkInterval: defaultInterval,
+		runID:         uuid.New().String(),
+	}
+}
+
+type StatusReporter interface {
+	Report(status constants.StatusType, metadata map[string]string)
 }
 
 type statusReporter struct {
-	initialized    bool
-	deploymentType string
+	id            constants.Event
+	timeout       time.Duration
+	checkInterval time.Duration
+	runID         string
 }
 
-func (sr statusReporter) NewStatusReport(id constants.Event, timeout time.Duration, checkInterval time.Duration) StatusReporterFunc {
-	if !sr.initialized {
-		log.Warn("status reporter not initialized, using stub implementation")
-		return stubStatusReporter{initialized: false}.NewStatusReport(id, timeout, checkInterval)
+func (r *statusReporter) Report(status constants.StatusType, metadata map[string]string) {
+	go r.report(status, metadata)
+}
+
+func (r *statusReporter) report(status constants.StatusType, metadata map[string]string) {
+	flake := utils.GetSnowflake()
+	callerProgramCounter, callerFilePath, callerLine, callerOK := runtime.Caller(2)
+	now := time.Now()
+
+	if metadata == nil {
+		metadata = make(map[string]string)
 	}
-	return newStatusReport(id, timeout, checkInterval, sr.deploymentType)
-}
 
-// default to stub implementation
-var globalStatusReporter StatusReport = stubStatusReporter{initialized: false}
+	metadata["run_id"] = r.runID
+	metadata["status"] = string(status)
+	metadata["executable_version"] = fmt.Sprintf("%s (%s)", version.Version, version.GoVersion)
 
-func InitStatusReporter(deploymentType string) {
-	globalStatusReporter = statusReporter{
-		initialized:    true,
-		deploymentType: deploymentType,
+	if callerOK {
+		callerFunction := runtime.FuncForPC(callerProgramCounter).Name()
+		callerFile := filepath.Base(callerFilePath)
+		metadata["caller"] = fmt.Sprintf("%s %s:%d", callerFunction, callerFile, callerLine)
+	}
+
+	timeoutsAt := now.Add(1 * time.Minute)
+	if r.timeout != constants.Default {
+		timeoutsAt = now.Add(r.timeout)
+	}
+	expiresAt := timeoutsAt.Add(1 * time.Minute)
+	if r.checkInterval >= 1*time.Minute {
+		expiresAt = timeoutsAt.Add(r.checkInterval)
+	}
+	log.TraceWithFields(log.Fields{
+		"emitter":         r.id,
+		"event_id":        utils.GetUUID(),
+		"deployment_type": config.deploymentType,
+		"insert_id":       flake,
+		"expires_at":      expiresAt,
+		"timeouts_at":     timeoutsAt,
+		"metadata":        metadata,
+	}, "sending status report")
+
+	if db.ClickHouseNativeWriter != nil {
+		monitoringCH := db2.NewMonitoringClickhouse(nil, db.ClickHouseNativeWriter)
+		err := monitoringCH.SaveNewStatusReport(db2.StatusReport{
+			ID:         r.id,
+			Flake:      flake,
+			ExpiresAt:  expiresAt,
+			TimeoutsAt: timeoutsAt,
+			Metadata:   metadata,
+		})
+		if err != nil && config.deploymentType != "development" {
+			log.Error(err, "error inserting status report", 0)
+		}
+	} else if config.deploymentType != "development" {
+		log.Error(nil, "clickhouse native writer is nil", 0)
 	}
 }
 
-func StatusReporter() StatusReport {
-	return globalStatusReporter
+type stubStatusReporter struct{}
+
+func (r *stubStatusReporter) Report(status constants.StatusType, metadata map[string]string) {
+	if config.deploymentType != "development" && config.deploymentType != "" {
+		log.Warnf("WARN: STUB STATUS REPORTER IN USE IN %s ENVIRONMENT! Status: %s, Metadata: %v",
+			config.deploymentType,
+			status,
+			metadata,
+		)
+	}
+}
+
+func GetRequiredEvents(deploymentType string, rocketpoolEnabled, pubkeyTagsEnabled bool) []constants.Event {
+	// create copy of slice to avoid modifying the original event slice
+	requiredEvents := make([]constants.Event, len(constants.RequiredEvents))
+	copy(requiredEvents, constants.RequiredEvents)
+
+	if deploymentType != "production" {
+		return requiredEvents
+	}
+	requiredEvents = append(requiredEvents, constants.ProductionRequiredEvents...)
+
+	if rocketpoolEnabled {
+		requiredEvents = append(requiredEvents, constants.Event_ExporterLegacyRocketPool)
+	}
+	if pubkeyTagsEnabled {
+		requiredEvents = append(requiredEvents, constants.Event_ExporterLegacyPubkeyTags)
+	}
+
+	return requiredEvents
 }

--- a/backend/pkg/monitoring/services/base_test.go
+++ b/backend/pkg/monitoring/services/base_test.go
@@ -1,0 +1,129 @@
+package services
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
+)
+
+func TestInitStatusReporter(t *testing.T) {
+	tests := []struct {
+		name                   string
+		deploymentType         string
+		expectedDeploymentType string
+	}{
+		{
+			name:                   "init production",
+			deploymentType:         "production",
+			expectedDeploymentType: "production",
+		},
+		{
+			name:                   "init development",
+			deploymentType:         "development",
+			expectedDeploymentType: "development",
+		},
+		{
+			name:                   "init empty",
+			deploymentType:         "",
+			expectedDeploymentType: "development",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configOnce = sync.Once{}
+			config = statusConfig{}
+			InitStatusReporter(tt.deploymentType)
+
+			if !config.initialized {
+				t.Errorf("init failed, got initialized=%v", config.initialized)
+			}
+
+			if config.deploymentType != tt.expectedDeploymentType {
+				t.Errorf("init failed, got deployment=%s, want=%s", config.deploymentType, tt.expectedDeploymentType)
+			}
+		})
+	}
+}
+
+func TestNewStatusReporter(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialized  bool
+		expectedStub bool
+	}{
+		{
+			name:         "initialized",
+			initialized:  true,
+			expectedStub: false,
+		},
+		{
+			name:         "not initialized",
+			initialized:  false,
+			expectedStub: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config = statusConfig{}
+			config.initialized = tt.initialized
+
+			reporter := NewStatusReporter("test", 0, 0)
+			_, isStub := reporter.(*stubStatusReporter)
+
+			if isStub != tt.expectedStub {
+				t.Errorf("got stub=%v, want=%v", isStub, tt.expectedStub)
+			}
+		})
+	}
+}
+
+func TestGetRequiredEvents(t *testing.T) {
+	tests := []struct {
+		name           string
+		deploymentType string
+		rocketpool     bool
+		pubkeyTags     bool
+		expectedEvents int
+	}{
+		{
+			name:           "development",
+			deploymentType: "development",
+			rocketpool:     false,
+			pubkeyTags:     false,
+			expectedEvents: len(constants.RequiredEvents),
+		},
+		{
+			name:           "production no extras",
+			deploymentType: "production",
+			rocketpool:     false,
+			pubkeyTags:     false,
+			expectedEvents: len(constants.RequiredEvents) + len(constants.ProductionRequiredEvents),
+		},
+		{
+			name:           "production with rocketpool",
+			deploymentType: "production",
+			rocketpool:     true,
+			pubkeyTags:     false,
+			expectedEvents: len(constants.RequiredEvents) + len(constants.ProductionRequiredEvents) + 1,
+		},
+		{
+			name:           "production with rocketpool and pubkeyTags",
+			deploymentType: "production",
+			rocketpool:     true,
+			pubkeyTags:     true,
+			expectedEvents: len(constants.RequiredEvents) + len(constants.ProductionRequiredEvents) + 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			events := GetRequiredEvents(tt.deploymentType, tt.rocketpool, tt.pubkeyTags)
+			if len(events) < tt.expectedEvents {
+				t.Errorf("got %d events, want %d", len(events), tt.expectedEvents)
+			}
+		})
+	}
+}

--- a/backend/pkg/monitoring/services/clean_shutdown_spam.go
+++ b/backend/pkg/monitoring/services/clean_shutdown_spam.go
@@ -37,10 +37,10 @@ func (s *CleanShutdownSpamDetector) internalProcess() {
 }
 
 func (s *CleanShutdownSpamDetector) runChecks() {
-	statusReport := StatusReporter().NewStatusReport(constants.Event_MonitoringCleanShutdownSpam, constants.Default, 30*time.Second)
-	statusReport(constants.Running, nil)
+	statusReporter := NewStatusReporter(constants.Event_MonitoringCleanShutdownSpam, constants.Default, 30*time.Second)
+	statusReporter.Report(constants.Running, nil)
 	if db.ClickHouseReader == nil {
-		statusReport(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})
+		statusReporter.Report(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})
 		// ignore
 		return
 	}
@@ -48,7 +48,7 @@ func (s *CleanShutdownSpamDetector) runChecks() {
 
 	emitters, err := s.db.GetEmitters()
 	if err != nil {
-		statusReport(constants.Failure, map[string]string{"error": err.Error()})
+		statusReporter.Report(constants.Failure, map[string]string{"error": err.Error()})
 		return
 	}
 
@@ -60,12 +60,12 @@ func (s *CleanShutdownSpamDetector) runChecks() {
 	if len(emitters) > threshold {
 		payload, err := json.Marshal(emitters)
 		if err != nil {
-			statusReport(constants.Failure, map[string]string{"error": err.Error()})
+			statusReporter.Report(constants.Failure, map[string]string{"error": err.Error()})
 			return
 		}
 		md["emitters"] = string(payload)
-		statusReport(constants.Failure, md)
+		statusReporter.Report(constants.Failure, md)
 		return
 	}
-	statusReport(constants.Success, md)
+	statusReporter.Report(constants.Success, md)
 }

--- a/backend/pkg/monitoring/services/clean_shutdown_spam.go
+++ b/backend/pkg/monitoring/services/clean_shutdown_spam.go
@@ -1,14 +1,12 @@
 package services
 
 import (
-	"context"
 	"encoding/json"
 	"strconv"
 	"time"
 
 	"github.com/gobitfly/beaconchain/pkg/commons/db"
 	"github.com/gobitfly/beaconchain/pkg/commons/log"
-	"github.com/gobitfly/beaconchain/pkg/commons/utils"
 	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
 )
 
@@ -39,33 +37,21 @@ func (s *CleanShutdownSpamDetector) internalProcess() {
 }
 
 func (s *CleanShutdownSpamDetector) runChecks() {
-	r := StatusReporter.NewStatusReport(constants.Event_MonitoringCleanShutdownSpam, constants.Default, 30*time.Second)
-	r(constants.Running, nil)
+	statusReport := StatusReporter.NewStatusReport(constants.Event_MonitoringCleanShutdownSpam, constants.Default, 30*time.Second)
+	statusReport(constants.Running, nil)
 	if db.ClickHouseReader == nil {
-		r(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})
+		statusReport(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})
 		// ignore
 		return
 	}
 	log.Tracef("checking clean shutdown spam")
 
-	query := `
-		SELECT
-			emitter
-		FROM
-			status_reports
-		WHERE
-			deployment_type = ?
-			AND inserted_at >= now() - interval 5 minutes
-			AND event_id = ?
-			`
-	ctx, cancel := context.WithTimeout(s.ctx, 15*time.Second)
-	defer cancel()
-	var emitters []string
-	err := db.ClickHouseReader.SelectContext(ctx, &emitters, query, utils.Config.DeploymentType, constants.Event_MonitoringCleanShutdown)
+	emitters, err := s.db.GetEmitters()
 	if err != nil {
-		r(constants.Failure, map[string]string{"error": err.Error()})
+		statusReport(constants.Failure, map[string]string{"error": err.Error()})
 		return
 	}
+
 	threshold := 10
 	md := map[string]string{
 		"count":     strconv.Itoa(len(emitters)),
@@ -74,12 +60,12 @@ func (s *CleanShutdownSpamDetector) runChecks() {
 	if len(emitters) > threshold {
 		payload, err := json.Marshal(emitters)
 		if err != nil {
-			r(constants.Failure, map[string]string{"error": err.Error()})
+			statusReport(constants.Failure, map[string]string{"error": err.Error()})
 			return
 		}
 		md["emitters"] = string(payload)
-		r(constants.Failure, md)
+		statusReport(constants.Failure, md)
 		return
 	}
-	r(constants.Success, md)
+	statusReport(constants.Success, md)
 }

--- a/backend/pkg/monitoring/services/clean_shutdown_spam.go
+++ b/backend/pkg/monitoring/services/clean_shutdown_spam.go
@@ -37,7 +37,7 @@ func (s *CleanShutdownSpamDetector) internalProcess() {
 }
 
 func (s *CleanShutdownSpamDetector) runChecks() {
-	statusReport := StatusReporter.NewStatusReport(constants.Event_MonitoringCleanShutdownSpam, constants.Default, 30*time.Second)
+	statusReport := StatusReporter().NewStatusReport(constants.Event_MonitoringCleanShutdownSpam, constants.Default, 30*time.Second)
 	statusReport(constants.Running, nil)
 	if db.ClickHouseReader == nil {
 		statusReport(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})

--- a/backend/pkg/monitoring/services/clickhouse_epoch.go
+++ b/backend/pkg/monitoring/services/clickhouse_epoch.go
@@ -35,10 +35,10 @@ func (s *ServiceClickhouseEpoch) internalProcess() {
 }
 
 func (s *ServiceClickhouseEpoch) runChecks() {
-	statusReport := StatusReporter().NewStatusReport(constants.Event_ClickhouseDashboardEpoch, constants.Default, 30*time.Second)
-	statusReport(constants.Running, nil)
+	statusReporter := NewStatusReporter(constants.Event_ClickhouseDashboardEpoch, constants.Default, 30*time.Second)
+	statusReporter.Report(constants.Running, nil)
 	if db.ClickHouseReader == nil {
-		statusReport(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})
+		statusReporter.Report(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})
 		// ignore
 		return
 	}
@@ -46,7 +46,7 @@ func (s *ServiceClickhouseEpoch) runChecks() {
 
 	ts, err := s.db.GetLatestEpoch()
 	if err != nil {
-		statusReport(constants.Failure, map[string]string{"error": err.Error()})
+		statusReporter.Report(constants.Failure, map[string]string{"error": err.Error()})
 		return
 	}
 	// check if delta is out of bounds
@@ -54,8 +54,8 @@ func (s *ServiceClickhouseEpoch) runChecks() {
 	md := map[string]string{"delta": time.Since(ts).String(), "threshold": threshold.String()}
 	if time.Since(ts) > threshold {
 		md["error"] = "delta is over threshold"
-		statusReport(constants.Failure, md)
+		statusReporter.Report(constants.Failure, md)
 		return
 	}
-	statusReport(constants.Success, md)
+	statusReporter.Report(constants.Success, md)
 }

--- a/backend/pkg/monitoring/services/clickhouse_epoch.go
+++ b/backend/pkg/monitoring/services/clickhouse_epoch.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"context"
 	"time"
 
 	"github.com/gobitfly/beaconchain/pkg/commons/db"
@@ -36,30 +35,27 @@ func (s *ServiceClickhouseEpoch) internalProcess() {
 }
 
 func (s *ServiceClickhouseEpoch) runChecks() {
-	r := StatusReporter.NewStatusReport(constants.Event_ClickhouseDashboardEpoch, constants.Default, 30*time.Second)
-	r(constants.Running, nil)
+	statusReport := StatusReporter.NewStatusReport(constants.Event_ClickhouseDashboardEpoch, constants.Default, 30*time.Second)
+	statusReport(constants.Running, nil)
 	if db.ClickHouseReader == nil {
-		r(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})
+		statusReport(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})
 		// ignore
 		return
 	}
 	log.Tracef("checking clickhouse epoch")
-	// context with deadline
-	ctx, cancel := context.WithTimeout(s.ctx, 15*time.Second)
-	defer cancel()
-	var t time.Time
-	err := db.ClickHouseReader.GetContext(ctx, &t, "SELECT MAX(t) FROM view_validator_dashboard_data_epoch_max_ts")
+
+	ts, err := s.db.GetVDLatestEpochTs()
 	if err != nil {
-		r(constants.Failure, map[string]string{"error": err.Error()})
+		statusReport(constants.Failure, map[string]string{"error": err.Error()})
 		return
 	}
 	// check if delta is out of bounds
 	threshold := 1 * time.Hour
-	md := map[string]string{"delta": time.Since(t).String(), "threshold": threshold.String()}
-	if time.Since(t) > threshold {
+	md := map[string]string{"delta": time.Since(ts).String(), "threshold": threshold.String()}
+	if time.Since(ts) > threshold {
 		md["error"] = "delta is over threshold"
-		r(constants.Failure, md)
+		statusReport(constants.Failure, md)
 		return
 	}
-	r(constants.Success, md)
+	statusReport(constants.Success, md)
 }

--- a/backend/pkg/monitoring/services/clickhouse_epoch.go
+++ b/backend/pkg/monitoring/services/clickhouse_epoch.go
@@ -35,7 +35,7 @@ func (s *ServiceClickhouseEpoch) internalProcess() {
 }
 
 func (s *ServiceClickhouseEpoch) runChecks() {
-	statusReport := StatusReporter.NewStatusReport(constants.Event_ClickhouseDashboardEpoch, constants.Default, 30*time.Second)
+	statusReport := StatusReporter().NewStatusReport(constants.Event_ClickhouseDashboardEpoch, constants.Default, 30*time.Second)
 	statusReport(constants.Running, nil)
 	if db.ClickHouseReader == nil {
 		statusReport(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})

--- a/backend/pkg/monitoring/services/clickhouse_epoch.go
+++ b/backend/pkg/monitoring/services/clickhouse_epoch.go
@@ -44,7 +44,7 @@ func (s *ServiceClickhouseEpoch) runChecks() {
 	}
 	log.Tracef("checking clickhouse epoch")
 
-	ts, err := s.db.GetVDLatestEpochTs()
+	ts, err := s.db.GetLatestEpoch()
 	if err != nil {
 		statusReport(constants.Failure, map[string]string{"error": err.Error()})
 		return

--- a/backend/pkg/monitoring/services/clickhouse_rollings.go
+++ b/backend/pkg/monitoring/services/clickhouse_rollings.go
@@ -55,7 +55,7 @@ func (s *ServiceClickhouseRollings) runChecks() {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			statusReport := StatusReporter.NewStatusReport(rollings[rolling], constants.Default, 30*time.Second)
+			statusReport := StatusReporter().NewStatusReport(rollings[rolling], constants.Default, 30*time.Second)
 			statusReport(constants.Running, nil)
 			if db.ClickHouseReader == nil {
 				statusReport(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})

--- a/backend/pkg/monitoring/services/clickhouse_rollings.go
+++ b/backend/pkg/monitoring/services/clickhouse_rollings.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"context"
 	"fmt"
 	"maps"
 	"sync"
@@ -56,37 +55,23 @@ func (s *ServiceClickhouseRollings) runChecks() {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			r := StatusReporter.NewStatusReport(rollings[rolling], constants.Default, 30*time.Second)
-			r(constants.Running, nil)
+			statusReport := StatusReporter.NewStatusReport(rollings[rolling], constants.Default, 30*time.Second)
+			statusReport(constants.Running, nil)
 			if db.ClickHouseReader == nil {
-				r(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})
+				statusReport(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})
 				// ignore
 				return
 			}
 			log.Tracef("checking clickhouse rolling %s", rolling)
 			// context with deadline
-			ctx, cancel := context.WithTimeout(s.ctx, 15*time.Second)
-			defer cancel()
-			var tsEpochTable time.Time
-			err := db.ClickHouseReader.GetContext(ctx, &tsEpochTable, `
-					SELECT
-						max(t)
-					FROM view_validator_dashboard_data_epoch_max_ts`,
-			)
+			tsEpochTable, err := s.db.GetVDLatestEpochTs()
 			if err != nil {
-				r(constants.Failure, map[string]string{"error": err.Error()})
+				statusReport(constants.Failure, map[string]string{"error": err.Error()})
 				return
 			}
-			var epochRollingTable uint64
-			err = db.ClickHouseReader.GetContext(ctx, &epochRollingTable, fmt.Sprintf(`
-					SELECT
-						max(epoch_end)
-					FROM validator_dashboard_data_rolling_%s`,
-				rolling,
-			),
-			)
+			epochRollingTable, err := s.db.GetVDRollingEpochEnd(rolling)
 			if err != nil {
-				r(constants.Failure, map[string]string{"error": err.Error()})
+				statusReport(constants.Failure, map[string]string{"error": err.Error()})
 				return
 			}
 			// convert to timestamp
@@ -97,10 +82,10 @@ func (s *ServiceClickhouseRollings) runChecks() {
 			md := map[string]string{"delta": delta.String(), "threshold": threshold.String()}
 			if delta > threshold {
 				md["error"] = fmt.Sprintf("delta is over threshold %d", threshold)
-				r(constants.Failure, md)
+				statusReport(constants.Failure, md)
 				return
 			}
-			r(constants.Success, md)
+			statusReport(constants.Success, md)
 		}()
 	}
 	wg.Wait()

--- a/backend/pkg/monitoring/services/clickhouse_rollings.go
+++ b/backend/pkg/monitoring/services/clickhouse_rollings.go
@@ -55,10 +55,10 @@ func (s *ServiceClickhouseRollings) runChecks() {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			statusReport := StatusReporter().NewStatusReport(rollings[rolling], constants.Default, 30*time.Second)
-			statusReport(constants.Running, nil)
+			statusReporter := NewStatusReporter(rollings[rolling], constants.Default, 30*time.Second)
+			statusReporter.Report(constants.Running, nil)
 			if db.ClickHouseReader == nil {
-				statusReport(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})
+				statusReporter.Report(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})
 				// ignore
 				return
 			}
@@ -66,12 +66,12 @@ func (s *ServiceClickhouseRollings) runChecks() {
 			// context with deadline
 			tsEpochTable, err := s.db.GetLatestEpoch()
 			if err != nil {
-				statusReport(constants.Failure, map[string]string{"error": err.Error()})
+				statusReporter.Report(constants.Failure, map[string]string{"error": err.Error()})
 				return
 			}
 			epochRollingTable, err := s.db.GetEpochEnd(rolling)
 			if err != nil {
-				statusReport(constants.Failure, map[string]string{"error": err.Error()})
+				statusReporter.Report(constants.Failure, map[string]string{"error": err.Error()})
 				return
 			}
 			// convert to timestamp
@@ -82,10 +82,10 @@ func (s *ServiceClickhouseRollings) runChecks() {
 			md := map[string]string{"delta": delta.String(), "threshold": threshold.String()}
 			if delta > threshold {
 				md["error"] = fmt.Sprintf("delta is over threshold %d", threshold)
-				statusReport(constants.Failure, md)
+				statusReporter.Report(constants.Failure, md)
 				return
 			}
-			statusReport(constants.Success, md)
+			statusReporter.Report(constants.Success, md)
 		}()
 	}
 	wg.Wait()

--- a/backend/pkg/monitoring/services/clickhouse_rollings.go
+++ b/backend/pkg/monitoring/services/clickhouse_rollings.go
@@ -64,12 +64,12 @@ func (s *ServiceClickhouseRollings) runChecks() {
 			}
 			log.Tracef("checking clickhouse rolling %s", rolling)
 			// context with deadline
-			tsEpochTable, err := s.db.GetVDLatestEpochTs()
+			tsEpochTable, err := s.db.GetLatestEpoch()
 			if err != nil {
 				statusReport(constants.Failure, map[string]string{"error": err.Error()})
 				return
 			}
-			epochRollingTable, err := s.db.GetVDRollingEpochEnd(rolling)
+			epochRollingTable, err := s.db.GetEpochEnd(rolling)
 			if err != nil {
 				statusReport(constants.Failure, map[string]string{"error": err.Error()})
 				return

--- a/backend/pkg/monitoring/services/db_connections.go
+++ b/backend/pkg/monitoring/services/db_connections.go
@@ -89,28 +89,28 @@ func (s *ServerDbConnections) checkDBConnections() {
 			// context with deadline
 			ctx, cancel := context.WithTimeout(s.ctx, 15*time.Second)
 			defer cancel()
-			r := StatusReporter.NewStatusReport(entry.ID, constants.Default, 10*time.Second)
+			statusReport := StatusReporter.NewStatusReport(entry.ID, constants.Default, 10*time.Second)
 			switch edb := entry.DB.(type) {
 			case *sqlx.DB:
 				err := edb.PingContext(ctx)
 				if err != nil {
-					r(constants.Failure, map[string]string{"error": err.Error()})
+					statusReport(constants.Failure, map[string]string{"error": err.Error()})
 				} else {
-					r(constants.Success, nil)
+					statusReport(constants.Success, nil)
 				}
 			case *redis.Client:
 				err := edb.Ping(ctx).Err()
 				if err != nil {
-					r(constants.Failure, map[string]string{"error": err.Error()})
+					statusReport(constants.Failure, map[string]string{"error": err.Error()})
 				} else {
-					r(constants.Success, nil)
+					statusReport(constants.Success, nil)
 				}
 			case *cache.TieredCacheBase:
 				// have to use reflection cause nothing is public. this is a hack. but it works
 				val := reflect.ValueOf(edb).Elem().FieldByName("remoteCache")
 				if !val.IsValid() {
 					log.Error(fmt.Errorf("failed to get remoteCache"), "failed to get remoteCache", 0)
-					r(constants.Failure, map[string]string{"error": "failed to get remoteCache"})
+					statusReport(constants.Failure, map[string]string{"error": "failed to get remoteCache"})
 					return
 				}
 				// its a pointer to a pointer that is cache.RemoteCache compliant. convert it so we can call Get() on it
@@ -122,20 +122,20 @@ func (s *ServerDbConnections) checkDBConnections() {
 					err = nil
 				}
 				if err != nil {
-					r(constants.Failure, map[string]string{"error": err.Error()})
+					statusReport(constants.Failure, map[string]string{"error": err.Error()})
 				} else {
-					r(constants.Success, nil)
+					statusReport(constants.Success, nil)
 				}
 			case ch.Conn: // its an interface
 				err := edb.Ping(ctx)
 				if err != nil {
-					r(constants.Failure, map[string]string{"error": err.Error()})
+					statusReport(constants.Failure, map[string]string{"error": err.Error()})
 				} else {
-					r(constants.Success, nil)
+					statusReport(constants.Success, nil)
 				}
 			default:
 				log.Error(fmt.Errorf("unknown db type"), "unknown db type", 0, map[string]interface{}{"entry": entry})
-				r(constants.Failure, map[string]string{"error": "unknown db type"})
+				statusReport(constants.Failure, map[string]string{"error": "unknown db type"})
 			}
 		}(entry)
 	}

--- a/backend/pkg/monitoring/services/db_connections.go
+++ b/backend/pkg/monitoring/services/db_connections.go
@@ -89,28 +89,28 @@ func (s *ServerDbConnections) checkDBConnections() {
 			// context with deadline
 			ctx, cancel := context.WithTimeout(s.ctx, 15*time.Second)
 			defer cancel()
-			statusReport := StatusReporter().NewStatusReport(entry.ID, constants.Default, 10*time.Second)
+			statusReporter := NewStatusReporter(entry.ID, constants.Default, 10*time.Second)
 			switch edb := entry.DB.(type) {
 			case *sqlx.DB:
 				err := edb.PingContext(ctx)
 				if err != nil {
-					statusReport(constants.Failure, map[string]string{"error": err.Error()})
+					statusReporter.Report(constants.Failure, map[string]string{"error": err.Error()})
 				} else {
-					statusReport(constants.Success, nil)
+					statusReporter.Report(constants.Success, nil)
 				}
 			case *redis.Client:
 				err := edb.Ping(ctx).Err()
 				if err != nil {
-					statusReport(constants.Failure, map[string]string{"error": err.Error()})
+					statusReporter.Report(constants.Failure, map[string]string{"error": err.Error()})
 				} else {
-					statusReport(constants.Success, nil)
+					statusReporter.Report(constants.Success, nil)
 				}
 			case *cache.TieredCacheBase:
 				// have to use reflection cause nothing is public. this is a hack. but it works
 				val := reflect.ValueOf(edb).Elem().FieldByName("remoteCache")
 				if !val.IsValid() {
 					log.Error(fmt.Errorf("failed to get remoteCache"), "failed to get remoteCache", 0)
-					statusReport(constants.Failure, map[string]string{"error": "failed to get remoteCache"})
+					statusReporter.Report(constants.Failure, map[string]string{"error": "failed to get remoteCache"})
 					return
 				}
 				// its a pointer to a pointer that is cache.RemoteCache compliant. convert it so we can call Get() on it
@@ -122,20 +122,20 @@ func (s *ServerDbConnections) checkDBConnections() {
 					err = nil
 				}
 				if err != nil {
-					statusReport(constants.Failure, map[string]string{"error": err.Error()})
+					statusReporter.Report(constants.Failure, map[string]string{"error": err.Error()})
 				} else {
-					statusReport(constants.Success, nil)
+					statusReporter.Report(constants.Success, nil)
 				}
 			case ch.Conn: // its an interface
 				err := edb.Ping(ctx)
 				if err != nil {
-					statusReport(constants.Failure, map[string]string{"error": err.Error()})
+					statusReporter.Report(constants.Failure, map[string]string{"error": err.Error()})
 				} else {
-					statusReport(constants.Success, nil)
+					statusReporter.Report(constants.Success, nil)
 				}
 			default:
 				log.Error(fmt.Errorf("unknown db type"), "unknown db type", 0, map[string]interface{}{"entry": entry})
-				statusReport(constants.Failure, map[string]string{"error": "unknown db type"})
+				statusReporter.Report(constants.Failure, map[string]string{"error": "unknown db type"})
 			}
 		}(entry)
 	}

--- a/backend/pkg/monitoring/services/db_connections.go
+++ b/backend/pkg/monitoring/services/db_connections.go
@@ -89,7 +89,7 @@ func (s *ServerDbConnections) checkDBConnections() {
 			// context with deadline
 			ctx, cancel := context.WithTimeout(s.ctx, 15*time.Second)
 			defer cancel()
-			statusReport := StatusReporter.NewStatusReport(entry.ID, constants.Default, 10*time.Second)
+			statusReport := StatusReporter().NewStatusReport(entry.ID, constants.Default, 10*time.Second)
 			switch edb := entry.DB.(type) {
 			case *sqlx.DB:
 				err := edb.PingContext(ctx)

--- a/backend/pkg/monitoring/services/flaky_test_service.go
+++ b/backend/pkg/monitoring/services/flaky_test_service.go
@@ -28,7 +28,7 @@ func (s *FlakyTestService) internalProcess() {
 			return
 		case <-time.After(10 * time.Second):
 			err := fmt.Errorf("random error")
-			StatusReporter.NewStatusReport("flaky_test", constants.Default, constants.Default)(constants.Failure, map[string]string{"error": err.Error()})
+			StatusReporter().NewStatusReport("flaky_test", constants.Default, constants.Default)(constants.Failure, map[string]string{"error": err.Error()})
 		}
 	}
 }

--- a/backend/pkg/monitoring/services/flaky_test_service.go
+++ b/backend/pkg/monitoring/services/flaky_test_service.go
@@ -28,7 +28,7 @@ func (s *FlakyTestService) internalProcess() {
 			return
 		case <-time.After(10 * time.Second):
 			err := fmt.Errorf("random error")
-			StatusReporter().NewStatusReport("flaky_test", constants.Default, constants.Default)(constants.Failure, map[string]string{"error": err.Error()})
+			NewStatusReporter("flaky_test", constants.Default, constants.Default).Report(constants.Failure, map[string]string{"error": err.Error()})
 		}
 	}
 }

--- a/backend/pkg/monitoring/services/timeout_detector.go
+++ b/backend/pkg/monitoring/services/timeout_detector.go
@@ -36,7 +36,7 @@ func (s *ServiceTimeoutDetector) internalProcess() {
 }
 
 func (s *ServiceTimeoutDetector) runChecks() {
-	statusReport := StatusReporter.NewStatusReport(constants.Event_MonitoringTimeouts, constants.Default, 30*time.Second)
+	statusReport := StatusReporter().NewStatusReport(constants.Event_MonitoringTimeouts, constants.Default, 30*time.Second)
 	statusReport(constants.Running, nil)
 	if db.ClickHouseReader == nil {
 		statusReport(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})

--- a/backend/pkg/monitoring/services/timeout_detector.go
+++ b/backend/pkg/monitoring/services/timeout_detector.go
@@ -36,10 +36,10 @@ func (s *ServiceTimeoutDetector) internalProcess() {
 }
 
 func (s *ServiceTimeoutDetector) runChecks() {
-	statusReport := StatusReporter().NewStatusReport(constants.Event_MonitoringTimeouts, constants.Default, 30*time.Second)
-	statusReport(constants.Running, nil)
+	statusReporter := NewStatusReporter(constants.Event_MonitoringTimeouts, constants.Default, 30*time.Second)
+	statusReporter.Report(constants.Running, nil)
 	if db.ClickHouseReader == nil {
-		statusReport(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})
+		statusReporter.Report(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})
 		// ignore
 		return
 	}
@@ -47,19 +47,19 @@ func (s *ServiceTimeoutDetector) runChecks() {
 
 	victims, err := s.db.GetLatestStatusReport()
 	if err != nil {
-		statusReport(constants.Failure, map[string]string{"error": err.Error()})
+		statusReporter.Report(constants.Failure, map[string]string{"error": err.Error()})
 		return
 	}
 	if len(victims) == 0 {
-		statusReport(constants.Success, nil)
+		statusReporter.Report(constants.Success, nil)
 		return
 	}
 	payload, err := json.Marshal(victims)
 	if err != nil {
-		statusReport(constants.Failure, map[string]string{"error": err.Error()})
+		statusReporter.Report(constants.Failure, map[string]string{"error": err.Error()})
 		return
 	}
 
 	md := map[string]string{"failing_reports": string(payload), "error": "reports are running for too long"}
-	statusReport(constants.Failure, md)
+	statusReporter.Report(constants.Failure, md)
 }

--- a/backend/pkg/monitoring/services/timeout_detector.go
+++ b/backend/pkg/monitoring/services/timeout_detector.go
@@ -1,13 +1,11 @@
 package services
 
 import (
-	"context"
 	"encoding/json"
 	"time"
 
 	"github.com/gobitfly/beaconchain/pkg/commons/db"
 	"github.com/gobitfly/beaconchain/pkg/commons/log"
-	"github.com/gobitfly/beaconchain/pkg/commons/utils"
 	"github.com/gobitfly/beaconchain/pkg/monitoring/constants"
 )
 
@@ -38,90 +36,30 @@ func (s *ServiceTimeoutDetector) internalProcess() {
 }
 
 func (s *ServiceTimeoutDetector) runChecks() {
-	r := StatusReporter.NewStatusReport(constants.Event_MonitoringTimeouts, constants.Default, 30*time.Second)
-	r(constants.Running, nil)
+	statusReport := StatusReporter.NewStatusReport(constants.Event_MonitoringTimeouts, constants.Default, 30*time.Second)
+	statusReport(constants.Running, nil)
 	if db.ClickHouseReader == nil {
-		r(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})
+		statusReport(constants.Failure, map[string]string{"error": "clickhouse reader is nil"})
 		// ignore
 		return
 	}
 	log.Tracef("checking services timeouts")
 
-	query := `
-		with active_reports as (
-			SELECT
-				event_id,
-				emitter,
-				run_id,
-				inserted_at,
-				insert_id,
-				expires_at,
-				timeouts_at,
-				status,
-				metadata
-			FROM status_reports
-			WHERE expires_at > now() and deployment_type = ? and emitter not in (select distinct emitter from status_reports where event_id = ? and inserted_at > now() - interval 1 days)
-			ORDER BY
-				event_id ASC,
-				emitter ASC,
-				run_id ASC,
-				insert_id DESC
-		), latest_report_per_run as (
-			SELECT
-				event_id,
-				emitter,
-				any(inserted_at) as inserted_at, 
-				any(insert_id) as insert_id, 
-				any(expires_at) as expires_at,
-				any(timeouts_at) as timeouts_at,
-				any(status) AS status,
-				any(metadata) AS metadata
-			FROM
-				active_reports
-			GROUP BY
-				event_id,
-				emitter,
-				run_id
-			order by insert_id desc
-		)
-		SELECT
-			event_id,
-			emitter,
-			status,
-			inserted_at,
-			expires_at,
-			timeouts_at,
-			metadata
-		FROM
-			latest_report_per_run
-		where status = 'running' and timeouts_at < now()
-		ORDER BY event_id ASC, inserted_at DESC`
-	// context with deadline
-	ctx, cancel := context.WithTimeout(s.ctx, 15*time.Second)
-	defer cancel()
-	var victims []struct {
-		EventID    string            `db:"event_id"`
-		Emitter    string            `db:"emitter"`
-		Status     string            `db:"status"`
-		InsertedAt time.Time         `db:"inserted_at"`
-		ExpiresAt  time.Time         `db:"expires_at"`
-		TimeoutsAt time.Time         `db:"timeouts_at"`
-		Metadata   map[string]string `db:"metadata"`
-	}
-	err := db.ClickHouseReader.SelectContext(ctx, &victims, query, utils.Config.DeploymentType, constants.Event_MonitoringCleanShutdown)
+	victims, err := s.db.GetLatestStatusReport()
 	if err != nil {
-		r(constants.Failure, map[string]string{"error": err.Error()})
+		statusReport(constants.Failure, map[string]string{"error": err.Error()})
 		return
 	}
 	if len(victims) == 0 {
-		r(constants.Success, nil)
+		statusReport(constants.Success, nil)
 		return
 	}
 	payload, err := json.Marshal(victims)
 	if err != nil {
-		r(constants.Failure, map[string]string{"error": err.Error()})
+		statusReport(constants.Failure, map[string]string{"error": err.Error()})
 		return
 	}
+
 	md := map[string]string{"failing_reports": string(payload), "error": "reports are running for too long"}
-	r(constants.Failure, md)
+	statusReport(constants.Failure, md)
 }


### PR DESCRIPTION
Changes:
- updated Status Reporter initialization
- stored initialized and deployment type values in `statusReporter` struct
- implemented `Monitoring` interface and moved db queries to `db2/monitoring.go` 

Tests:
- tested changes on local dev server 