### PR TITLE
feat: allow 'latest' search for slots, blocks & epochs

### DIFF
--- a/backend/pkg/api/data_access/data_access.go
+++ b/backend/pkg/api/data_access/data_access.go
@@ -39,6 +39,7 @@ type DataAccessor interface {
 	GetLatestFinalizedEpoch(ctx context.Context) (uint64, error)
 	GetLatestSlot(ctx context.Context) (uint64, error)
 	GetLatestBlock(ctx context.Context) (uint64, error)
+	GetLatestTransaction(ctx context.Context) (t.Hash, error)
 	GetLatestExchangeRates(ctx context.Context) ([]t.EthConversionRate, error)
 
 	GetProductSummary(ctx context.Context) (*t.ProductSummary, error)

--- a/backend/pkg/api/data_access/dummy.go
+++ b/backend/pkg/api/data_access/dummy.go
@@ -165,6 +165,10 @@ func (*DummyService) GetLatestBlock(ctx context.Context) (uint64, error) {
 	return getDummyData[uint64](ctx)
 }
 
+func (*DummyService) GetLatestTransaction(ctx context.Context) (t.Hash, error) {
+	return getDummyData[t.Hash](ctx)
+}
+
 func (*DummyService) GetLatestExchangeRates(ctx context.Context) ([]t.EthConversionRate, error) {
 	return getDummyData[[]t.EthConversionRate](ctx)
 }

--- a/backend/pkg/api/data_access/header.go
+++ b/backend/pkg/api/data_access/header.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/doug-martin/goqu/v9"
 	t "github.com/gobitfly/beaconchain/pkg/api/types"
 	"github.com/gobitfly/beaconchain/pkg/commons/cache"
 	"github.com/gobitfly/beaconchain/pkg/commons/log"
@@ -23,8 +24,19 @@ func (d *DataAccessService) GetLatestFinalizedEpoch(ctx context.Context) (uint64
 }
 
 func (d *DataAccessService) GetLatestBlock(ctx context.Context) (uint64, error) {
-	// @DATA-ACCESS implement
-	return d.dummy.GetLatestBlock(ctx)
+	ds := goqu.Dialect("postgres").
+		From(goqu.T("blocks")).
+		Select(goqu.MAX(goqu.C("exec_block_number")))
+
+	res, err := runQuery[uint64](ctx, d.readerDb, ds)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			log.Warn("no EL block found")
+			return 0, nil
+		}
+		return 0, fmt.Errorf("failed to get latest existing block height: %w", err)
+	}
+	return res, nil
 }
 
 func (d *DataAccessService) GetBlockHeightAt(ctx context.Context, slot uint64) (uint64, error) {

--- a/backend/pkg/api/data_access/header.go
+++ b/backend/pkg/api/data_access/header.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 
 	"github.com/doug-martin/goqu/v9"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	t "github.com/gobitfly/beaconchain/pkg/api/types"
 	"github.com/gobitfly/beaconchain/pkg/commons/cache"
+	"github.com/gobitfly/beaconchain/pkg/commons/db"
 	"github.com/gobitfly/beaconchain/pkg/commons/log"
 	"github.com/gobitfly/beaconchain/pkg/commons/price"
 	"github.com/gobitfly/beaconchain/pkg/commons/utils"
@@ -37,6 +39,23 @@ func (d *DataAccessService) GetLatestBlock(ctx context.Context) (uint64, error) 
 		return 0, fmt.Errorf("failed to get latest existing block height: %w", err)
 	}
 	return res, nil
