### PR TITLE
feat: change `proposal rewards` tooltip label

### DIFF
--- a/frontend/components/block/table/BlockTableRewardItem.vue
+++ b/frontend/components/block/table/BlockTableRewardItem.vue
@@ -30,7 +30,7 @@ defineProps<{
       <div>
         <div class="tooltip-row">
           <h3 class="tooltip-title">
-            {{ $t("dashboard.validator.blocks.el_rewards") }}
+            {{ $t("dashboard.validator.blocks.el_reward") }}
           </h3>
           <BcFormatAmount
             :value="reward?.el"
@@ -42,7 +42,7 @@ defineProps<{
         </div>
         <div class="tooltip-row">
           <h3 class="tooltip-title">
-            {{ $t("dashboard.validator.blocks.cl_rewards") }}
+            {{ $t("dashboard.validator.blocks.cl_reward") }}
           </h3>
           <template
             v-if="reward?.cl && reward.cl != '0'"

--- a/frontend/components/dashboard/table/SummaryMissedRewards.vue
+++ b/frontend/components/dashboard/table/SummaryMissedRewards.vue
@@ -36,7 +36,7 @@ const { missedRewards } = defineProps<{
             </span>
           </div>
           <div class="tt-row">
-            <span class="bold">{{ $t("dashboard.validator.blocks.el_rewards") }}:
+            <span class="bold">{{ $t("dashboard.validator.blocks.el_proposal_reward") }}:
             </span>
             <BcFormatAmount
               :value="missedRewards.proposer_rewards.el"
@@ -45,7 +45,7 @@ const { missedRewards } = defineProps<{
             />
           </div>
           <div class="tt-row">
-            <span class="bold">{{ $t("dashboard.validator.blocks.cl_rewards") }}:
+            <span class="bold">{{ $t("dashboard.validator.blocks.cl_proposal_reward") }}:
             </span>
             <BcFormatAmount
               :value="missedRewards.proposer_rewards.cl"

--- a/frontend/components/dashboard/table/SummaryReward.vue
+++ b/frontend/components/dashboard/table/SummaryReward.vue
@@ -28,7 +28,7 @@ const hasReward = computed(() => !(reward.el === '0' && reward.cl === '0'))
         <div>
           <div>
             <h3 class="bold">
-              {{ $t("dashboard.validator.blocks.el_rewards") }}
+              {{ $t("dashboard.validator.blocks.el_reward") }}
             </h3>
             <BcFormatAmount
               :value="reward.el"
@@ -40,7 +40,7 @@ const hasReward = computed(() => !(reward.el === '0' && reward.cl === '0'))
           </div>
           <div>
             <h3 class="bold">
-              {{ $t("dashboard.validator.blocks.cl_rewards") }}
+              {{ $t("dashboard.validator.blocks.cl_reward") }}
             </h3>
             <BcFormatAmount
               :value="reward.cl"

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -218,8 +218,10 @@
         "validator": {
             "blocks": {
                 "cl_pending": "CL Pending",
-                "cl_rewards": "Consensus Layer Reward",
-                "el_rewards": "Execution Layer Reward",
+                "cl_proposal_reward": "Consensus Layer Proposal Reward",
+                "cl_reward": "Consensus Layer Reward",
+                "el_proposal_reward": "Execution Layer Proposal Reward",
+                "el_reward": "Execution Layer Reward",
                 "pending": "Pending",
                 "search_placeholder": "Index, Public Key, Group",
                 "search_placeholder_public": "Index, Public Key",


### PR DESCRIPTION
- additionally make cl and el reward translation keys singular

See: BEDS-1168