### PR TITLE
refactor: remove csrf middleware

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -112,6 +112,10 @@ linters-settings:
         msg: Use log.Infof instead
       - p: ^fmt\.Printf.*$
         msg: Use log.Infof instead
+      - p: ^.*ParseForm().*$
+        msg: Don't use html forms without proper CSRF protection
+      - p: ^.*FormValue().*$
+        msg: Don't use html forms without proper CSRF protection
   gocognit:
     min-complexity: 65
   depguard:

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -36,7 +36,6 @@ require (
 	github.com/gomodule/redigo v1.9.2
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/gorilla/csrf v1.7.2
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
@@ -200,7 +199,6 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
-	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/hashicorp/go-bexpr v0.1.10 // indirect
 	github.com/herumi/bls-eth-go-binary v1.31.0 // indirect
 	github.com/holiman/billy v0.0.0-20240216141850-2abb0c79d3c4 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -433,14 +433,10 @@ github.com/googleapis/gax-go/v2 v2.14.1/go.mod h1:Hb/NubMaVM88SrNkvl8X/o8XWwDJEP
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c h1:7lF+Vz0LqiRidnzC1Oq86fpX1q/iEv2KJdrCtttYjT4=
 github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/gorilla/csrf v1.7.2 h1:oTUjx0vyf2T+wkrx09Trsev1TE+/EbDAeHtSTbtC2eI=
-github.com/gorilla/csrf v1.7.2/go.mod h1:F1Fj3KG23WYHE6gozCmBAezKookxbIvUJT+121wTuLk=
 github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE=
 github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
-github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kXD8ePA=
-github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/graph-gophers/graphql-go v1.3.0 h1:Eb9x/q6MFpCLz7jBCiP/WTxjSDrYLR1QY41SORZyNJ0=

--- a/backend/pkg/api/auth.go
+++ b/backend/pkg/api/auth.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"regexp"
 	"time"
 
 	"github.com/alexedwards/scs/redisstore"
@@ -57,7 +58,7 @@ func getSlidingSessionExpirationMiddleware(scs *scs.SessionManager) func(http.Ha
 func contentTypeMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// if body is not empty, check if content type is set to json
-		if (r.Method == http.MethodPost || r.Method == http.MethodPut) && r.ContentLength > 0 && r.Header.Get("Content-Type") != "application/json" {
+		if (r.Method == http.MethodPost || r.Method == http.MethodPut) && r.ContentLength > 0 && regexp.MustCompile(`^application\/json(;.*)?$`).MatchString(r.Header.Get("Content-Type")) {
 			http.Error(w, "bad request: Content-Type header must be application/json", http.StatusBadRequest)
 			return
 		}

--- a/backend/pkg/api/auth.go
+++ b/backend/pkg/api/auth.go
@@ -1,16 +1,13 @@
 package api
 
 import (
-	"encoding/hex"
 	"net/http"
 	"time"
 
 	"github.com/alexedwards/scs/redisstore"
 	"github.com/alexedwards/scs/v2"
-	"github.com/gobitfly/beaconchain/pkg/commons/log"
 	"github.com/gobitfly/beaconchain/pkg/commons/types"
 	"github.com/gomodule/redigo/redis"
-	"github.com/gorilla/csrf"
 )
 
 var day time.Duration = time.Hour * 24
@@ -55,37 +52,6 @@ func getSlidingSessionExpirationMiddleware(scs *scs.SessionManager) func(http.Ha
 			next.ServeHTTP(w, r)
 		})
 	}
-}
-
-// returns goriila/csrf middleware with the given config settings
-func getCsrfProtectionMiddleware(cfg *types.Config) func(http.Handler) http.Handler {
-	csrfBytes, err := hex.DecodeString(cfg.Frontend.CsrfAuthKey)
-	if err != nil {
-		log.Fatal(err, "error decoding cfg.Frontend.CsrfAuthKey, set it to a valid hex string", 0)
-	}
-	if len(csrfBytes) == 0 {
-		log.Warn("CSRF auth key is empty, unsafe requests will not work! Set cfg.Frontend.Debug to true to disable CSRF protection or cfg.Frontend.CsrfAuthKey.")
-	}
-	sameSite := csrf.SameSiteStrictMode
-	if cfg.Frontend.SessionSameSiteNone {
-		sameSite = csrf.SameSiteNoneMode
-	}
-
-	return csrf.Protect(
-		csrfBytes,
-		csrf.Secure(!cfg.Frontend.CsrfInsecure),
-		csrf.Path("/"),
-		csrf.Domain(cfg.Frontend.SessionCookieDomain),
-		csrf.SameSite(sameSite),
-	)
-}
-
-// returns a middleware that injects the CSRF token into the response headers
-func csrfInjecterMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("X-CSRF-Token", csrf.Token(r))
-		next.ServeHTTP(w, r)
-	})
 }
 
 func contentTypeMiddleware(next http.Handler) http.Handler {

--- a/backend/pkg/api/auth.go
+++ b/backend/pkg/api/auth.go
@@ -58,7 +58,7 @@ func getSlidingSessionExpirationMiddleware(scs *scs.SessionManager) func(http.Ha
 func contentTypeMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// if body is not empty, check if content type is set to json
-		if (r.Method == http.MethodPost || r.Method == http.MethodPut) && r.ContentLength > 0 && regexp.MustCompile(`^application\/json(;.*)?$`).MatchString(r.Header.Get("Content-Type")) {
+		if (r.Method == http.MethodPost || r.Method == http.MethodPut) && r.ContentLength > 0 && !regexp.MustCompile(`^application\/json(;.*)?$`).MatchString(r.Header.Get("Content-Type")) {
 			http.Error(w, "bad request: Content-Type header must be application/json", http.StatusBadRequest)
 			return
 		}

--- a/backend/pkg/api/router.go
+++ b/backend/pkg/api/router.go
@@ -31,9 +31,6 @@ func NewApiRouter(dataAccessor dataaccess.DataAccessor, dummy dataaccess.DataAcc
 	sessionManager := newSessionManager(cfg)
 	internalRouter.Use(sessionManager.LoadAndSave, getSlidingSessionExpirationMiddleware(sessionManager))
 
-	if !(cfg.Frontend.CsrfInsecure || cfg.Frontend.Debug) {
-		internalRouter.Use(getCsrfProtectionMiddleware(cfg), csrfInjecterMiddleware)
-	}
 	handlerService := handlers.NewHandlerService(dataAccessor, dummy, sessionManager, cfg)
 
 	// store user id in context, if available
@@ -60,8 +57,7 @@ func GetCorsMiddleware(allowedHosts []string) func(http.Handler) http.Handler {
 		return gorillaHandlers.CORS(
 			gorillaHandlers.AllowedOrigins([]string{"*"}),
 			gorillaHandlers.AllowedMethods([]string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions, http.MethodHead}),
-			gorillaHandlers.AllowedHeaders([]string{"Content-Type", "Authorization", "X-CSRF-Token"}),
-			gorillaHandlers.ExposedHeaders([]string{"X-CSRF-Token"}),
+			gorillaHandlers.AllowedHeaders([]string{"Content-Type", "Authorization"}),
 		)
 	}
 
@@ -85,8 +81,7 @@ func GetCorsMiddleware(allowedHosts []string) func(http.Handler) http.Handler {
 			return false
 		}),
 		gorillaHandlers.AllowedMethods([]string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions, http.MethodHead}),
-		gorillaHandlers.AllowedHeaders([]string{"Content-Type", "Authorization", "X-CSRF-Token"}),
-		gorillaHandlers.ExposedHeaders([]string{"X-CSRF-Token"}),
+		gorillaHandlers.AllowedHeaders([]string{"Content-Type", "Authorization"}),
 		gorillaHandlers.AllowCredentials(),
 	)
 }


### PR DESCRIPTION
- Since the API uses no HTML forms and validates the Content-Type of all unsafe requests, the middleware is unnecessary.
- Added linter rule preventing any form parsing being added in the future.
- Proper CORS config has to be maintained with or without CSRF middleware anyways.