+}
+
+func (d *DataAccessService) GetLatestTransaction(ctx context.Context) (t.Hash, error) {
+	indexedBlock, err := d.bigtable.GetMostRecentBlockFromDataTable()
+	if err != nil {
+		return "", fmt.Errorf("failed to get latest block: %w", err)
+	}
+	block, err := d.bigtable.GetBlockFromBlocksTable(indexedBlock.GetNumber())
+	if err != nil {
+		if err == db.ErrBlockNotFound {
+			err = db.ErrNotFound
+		}
+		return "", fmt.Errorf("failed to get latest block from bigtable: %w", err)
+	}
+	transactions := block.GetTransactions()
+	hash := transactions[len(transactions)-1].GetHash()
+	return t.Hash(hexutil.Encode(hash)), nil
 }
 
 func (d *DataAccessService) GetBlockHeightAt(ctx context.Context, slot uint64) (uint64, error) {

--- a/backend/pkg/api/handlers/search.go
+++ b/backend/pkg/api/handlers/search.go
@@ -127,12 +127,12 @@ func init() {
 			handlerFunc:  handleSearchTransaction,
 		},
 		blockKey: {
-			regex:        types.ReInteger,
+			regex:        types.ReIntegerOrLatest,
 			responseType: string(blockKey),
 			handlerFunc:  handleSearchBlock,
 		},
 		slotKey: {
-			regex:        types.ReInteger,
+			regex:        types.ReIntegerOrLatest,
 			responseType: "slot",
 			handlerFunc:  handleSearchSlot,
 		},
@@ -147,7 +147,7 @@ func init() {
 			handlerFunc:  handleSearchSlotByStateRoot,
 		},
 		epochKey: {
-			regex:        types.ReInteger,
+			regex:        types.ReIntegerOrLatest,
 			responseType: string(epochKey),
 			handlerFunc:  handleSearchEpoch,
 		},
@@ -376,6 +376,13 @@ func handleSearchTransaction(ctx context.Context, h *HandlerService, input strin
 }
 
 func handleSearchBlock(ctx context.Context, h *HandlerService, input string, chainId uint64) (*types.SearchResult, error) {
+	if input == "latest" {
+		result, err := h.daService.GetLatestBlock(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return asSearchResult(blockKey, chainId, &types.SearchBlock{BlockNumber: result}, nil)
+	}
 	blockNumber, err := strconv.ParseUint(input, 10, 64)
 	if err != nil {
 		return nil, err
@@ -385,6 +392,13 @@ func handleSearchBlock(ctx context.Context, h *HandlerService, input string, cha
 }
 
 func handleSearchSlot(ctx context.Context, h *HandlerService, input string, chainId uint64) (*types.SearchResult, error) {
+	if input == "latest" {
+		result, err := h.daService.GetLatestSlot(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return asSearchResult(slotKey, chainId, &types.SearchSlot{Slot: result}, nil)
+	}
 	slot, err := strconv.ParseUint(input, 10, 64)
 	if err != nil {
 		return nil, err
@@ -412,6 +426,14 @@ func handleSearchSlotByStateRoot(ctx context.Context, h *HandlerService, input s
 }
 
 func handleSearchEpoch(ctx context.Context, h *HandlerService, input string, chainId uint64) (*types.SearchResult, error) {
+	if input == "latest" {
+		result, err := h.daService.GetLatestSlot(ctx)
+		if err != nil {
+			return nil, err
+		}
+		epoch := result / h.cfg.ClConfig.SlotsPerEpoch
+		return asSearchResult(epochKey, chainId, &types.SearchEpoch{Epoch: epoch}, nil)
+	}
 	epoch, err := strconv.ParseUint(input, 10, 64)
 	if err != nil {
 		return nil, err

--- a/backend/pkg/api/handlers/search.go
+++ b/backend/pkg/api/handlers/search.go
@@ -122,7 +122,7 @@ func init() {
 			handlerFunc:  handleSearchEnsName,
 		},
 		transactionKey: {
-			regex:        types.ReTransactionHash,
+			regex:        types.ReTransactionHashOrLatest,
 			responseType: string(transactionKey),
 			handlerFunc:  handleSearchTransaction,
 		},
@@ -366,7 +366,16 @@ func handleSearchEnsName(ctx context.Context, h *HandlerService, input string, c
 	return asSearchResult(ensNameKey, chainId, result, err)
 }
 
+const latestSearch = "/latest"
+
 func handleSearchTransaction(ctx context.Context, h *HandlerService, input string, chainId uint64) (*types.SearchResult, error) {
+	if input == latestSearch {
+		result, err := h.daService.GetLatestTransaction(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return asSearchResult(transactionKey, chainId, &types.SearchTransaction{TransactionHash: result}, nil)
+	}
 	transactionHash, err := hex.DecodeString(strings.TrimPrefix(input, "0x"))
 	if err != nil {
 		return nil, err
@@ -376,7 +385,7 @@ func handleSearchTransaction(ctx context.Context, h *HandlerService, input strin
 }
 
 func handleSearchBlock(ctx context.Context, h *HandlerService, input string, chainId uint64) (*types.SearchResult, error) {
-	if input == "latest" {
+	if input == latestSearch {
 		result, err := h.daService.GetLatestBlock(ctx)
 		if err != nil {
 			return nil, err
@@ -392,7 +401,7 @@ func handleSearchBlock(ctx context.Context, h *HandlerService, input string, cha
 }
 
 func handleSearchSlot(ctx context.Context, h *HandlerService, input string, chainId uint64) (*types.SearchResult, error) {
-	if input == "latest" {
+	if input == latestSearch {
 		result, err := h.daService.GetLatestSlot(ctx)
 		if err != nil {
 			return nil, err
@@ -426,7 +435,7 @@ func handleSearchSlotByStateRoot(ctx context.Context, h *HandlerService, input s
 }
 
 func handleSearchEpoch(ctx context.Context, h *HandlerService, input string, chainId uint64) (*types.SearchResult, error) {
-	if input == "latest" {
+	if input == latestSearch {
 		result, err := h.daService.GetLatestSlot(ctx)
 		if err != nil {
 			return nil, err

--- a/backend/pkg/api/types/regexes.go
+++ b/backend/pkg/api/types/regexes.go
@@ -5,7 +5,7 @@ import "regexp"
 var (
 	ReName                         = regexp.MustCompile(`^[a-zA-Z0-9_\-.\ ]*$`)
 	ReInteger                      = regexp.MustCompile(`^[0-9]+$`)
-	ReIntegerOrLatest              = regexp.MustCompile(`^(latest|[0-9]+)$`)
+	ReIntegerOrLatest              = regexp.MustCompile(`^(\/latest|[0-9]+)$`)
 	ReValidatorDashboardPublicId   = regexp.MustCompile(`^v-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 	ReValidatorPublicKeyWithPrefix = regexp.MustCompile(`^0x[0-9a-fA-F]{96}$`)
 	ReValidatorPublicKey           = regexp.MustCompile(`^(0x)?[0-9a-fA-F]{96}$`)
@@ -14,6 +14,7 @@ var (
 	ReWithdrawalCredential         = regexp.MustCompile(`^(0x)?0[012][0-9a-fA-F]{62}$`)
 	Re64ByteHash                   = regexp.MustCompile(`^0x[0-9a-fA-F]{64}$`)
 	ReTransactionHash              = Re64ByteHash
+	ReTransactionHashOrLatest      = regexp.MustCompile(`^(\/latest|0x[0-9a-fA-F]{64})$`)
 	ReEnsName                      = regexp.MustCompile(`^.+\.eth$`)
 	ReGraffiti                     = regexp.MustCompile(`^.{2,32}$`) // at least 2 characters, so that queries won't time out
 	ReGraffitiHex                  = regexp.MustCompile(`^(0x)?([0-9a-fA-F]{2}){32}$`)

--- a/backend/pkg/api/types/regexes.go
+++ b/backend/pkg/api/types/regexes.go
@@ -5,6 +5,7 @@ import "regexp"
 var (
 	ReName                         = regexp.MustCompile(`^[a-zA-Z0-9_\-.\ ]*$`)
 	ReInteger                      = regexp.MustCompile(`^[0-9]+$`)
+	ReIntegerOrLatest              = regexp.MustCompile(`^(latest|[0-9]+)$`)
 	ReValidatorDashboardPublicId   = regexp.MustCompile(`^v-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 	ReValidatorPublicKeyWithPrefix = regexp.MustCompile(`^0x[0-9a-fA-F]{96}$`)
 	ReValidatorPublicKey           = regexp.MustCompile(`^(0x)?[0-9a-fA-F]{96}$`)


### PR DESCRIPTION
Allows this:
```bash
curl --location 'http://0.0.0.0:8081/api/i/search' \
                                                             --header 'Content-Type: application/json' \
                                                             --data '{
                                                             "input":"latest",
                                                             "types":["epoch"],
                                                             "networks":["hoodi"]
                                                         }'
{"data":[{"type":"epoch","chain_id":560048,"value":{"epoch":49055}}]}
```
