### PR TITLE
chore: update config and docs for creating the `server certificate`

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -30,6 +30,10 @@ pnpm-lock.yaml
 
 .npmrc
 
+# SSL certificate files created via `mkcert`
+*.pem
+
+# Prevent accidentally commiting obsolete SSL certificate files
 server.crt
 server.key
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,32 +14,11 @@ Look at the [Nuxt 3 documentation](https://nuxt.com/docs/getting-started/introdu
 
 ## Setup
 
-Install `npm` and Nuxt.
-
 Clone the `beaconchain` repository from git.
 
-On your console, navigate to folder `beaconchain/frontend`.
+In your terminal, navigate to folder `beaconchain/frontend`.
 
-Type
-
-Then type:
-
-```bash
-cp .env-example .env
-```
-
-In file `.env`, write the URLs of the API servers and the secret key to access to them.
-The variable evoking the development is used to show/hide features and components that are not ready for production.
-
-Create server certificates for locally running on https, by runing these comands in the console:
-
-```bash
-openssl genrsa 2048 > server.key
-sudo chmod 400 server.key
-sudo openssl req -new -x509 -nodes -sha256 -days 365 -key server.key -out server.crt
-```
-
-Navigate to folder `beaconchain/frontend` and run
+### Install packages.
 
 ```bash
 npm install
@@ -59,6 +38,28 @@ then
 pnpm install
 yarn install
 bun install
+```
+
+### Create `.env` file
+Copy the existing `.env-example` file to a new `.env`:
+
+```bash
+cp .env-example .env
+```
+
+Inside of `.env`, add necessary URLs and secrets.
+
+### Create `SSL certificate` to enable local development over `https`
+
+We recommend using `mkcert` for creating self-signed certificates, as it simplifies the process and avoids browser warnings. If you don't have `mkcert` installed, you can follow the [installation instructions](https://github.com/FiloSottile/mkcert#installation).
+
+Once installed, run:
+
+```bash
+# create a local CA (Certificate Authority)
+mkcert -install
+# create a certificate for your local development domain
+mkcert local.beaconcha.in
 ```
 
 ## Development Server
@@ -121,7 +122,7 @@ You can `turn on` mocked data `globally` for all `configured enpoints`
 in your [.env](.env) or
 - running `npm run dev:mock:api` (See: [package.json](package.json))
 
-## Descision Record
+## Decision Record
 
 We documented our decisions in the [decisions](decisions.md) file.
 The documentation should be inspired by Architecture Decision Records ([ADR](https://adr.github.io/)).

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -81,8 +81,8 @@ export default defineNuxtConfig({
   devServer: {
     host: 'local.beaconcha.in',
     https: {
-      cert: 'server.crt',
-      key: 'server.key',
+      cert: 'local.beaconcha.in.pem',
+      key: 'local.beaconcha.in-key.pem',
     },
   },
   compatibilityDate: '2024-07-15',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,7 +46,7 @@
     "private": true,
     "scripts": {
         "build": "nuxt build",
-        "dev": "NODE_TLS_REJECT_UNAUTHORIZED=0 nuxt dev",
+        "dev": "nuxt dev",
         "dev:mock:api": "NUXT_PUBLIC_IS_API_MOCKED=true npm run dev",
         "dev:mock:production": "NUXT_DEPLOYMENT_TYPE=production npm run dev",
         "dev:mock:staging": "NUXT_DEPLOYMENT_TYPE=staging npm run dev",


### PR DESCRIPTION
- re-enable `certificate` usage in local development with `https`
- restructure `setup` section in `readme`

See: BEDS-1109