### PR TITLE
refactor: omit unnecessary reassignment

### DIFF
--- a/backend/cmd/misc/main.go
+++ b/backend/cmd/misc/main.go
@@ -706,7 +706,6 @@ func fixEns(erigonClient *rpc.ErigonClient) error {
 
 		log.Infof("processing batch %v-%v / %v", i, to, total)
 		for _, addr := range batch {
-			addr := addr
 			g.Go(func() error {
 				ensAddr, err := go_ens.Resolve(erigonClient.GetNativeClient(), addr.EnsName)
 				if err != nil {

--- a/backend/cmd/rewards_exporter/main.go
+++ b/backend/cmd/rewards_exporter/main.go
@@ -148,7 +148,6 @@ func Run() {
 		}()
 
 		for _, e := range notExportedEpochs {
-			e := e
 			g.Go(func() error {
 				var err error
 				for i := 0; i < 10; i++ {

--- a/backend/pkg/api/handlers/search.go
+++ b/backend/pkg/api/handlers/search.go
@@ -192,7 +192,6 @@ func (h *HandlerService) InternalPostSearch(w http.ResponseWriter, r *http.Reque
 			continue
 		}
 		for _, chainId := range chainIdSet {
-			chainId := chainId
 			searchType := searchType
 			g.Go(func() error {
 				searchResult, err := searchTypeMap[searchType].handlerFunc(ctx, h, req.Input, chainId)

--- a/backend/pkg/blobindexer/blobindexer.go
+++ b/backend/pkg/blobindexer/blobindexer.go
@@ -476,7 +476,6 @@ func (bi *BlobIndexer) storeBlobsInS3(blobs []constypes.BlobSidecarsData) error 
 	g.SetLimit(4)
 
 	for _, d := range blobs {
-		d := d
 		g.Go(func() error {
 			select {
 			case <-gCtx.Done():

--- a/backend/pkg/commons/db/bigtable_eth1.go
+++ b/backend/pkg/commons/db/bigtable_eth1.go
@@ -951,7 +951,6 @@ func (bigtable *Bigtable) GetAddressesNamesArMetadata(addresses *map[string]stri
 
 	if inputMetadata != nil {
 		for address := range *inputMetadata {
-			address := address
 			g.Go(func() error {
 				metadata, err := bigtable.GetERC20MetadataForAddress([]byte(address))
 				if err != nil {

--- a/backend/pkg/commons/price/price.go
+++ b/backend/pkg/commons/price/price.go
@@ -133,8 +133,6 @@ func Init(chainId uint64, eth1Endpoint, mainCurrencyParam, clCurrencyParam, elCu
 func updatePrices() {
 	g := &errgroup.Group{}
 	for pair, feed := range feeds {
-		pair := pair
-		feed := feed
 		g.Go(func() error {
 			price, err := getPriceFromFeed(feed)
 			if err != nil {

--- a/backend/pkg/commons/utils/utils_test.go
+++ b/backend/pkg/commons/utils/utils_test.go
@@ -18,7 +18,6 @@ type sliceToMapTestCase[T comparable] struct {
 func runSliceToMapTests[T comparable](t *testing.T, testCases []sliceToMapTestCase[T]) {
 	for _, tc := range testCases {
 		// Capture tc to avoid issues with the loop variable in parallel tests.
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			result := SliceToMap(tc.input)
 			assert.True(t, maps.Equal(tc.expected, result))

--- a/backend/pkg/exporter/modules/base.go
+++ b/backend/pkg/exporter/modules/base.go
@@ -173,7 +173,6 @@ func startSubscriptionModules(moduleCtx *ModuleContext, modules []ModuleInterfac
 
 func notifyAllModules(goPool *errgroup.Group, modules []ModuleInterface, f func(ModuleInterface) error) {
 	for _, module := range modules {
-		module := module
 		goPool.Go(func() error {
 			start := time.Now()
 			r := services.StatusReporter.NewStatusReport(module.GetMonitoringEventId(), 5*time.Minute, constants.Default)

--- a/backend/pkg/exporter/modules/dashboard_data_aggregate_backfills.go
+++ b/backend/pkg/exporter/modules/dashboard_data_aggregate_backfills.go
@@ -38,7 +38,6 @@ func (d *dashboardData) aggregateBackfillTask() {
 		// fork for every backfill we have to do
 		backfillType := backfillType
 		for _, aggregateType := range aggregates {
-			aggregateType := aggregateType
 			fields := log.Fields{
 				"backfillType":  backfillType,
 				"aggregateType": aggregateType,
@@ -109,8 +108,6 @@ func (d *dashboardData) backfillAggregates(t edb.AggregateBackfillType, a edb.Ag
 	eg := &errgroup.Group{}
 	eg.SetLimit(int(utils.Config.DashboardExporter.AggregateBackfillsIncompleteInParallel))
 	for id, batch := range batches {
-		batch := batch
-		id := id
 		eg.Go(func() (err error) {
 			//d.log.InfoWithFields("doing backfill batch %s", id)
 			d.log.InfoWithFields(log.Fields{"backfillType": t, "backfillBatchId": id, "timestampRange": []time.Time{batch[0].Timestamp, batch[len(batch)-1].Timestamp}}, "doing aggregate backfill batch")

--- a/backend/pkg/exporter/modules/dashboard_data_backfills.go
+++ b/backend/pkg/exporter/modules/dashboard_data_backfills.go
@@ -26,7 +26,6 @@ func (d *dashboardData) backfillTask() {
 	}
 	for _, backfillType := range jobs {
 		// fork for every backfill we have to do
-		backfillType := backfillType
 		go func() {
 			log.Tracef("starting backfill for %s", backfillType)
 			for {
@@ -89,8 +88,6 @@ func (d *dashboardData) backfillEpochs(t edb.BackfillType, epochs []edb.Backfill
 	eg := &errgroup.Group{}
 	eg.SetLimit(int(utils.Config.DashboardExporter.BackfillInParallel))
 	for id, epochs := range backfillBatchEpochs {
-		epochs := epochs
-		id := id
 		eg.Go(func() (err error) {
 			//d.log.InfoWithFields("doing backfill batch %s", id)
 			d.log.InfoWithFields(log.Fields{"backfillType": t, "backfillBatchId": id, "epochRange": []uint64{epochs[0].Epoch, epochs[len(epochs)-1].Epoch}}, "doing backfill batch")

--- a/backend/pkg/exporter/modules/dashboard_data_maintenance.go
+++ b/backend/pkg/exporter/modules/dashboard_data_maintenance.go
@@ -110,8 +110,6 @@ func (d *dashboardData) transferEpochs(epochs []edb.EpochMetadata) error {
 	eg := &errgroup.Group{}
 	eg.SetLimit(int(utils.Config.DashboardExporter.TransferInParallel))
 	for id, epochs := range transferBatchEpochs {
-		epochs := epochs
-		id := id
 		eg.Go(func() error {
 			d.log.Infof("doing transfer batch %s", id)
 			err := edb.TransferEpochs(epochs)

--- a/backend/pkg/exporter/modules/dashboard_data_rollings.go
+++ b/backend/pkg/exporter/modules/dashboard_data_rollings.go
@@ -40,7 +40,6 @@ func (d *dashboardData) handleRollings() error {
 	eg := errgroup.Group{}
 	eg.SetLimit(int(utils.Config.DashboardExporter.RollingsInParallel))
 	for _, rolling := range rollings {
-		rolling := rolling
 		eg.Go(func() error {
 			return d.doRollingCheck(rolling)
 		})

--- a/backend/pkg/monitoring/services/clickhouse_rollings.go
+++ b/backend/pkg/monitoring/services/clickhouse_rollings.go
@@ -52,7 +52,6 @@ func (s *ServiceClickhouseRollings) runChecks() {
 	}
 	wg := sync.WaitGroup{}
 	for rolling := range maps.Keys(rollings) {
-		rolling := rolling
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/backend/pkg/notification/sending.go
+++ b/backend/pkg/notification/sending.go
@@ -275,7 +275,6 @@ func sendWebhookNotifications() error {
 	g := &errgroup.Group{}
 	g.SetLimit(50) // issue at most 50 requests at a time
 	for _, n := range notificationQueueItem {
-		n := n
 		_, _, err := db.IncrSentMessagesCount(NOTIFICAION_WEBHOOK_RATE_LIMIT_BUCKET, n.Content.UserId, 1, -1)
 		if err != nil {
 			log.Error(err, "error increasing sent webhook count", 0)
@@ -392,7 +391,6 @@ func sendDiscordNotifications() error {
 	g := &errgroup.Group{}
 	g.SetLimit(50) // issue at most 50 requests at a time
 	for _, n := range notificationQueueItem {
-		n := n
 		_, _, err := db.IncrSentMessagesCount(NOTIFICAION_WEBHOOK_RATE_LIMIT_BUCKET, n.Content.UserId, 1, -1)
 		if err != nil {
 			log.Error(err, "error increasing sent discord count", 0)


### PR DESCRIPTION
The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore