### PR TITLE
feat: reset `cursor` on `page size change`

### DIFF
--- a/frontend/components/dashboard/DashboardGroupManagementModal.vue
+++ b/frontend/components/dashboard/DashboardGroupManagementModal.vue
@@ -167,6 +167,7 @@ const setCursor = (value: Cursor) => {
 }
 
 const setPageSize = (value: number) => {
+  cursor.value = 0
   pageSize.value = value
 }
 

--- a/frontend/utils/table.ts
+++ b/frontend/utils/table.ts
@@ -9,6 +9,7 @@ export const setQueryPageSize = (
 ): TableQueryParams => {
   return {
     ...query,
+    cursor: undefined,
     limit,
   }
 }


### PR DESCRIPTION
Due to a bigger refactoring for `backend` it was
decided, that we should reset the cursor on `page size` change events.
Otherwise the following scenario is misleading:
1. user sets `page size`: 5
2. user gets to page 3
3. user sets `page size` to 10
4. user clicks `previous`
result:  user will get back to last `result` with `page size` 5

See: BEDS-1483