### PR TITLE
fix(BaseNavigation): `menu items` not clickable

### DIFF
--- a/frontend/layers/base/app/components/BaseNavigation.vue
+++ b/frontend/layers/base/app/components/BaseNavigation.vue
@@ -21,7 +21,7 @@ const v1Domain = useV1Domain()
 <template>
   <nav class="p-2xl isolate">
     <div class="max-w-8xl mx-auto grid gap-2xl [&>*]:[grid-area:1/1]">
-      <span class="flex gap-2xl items-center z-10">
+      <span class="flex gap-2xl items-center z-10 w-fit">
         <BaseButtonIcon
           screenreader-text="base.common.open_navigation"
           class="sm:hidden"


### PR DESCRIPTION
Due to elements stacking eachother in a `grid container`