### PR TITLE
fix: add missing `/-prefix` for `api doc links`

### DIFF
--- a/frontend/layers/base/app/components/TheFooter.vue
+++ b/frontend/layers/base/app/components/TheFooter.vue
@@ -11,7 +11,7 @@ const { t: $t } = useTranslation()
 
 const productLinks: Link[] = [
   {
-    href: 'products/api/docs', icon: 'file-code', text: $t('products.api'),
+    href: '/products/api/docs', icon: 'file-code', text: $t('products.api'),
   },
   {
     href: '/dashboard', icon: 'coins', text: $t('products.staking_hub'),

--- a/frontend/layers/products/app/pages/products/index.vue
+++ b/frontend/layers/products/app/pages/products/index.vue
@@ -126,7 +126,7 @@ const {
             :title="$t('products.landing_page.api.cards.api_docs.title')"
             :subtitle="$t('products.landing_page.api.cards.api_docs.subtitle')"
             title-icon="file-code-2"
-            title-to="products/api/docs"
+            title-to="/products/api/docs"
           >
             <div class="grid grid-cols-2 lg:grid-cols-3 gap-5xl mt-7xl">
               <article class="flex flex-col gap-4xl">


### PR DESCRIPTION
This expressed itself as a hydration missmatch.