### PR TITLE
fix(useStripeProvider): safari did not route to `stripe customer portal`

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -78,6 +78,7 @@
         "useFeatureFlag",
         "useNotificationsOverviewStore",
         "useSettingsStore",
+        "useStripeProvider",
         "useWindowSize",
         "variables.scss",
         "vscode"

--- a/frontend/composables/useStripeProvider.ts
+++ b/frontend/composables/useStripeProvider.ts
@@ -59,7 +59,7 @@ export function useStripeProvider() {
       },
     )
 
-    window.open(res?.url, '_blank')
+    await navigateTo(res?.url, { external: true })
 
     isStripeProcessing.value = false
   }


### PR DESCRIPTION
`window.open()` does not work on `safari based browsers`