### PR TITLE
fix: allow adding validators by public key

### DIFF
--- a/backend/pkg/api/handlers/public.go
+++ b/backend/pkg/api/handlers/public.go
@@ -556,12 +556,12 @@ func (h *HandlerService) PublicPostValidatorDashboardValidators(w http.ResponseW
 	var requestedValidators []types.VDBValidator
 	switch {
 	case req.Validators != nil:
-		requestedValidators, _ = v.checkValidators(req.Validators, forbidEmpty)
+		requestedIndices, requestedPublicKeys := v.checkValidators(req.Validators, forbidEmpty)
 		if err = v.AsError(); err != nil {
 			handleErr(w, r, err)
 			return
 		}
-		requestedValidators, err = h.getDataAccessor(ctx).GetValidatorsFromSlices(ctx, requestedValidators, nil)
+		requestedValidators, err = h.getDataAccessor(ctx).GetValidatorsFromSlices(ctx, requestedIndices, requestedPublicKeys)
 
 	case req.DepositAddress != "":
 		requestedValidators, err = h.getValidatorDashboardValidators(r, req.DepositAddress, "deposit_address", types.ReEthereumAddress, h.getDataAccessor(ctx).GetValidatorsByDepositAddress)


### PR DESCRIPTION
With this PR, adding validators through public keys works again, e.g. for hoodi pass
```json
{
    "validators": ["0xb85e6fd8df381a240faab6a90e5ba94adffcc498fbb8176146abead667757e0e8a6888c2773653bb247d2e24e09b70de"]
}
```
to `POST /api/i/validator-dashboards/<ID>/validators`