### PR TITLE
fix: update sync committees period calculations

### DIFF
--- a/backend/pkg/commons/utils/eth.go
+++ b/backend/pkg/commons/utils/eth.go
@@ -228,11 +228,18 @@ func SyncPeriodOfEpoch(epoch uint64) uint64 {
 	if epoch < Config.Chain.ClConfig.AltairForkEpoch {
 		return 0
 	}
-	return (epoch - Config.Chain.ClConfig.AltairForkEpoch) / Config.Chain.ClConfig.EpochsPerSyncCommitteePeriod
+	return epoch / Config.Chain.ClConfig.EpochsPerSyncCommitteePeriod
 }
 
+// FirstEpochOfSyncPeriod returns the first epoch of a given sync period.
+//
+// Please note that it will return the calculated first epoch of the sync period even if it is pre ALTAIR.
+//
+// Furthermore, for the very first actual sync period, it may return an epoch pre ALTAIR even though that is inccorect.
+//
+// For more information: https://eth2book.info/capella/annotated-spec/#sync-committee-updates
 func FirstEpochOfSyncPeriod(syncPeriod uint64) uint64 {
-	return Config.Chain.ClConfig.AltairForkEpoch + (syncPeriod * Config.Chain.ClConfig.EpochsPerSyncCommitteePeriod)
+	return syncPeriod * Config.Chain.ClConfig.EpochsPerSyncCommitteePeriod
 }
 
 func SlotsPerSyncCommittee() uint64 {


### PR DESCRIPTION
Changes: 
- Modified `SyncPeriodOfEpoch` calculation:
    * Old formula: `(Epoch - AltairForkEpoch) / EpochsPerSyncCommitteePeriod`
    * New formula: `Epoch / EpochsPerSyncCommitteePeriod`
    * Removed AltairForkEpoch subtraction from the calculation
- Modified `FirstEpochOfSyncPeriod` calculation:
    * Old formula: `AltairForkEpoch + (SyncPeriod * EpochsPerSyncCommitteePeriod)`
    * New formula: `SyncPeriod * EpochsPerSyncCommitteePeriod`
    * Removed AltairForkEpoch offset
   