### PR TITLE
fix: account for consolidations when writing validator_stats

### DIFF
--- a/backend/pkg/commons/db/statistics.go
+++ b/backend/pkg/commons/db/statistics.go
@@ -134,6 +134,12 @@ func WriteValidatorStatisticsForDay(day uint64, client rpc.Client) error {
 		}
 		return nil
 	})
+	g.Go(func() error {
+		if err := gatherValidatorConsolidations(day, validatorData, validatorDataMux); err != nil {
+			return fmt.Errorf("error in gatherValidatorConsolidations: %w", err)
+		}
+		return nil
+	})
 
 	var statisticsData1d []*types.ValidatorStatsTableDbRow
 	g.Go(func() error {
@@ -202,7 +208,7 @@ func WriteValidatorStatisticsForDay(day uint64, client rpc.Client) error {
 		data.OrphanedSyncTotal = previousDayData.OrphanedSyncTotal + data.OrphanedSync
 
 		// calculate cl reward & update totals
-		data.ClRewardsGWei = data.EndBalance - previousDayData.EndBalance + data.WithdrawalsAmount - data.DepositsAmount
+		data.ClRewardsGWei = data.EndBalance - previousDayData.EndBalance + data.WithdrawalsAmount - data.DepositsAmount - data.IncomingConsolidationAmount + data.OutgoingConsolidationAmount
 		data.ClRewardsGWeiTotal = previousDayData.ClRewardsGWeiTotal + data.ClRewardsGWei
 
 		// update el reward total
@@ -213,11 +219,11 @@ func WriteValidatorStatisticsForDay(day uint64, client rpc.Client) error {
 
 		// update withdrawal total
 		data.WithdrawalsTotal = previousDayData.WithdrawalsTotal + data.Withdrawals
-		data.WithdrawalsAmountTotal = previousDayData.WithdrawalsAmountTotal + data.WithdrawalsAmount
+		data.WithdrawalsAmountTotal = previousDayData.WithdrawalsAmountTotal + data.WithdrawalsAmount + data.OutgoingConsolidationAmount
 
 		// update deposits total
 		data.DepositsTotal = previousDayData.DepositsTotal + data.Deposits
-		data.DepositsAmountTotal = previousDayData.DepositsAmountTotal + data.DepositsAmount
+		data.DepositsAmountTotal = previousDayData.DepositsAmountTotal + data.DepositsAmount + data.IncomingConsolidationAmount
 
 		if statisticsData1d != nil && len(statisticsData1d) > index {
 			data.ClPerformance1d = data.ClRewardsGWeiTotal - statisticsData1d[index].ClRewardsGWeiTotal
@@ -1181,6 +1187,51 @@ func gatherValidatorMissedAttestationsStatisticsForDay(validators []uint64, day 
 	// mux.Unlock()
 	log.Infof("gathering missed attestations completed, took %v", time.Since(start))
 
+	return nil
+}
+
+func gatherValidatorConsolidations(day uint64, data []*types.ValidatorStatsTableDbRow, mux *sync.Mutex) error {
+	exportStart := time.Now()
+	defer func() {
+		metrics.TaskDuration.WithLabelValues("db_update_validator_consolidations_stats").Observe(time.Since(exportStart).Seconds())
+	}()
+
+	firstSlot := day * utils.EpochsPerDay() * utils.Config.Chain.ClConfig.SlotsPerEpoch
+	lastSlot := utils.GetLastBalanceInfoSlotForDay(day)
+
+	fields := log.Fields{
+		"day":       day,
+		"firstSlot": firstSlot,
+		"lastSlot":  lastSlot,
+	}
+
+	log.Info("gathering consolidation statistics", fields)
+	var consolidationData []struct {
+		SourceIndex        int   `db:"source_index"`
+		TargetIndex        int   `db:"target_index"`
+		AmountConsolidated int64 `db:"amount_consolidated"`
+	}
+	err := ReaderDb.Select(&consolidationData, `
+		SELECT
+			source_index,
+			target_index,
+			COALESCE(amount_consolidated, 0) AS amount_consolidated
+		FROM blocks_consolidation_requests
+		INNER JOIN blocks ON blocks_consolidation_requests.block_root = blocks.blockroot AND blocks.status = '1'
+		WHERE block_slot >= $1 AND block_slot <= $2
+	`, firstSlot, lastSlot)
+	if err != nil {
+		return fmt.Errorf("error retrieving consolidation data for day [%v], firstSlot [%v] and lastSlot [%v]: %w", day, firstSlot, lastSlot, err)
+	}
+
+	mux.Lock()
+	for _, r := range consolidationData {
+		data[r.TargetIndex].IncomingConsolidationAmount += r.AmountConsolidated
+		data[r.SourceIndex].OutgoingConsolidationAmount += r.AmountConsolidated
+	}
+	mux.Unlock()
+
+	log.Infof("gathering consolidation statistics completed, took %v", time.Since(exportStart))
 	return nil
 }
 

--- a/backend/pkg/commons/types/exporter.go
+++ b/backend/pkg/commons/types/exporter.go
@@ -732,6 +732,9 @@ type ValidatorStatsTableDbRow struct {
 	MEVPerformance7d   decimal.Decimal `db:"-"`
 	MEVPerformance31d  decimal.Decimal `db:"-"`
 	MEVPerformance365d decimal.Decimal `db:"-"`
+
+	IncomingConsolidationAmount int64
+	OutgoingConsolidationAmount int64
 }
 
 type RedisCachedEpochAssignments struct {


### PR DESCRIPTION
- Fixes consolidations being counted towards CL Rewards
- Treats incoming and outgoing consolidations as deposits and withdrawals respectively