### PR TITLE
feat(useSettingsStore): show `relative time` by default

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -68,6 +68,7 @@
         "useCustomFetch",
         "useFeatureFlag",
         "useNotificationsOverviewStore",
+        "useSettingsStore",
         "useWindowSize",
         "vscode"
     ],

--- a/frontend/stores/useSettingsStore.ts
+++ b/frontend/stores/useSettingsStore.ts
@@ -1,7 +1,7 @@
 export type DateTimeFormat = 'absolute' | 'relative'
 
 export const useSettingsStore = defineStore('settings', () => {
-  const dateTimeFormat = ref<DateTimeFormat>('absolute')
+  const dateTimeFormat = ref<DateTimeFormat>('relative')
   const toggleDateTimeFormat = () => {
     dateTimeFormat.value = dateTimeFormat.value === 'absolute' ? 'relative' : 'absolute'
   }


### PR DESCRIPTION
See: BEDS-1044