### PR TITLE
fix: error for `empty dashboard` and `private dashboard id` in cookie

### DIFF
--- a/frontend/composables/useBcCookie.ts
+++ b/frontend/composables/useBcCookie.ts
@@ -21,7 +21,7 @@ type OptionsUseCookie<T> = CookieOptions<T> & {
  * This allows us to have autocompletion for the cookie names.
  *
  */
-export const useBcCookie = <T = string | undefined>(
+export const useBcCookie = <T = unknown>(
   name: CookieName,
   options?: OptionsUseCookie<T>,
 ) => {

--- a/frontend/composables/useDashboardKeyProvider.ts
+++ b/frontend/composables/useDashboardKeyProvider.ts
@@ -65,8 +65,8 @@ export function useDashboardKeyProvider(
       // only use the dashboard cookie key as default if you are not logged in and it's not private
       if (
         !isLoggedIn.value
-        && isGuestDashboardKey(dashboardKeyCookie.value)
-        && !isSharedDashboardKey(dashboardKeyCookie.value)
+        && isGuestDashboardKey(`${dashboardKeyCookie.value}`)
+        && !isSharedDashboardKey(`${dashboardKeyCookie.value}`)
       ) {
         setDashboardKey(`${dashboardKeyCookie.value}`)
       }
@@ -135,7 +135,7 @@ export function useDashboardKeyProvider(
       oldValue
       && !newValue
       && dashboardKeyCookie.value
-      && !isNaN(parseInt(dashboardKeyCookie.value))
+      && !isNaN(parseInt(`${dashboardKeyCookie.value}`))
     ) {
       setDashboardKey('')
     }

--- a/frontend/stores/dashboard/useUserDashboardStore.ts
+++ b/frontend/stores/dashboard/useUserDashboardStore.ts
@@ -29,7 +29,7 @@ export const useUserDashboardStore = defineStore('user_dashboards_store', () => 
         return dashboardCookie.value as any as UserDashboardsData
       }
       else {
-        return JSON.parse(dashboardCookie.value)
+        return JSON.parse(`${dashboardCookie.value}`)
       }
     }
   })


### PR DESCRIPTION
Before the `isGuestDashboardKey()` utility function threw an error, in the `useDasboardKeyProvider()` composable.
Only when the url was `/dashboard` (no dashboard key) and the `bc-validator-dashboard-key` cookie value was a number (e.g. private dashboards).

Trying to use startsWith() on a number remained undetected since the `useBcCookie() composable` used `string` as a default type value.