### PR TITLE
refactor: remove `queue position` from `DashboardValidatorManagementModal`

### DIFF
--- a/backend/pkg/api/data_access/mobile.go
+++ b/backend/pkg/api/data_access/mobile.go
@@ -425,7 +425,6 @@ func (d *DataAccessService) GetValidatorDashboardMobileValidators(ctx context.Co
 			GroupId:               row.GroupId,
 			Balance:               row.Balance,
 			Status:                row.Status,
-			QueuePosition:         row.QueuePosition,
 			WithdrawalCredential:  row.WithdrawalCredential,
 			IsInSyncCommittee:     currentSyncCommitteeValidators[row.Index],
 			IsInNextSyncCommittee: upcomingSyncCommitteeValidators[row.Index],

--- a/backend/pkg/api/data_access/vdb_management.go
+++ b/backend/pkg/api/data_access/vdb_management.go
@@ -607,11 +607,6 @@ func (d *DataAccessService) GetValidatorDashboardValidators(ctx context.Context,
 			WithdrawalCredential: t.Hash(hexutil.Encode(metadata.WithdrawalCredentials)),
 		}
 
-		if constypes.ValidatorDbStatus(metadata.Status) == constypes.DbPending && metadata.Queues.ActivationIndex.Valid {
-			activationIndex := uint64(metadata.Queues.ActivationIndex.Int64)
-			row.QueuePosition = &activationIndex
-		}
-
 		if search == "" {
 			data = append(data, row)
 		} else {

--- a/backend/pkg/api/types/mobile.go
+++ b/backend/pkg/api/types/mobile.go
@@ -36,7 +36,6 @@ type MobileValidatorDashboardValidatorsTableRow struct {
 	GroupId              uint64          `json:"group_id"`
 	Balance              decimal.Decimal `json:"balance"`
 	Status               string          `json:"status" tstype:"'slashed' | 'exited' | 'deposited' | 'pending' | 'slashing_offline' | 'slashing_online' | 'exiting_offline' | 'exiting_online' | 'active_offline' | 'active_online'" faker:"oneof: slashed, exited, deposited, pending, slashing_offline, slashing_online, exiting_offline, exiting_online, active_offline, active_online"`
-	QueuePosition        *uint64         `json:"queue_position,omitempty"`
 	WithdrawalCredential Hash            `json:"withdrawal_credential"`
 	// additional mobile fields
 	IsInSyncCommittee     bool                                          `json:"is_in_sync_committee"`

--- a/backend/pkg/api/types/validator_dashboard.go
+++ b/backend/pkg/api/types/validator_dashboard.go
@@ -341,7 +341,6 @@ type VDBManageValidatorsTableRow struct {
 	GroupId              uint64          `json:"group_id"`
 	Balance              decimal.Decimal `json:"balance"`
 	Status               string          `json:"status" tstype:"'slashed' | 'exited' | 'deposited' | 'pending' | 'slashing_offline' | 'slashing_online' | 'exiting_offline' | 'exiting_online' | 'active_offline' | 'active_online'" faker:"oneof: slashed, exited, deposited, pending, slashing_offline, slashing_online, exiting_offline, exiting_online, active_offline, active_online"`
-	QueuePosition        *uint64         `json:"queue_position,omitempty"`
 	WithdrawalCredential Hash            `json:"withdrawal_credential"`
 }
 

--- a/frontend/components/dashboard/DashboardValidatorManagementModal.vue
+++ b/frontend/components/dashboard/DashboardValidatorManagementModal.vue
@@ -478,7 +478,6 @@ const inputValidator = ref('')
               <template #body="slotProps">
                 <ValidatorTableStatus
                   :status="slotProps.data.status"
-                  :position="slotProps.data.queue_position"
                   :hide-label="size.expandable"
                 />
               </template>
@@ -562,7 +561,6 @@ const inputValidator = ref('')
                   </div>
                   <ValidatorTableStatus
                     :status="slotProps.data.status"
-                    :position="slotProps.data.queue_position"
                   />
                 </div>
                 <div class="info">

--- a/frontend/components/validator/table/ValidatorTableStatus.vue
+++ b/frontend/components/validator/table/ValidatorTableStatus.vue
@@ -4,7 +4,6 @@ import type { ValidatorStatus } from '~/types/validator'
 
 interface Props {
   hideLabel?: boolean,
-  position?: number,
   status: ValidatorStatus,
 }
 const props = defineProps<Props>()
@@ -27,7 +26,6 @@ const iconColor = computed(() => {
       class="status"
     >
       {{ $t(`validator_state.${status}`) }}
-      <span v-if="position"> #<BcFormatNumber :value="position" /></span>
     </span>
   </div>
 </template>

--- a/frontend/types/api/mobile.ts
+++ b/frontend/types/api/mobile.ts
@@ -35,7 +35,6 @@ export interface MobileValidatorDashboardValidatorsTableRow {
   group_id: number /* uint64 */;
   balance: string /* decimal.Decimal */;
   status: 'slashed' | 'exited' | 'deposited' | 'pending' | 'slashing_offline' | 'slashing_online' | 'exiting_offline' | 'exiting_online' | 'active_offline' | 'active_online';
-  queue_position?: number /* uint64 */;
   withdrawal_credential: Hash;
   /**
    * additional mobile fields

--- a/frontend/types/api/validator_dashboard.ts
+++ b/frontend/types/api/validator_dashboard.ts
@@ -299,7 +299,6 @@ export interface VDBManageValidatorsTableRow {
   group_id: number /* uint64 */;
   balance: string /* decimal.Decimal */;
   status: 'slashed' | 'exited' | 'deposited' | 'pending' | 'slashing_offline' | 'slashing_online' | 'exiting_offline' | 'exiting_online' | 'active_offline' | 'active_online';
-  queue_position?: number /* uint64 */;
   withdrawal_credential: Hash;
 }
 export type GetValidatorDashboardValidatorsResponse = ApiPagingResponse<VDBManageValidatorsTableRow>;


### PR DESCRIPTION
This feature showed information like `Pending #2` before,
which indicated the number in the `activation queue`.

See: BEDS-1468