### PR TITLE
BEDS-1499 / withdrawals index type is int64

### DIFF
--- a/backend/pkg/commons/types/exporter.go
+++ b/backend/pkg/commons/types/exporter.go
@@ -248,7 +248,7 @@ type WithdrawalsByEpoch struct {
 
 type WithdrawalsNotification struct {
 	Slot           uint64 `json:"slot,omitempty"`
-	Index          uint64 `json:"index"`
+	Index          int64  `json:"index"`
 	ValidatorIndex uint64 `json:"validatorindex"`
 	Address        []byte `json:"address"`
 	Amount         uint64 `json:"amount"`


### PR DESCRIPTION
`time="2025-05-04T20:49:17Z" level=error msg="error collection notifications" _file=collection.go _function=github.com/gobitfly/beaconchain/pkg/notification.notificationCollector _line=172 _version=20250430102124-2ba7a7a7 errType="*errors.errorString" error="error collecting withdrawal notifications: error getting withdrawals from database, err: error getting blocks_withdrawals for epoch: 10873: sql: Scan error on column index 1, name \"index\": converting driver.Value type int64 (\"-30000\") to a uint64: invalid`